### PR TITLE
fix: Pointers to slice are handled correctly

### DIFF
--- a/helpers/slice.go
+++ b/helpers/slice.go
@@ -9,9 +9,18 @@ func InterfaceSlice(slice interface{}) []interface{} {
 		return nil
 	}
 	s := reflect.ValueOf(slice)
-	// Keep the distinction between nil and empty slice input
-	if s.Kind() == reflect.Ptr && s.Elem().Kind() == reflect.Slice && s.Elem().IsNil() {
-		return nil
+	//handle slice behind pointer
+	if s.Kind() == reflect.Ptr && s.Elem().Kind() == reflect.Slice {
+		// Keep the distinction between nil and empty slice input
+		if s.Elem().IsNil() {
+			return nil
+		}
+
+		ret := make([]interface{}, s.Elem().Len())
+		for i := 0; i < s.Elem().Len(); i++ {
+			ret[i] = s.Elem().Index(i).Interface()
+		}
+		return ret
 	}
 	if s.Kind() != reflect.Slice {
 		return []interface{}{slice}

--- a/helpers/slice_test.go
+++ b/helpers/slice_test.go
@@ -18,7 +18,7 @@ func TestInterfaceSlice(t *testing.T) {
 		{Name: "empty", Value: []interface{}{}, Want: []interface{}{}},
 		{Name: "empty_string_array", Value: []string{}, Want: []interface{}{}},
 		{Name: "string_ptr_array", Value: []*string{&someStringPtr}, Want: []interface{}{&someStringPtr}},
-		//{Name: "string_array_ptr", Value: &[]string{"a"}, Want: []interface{}{"a"}}, // TODO: support this?
+		{Name: "string_array_ptr", Value: &[]string{"a"}, Want: []interface{}{"a"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Handles cases when structure has fields that are pointers to slices like `*[]SomeStruct`

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
