### PR TITLE
feat: Speed up description parsing, support use of comments and other…

### DIFF
--- a/codegen/golang.go
+++ b/codegen/golang.go
@@ -17,11 +17,7 @@ import (
 //go:embed templates/*.go.tpl
 var TemplatesFS embed.FS
 
-var pkgCache map[string][]*packages.Package
-
-func init() {
-	pkgCache = map[string][]*packages.Package{}
-}
+var pkgCache = map[string][]*packages.Package{}
 
 func valueToSchemaType(v reflect.Type) (schema.ValueType, error) {
 	k := v.Kind()

--- a/codegen/table.go
+++ b/codegen/table.go
@@ -15,15 +15,16 @@ type TableDefinition struct {
 	Columns     []ColumnDefinition
 	Relations   []*TableDefinition
 
-	Resolver             string
-	IgnoreError          string
-	Multiplex            string
-	PostResourceResolver string
-	Options              schema.TableCreationOptions
-	nameTransformer      func(string) string
-	skipFields           []string
-	overrideColumns      ColumnDefinitions
-	descriptionsEnabled  bool
+	Resolver               string
+	IgnoreError            string
+	Multiplex              string
+	PostResourceResolver   string
+	Options                schema.TableCreationOptions
+	nameTransformer        func(string) string
+	skipFields             []string
+	overrideColumns        ColumnDefinitions
+	descriptionsEnabled    bool
+	descriptionTransformer func(string) string
 }
 
 type ColumnDefinitions []ColumnDefinition


### PR DESCRIPTION
- Cache package parsing for faster description-reading for ~30x speed-up in the Heroku case. Currently uses a global cache, which I figure is okay for a codegen binary that's not supposed to be long-running. If we move `NewTableFromStruct` to be a struct method, we can move the cache onto the same struct. Let me know how you feel about this
- if docstring is unavailable, use comment string
- add DescriptionTransformer option to optionally clean descriptions

Before:

```
✗ time go run main.go
go run main.go  40.00s user 27.64s system 417% cpu 16.212 total
```

After:

```
✗ time go run main.go
go run main.go  1.11s user 0.79s system 112% cpu 1.699 total
```