### PR TITLE
fix: NewTableFromStruct pointer to time.Time

### DIFF
--- a/codegen/golang_test.go
+++ b/codegen/golang_test.go
@@ -3,6 +3,8 @@ package codegen
 import (
 	"bytes"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
 
@@ -14,7 +16,7 @@ type testStruct struct {
 	StringCol string  `json:"string_col,omitempty"`
 	FloatCol  float64 `json:"float_col,omitempty"`
 	BoolCol   bool    `json:"bool_col,omitempty"`
-	JsonCol   struct {
+	JSONCol   struct {
 		IntCol    int    `json:"int_col,omitempty"`
 		StringCol string `json:"string_col,omitempty"`
 	}
@@ -28,40 +30,49 @@ var expectedTestTable = TableDefinition{
 	Name: "test_struct",
 	Columns: []ColumnDefinition{
 		{
-			Name: "int_col",
-			Type: schema.TypeInt,
+			Name:     "int_col",
+			Type:     schema.TypeInt,
+			Resolver: `schema.PathResolver("IntCol")`,
 		},
 		{
-			Name: "string_col",
-			Type: schema.TypeString,
+			Name:     "string_col",
+			Type:     schema.TypeString,
+			Resolver: `schema.PathResolver("StringCol")`,
 		},
 		{
-			Name: "float_col",
-			Type: schema.TypeFloat,
+			Name:     "float_col",
+			Type:     schema.TypeFloat,
+			Resolver: `schema.PathResolver("FloatCol")`,
 		},
 		{
-			Name: "bool_col",
-			Type: schema.TypeBool,
+			Name:     "bool_col",
+			Type:     schema.TypeBool,
+			Resolver: `schema.PathResolver("BoolCol")`,
 		},
 		{
-			Name: "json_col",
-			Type: schema.TypeJSON,
+			Name:     "json_col",
+			Type:     schema.TypeJSON,
+			Resolver: `schema.PathResolver("JSONCol")`,
 		},
 		{
-			Name: "int_array_col",
-			Type: schema.TypeIntArray,
+			Name:     "int_array_col",
+			Type:     schema.TypeIntArray,
+			Resolver: `schema.PathResolver("IntArrayCol")`,
 		},
 		{
-			Name: "string_array_col",
-			Type: schema.TypeStringArray,
+			Name:     "string_array_col",
+			Type:     schema.TypeStringArray,
+			Resolver: `schema.PathResolver("StringArrayCol")`,
 		},
 		{
-			Name: "time_col",
-			Type: schema.TypeTimestamp,
+			Name:     "time_col",
+			Type:     schema.TypeTimestamp,
+			Resolver: `schema.PathResolver("TimeCol")`,
 		},
 		{
-			Name: "time_pointer_col",
-			Type: schema.TypeTimestamp,
+			Name:     "time_pointer_col",
+			Type:     schema.TypeTimestamp,
+			Resolver: `schema.PathResolver("TimePointerCol")`,
 		},
 	},
 	nameTransformer: defaultTransformer,
@@ -72,9 +83,10 @@ func TestTableFromGoStruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// if !reflect.DeepEqual(table, &expectedTestTable) {
-	// 	t.Fatalf("expected:\n%+v, got:\n%+v", expectedTestTable, table)
-	// }
+	if diff := cmp.Diff(table, &expectedTestTable,
+		cmpopts.IgnoreUnexported(TableDefinition{})); diff != "" {
+		t.Fatalf("table does not match expected. diff (-got, +want): %v", diff)
+	}
 	buf := bytes.NewBufferString("")
 	if err := table.GenerateTemplate(buf); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This: 
 - fixes the test so that it makes assertions (previously it was only printing)
 - fixes the test that would have been failing after https://github.com/cloudquery/plugin-sdk/pull/14 if it had been making assertions
 - fixes the case where a pointer to time.Time is given. I thought it was working before because I thought the test was making assertions, but it wasn't 😅 

I spent a few minutes trying to make it work with typecasts like before, but couldn't figure out how to get the actual interface from the reflect value after calling `Elem()` to dereference the pointer. Switched to a comparison with `PkgPath` and `Name` instead to save some time, but maybe we can revisit this again later. 