### PR TITLE
Add column meta struct

### DIFF
--- a/codegen/golang.go
+++ b/codegen/golang.go
@@ -109,6 +109,9 @@ func NewTableFromStruct(name string, obj interface{}, opts ...TableOptions) (*Ta
 		column := ColumnDefinition{
 			Name: t.nameTransformer(field.Name),
 			Type: columnType,
+			Meta: ColumnMeta{
+				OriginalName: field.Name,
+			},
 		}
 		t.Columns = append(t.Columns, column)
 	}

--- a/codegen/table.go
+++ b/codegen/table.go
@@ -31,4 +31,9 @@ type ColumnDefinition struct {
 	Description   string
 	IgnoreInTests bool
 	Options       schema.ColumnCreationOptions
+	Meta          ColumnMeta
+}
+
+type ColumnMeta struct {
+	OriginalName string
 }


### PR DESCRIPTION
I'm not sure whether this is necessarily the cleanest way to handle it, but having the original name of a field allows us to do the following inside the generate code:

```
	for u, c := range r.Table.Columns {
		if c.Meta.OriginalName != strcase.ToCamel(c.Name) {
			r.Table.Columns[u].Resolver = fmt.Sprintf(`schema.PathResolver(%q)`, c.Meta.OriginalName)
		}
	}
```

This then handles cases like `ID`, `DocURL`, etc automatically. 