### PR TITLE
feat: Add sentry for serve.Serve function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
+github.com/getsentry/sentry-go v0.13.0 h1:20dgTiUSfxRB/EhMPtxcL9ZEbM1ZdR+W/7f7NWD+xWo=
+github.com/getsentry/sentry-go v0.13.0/go.mod h1:EOsfu5ZdvKPfeHYV6pTVQnsjfp30+XA7//UooKNumH0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -81,6 +81,12 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 	if err := p.validate(); err != nil {
 		panic(err)
 	}
+	// if ignore error is not set on a table level set it with the plugin
+	for _, table := range p.tables {
+		if table.IgnoreError == nil && p.ignoreError != nil {
+			table.IgnoreError = p.ignoreError
+		}
+	}
 	return &p
 }
 

--- a/schema/table.go
+++ b/schema/table.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"context"
 	"fmt"
-
 	"runtime/debug"
 	"sync"
 	"time"

--- a/schema/table.go
+++ b/schema/table.go
@@ -3,11 +3,13 @@ package schema
 import (
 	"context"
 	"fmt"
+
 	"runtime/debug"
 	"sync"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/helpers"
+	"github.com/getsentry/sentry-go"
 	"github.com/iancoleman/strcase"
 	"github.com/thoas/go-funk"
 )
@@ -178,10 +180,15 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, syncTime time.Time,
 		if err := t.Resolver(ctx, meta, parent, res); err != nil {
 			if t.IgnoreError != nil {
 				if ignore, errType := t.IgnoreError(err); ignore {
-					meta.Logger().Debug().Str("table_name", t.Name).TimeDiff("duration", time.Now(), startTime).Str("error_type", errType).Msg("table resolver finished with error")
+					meta.Logger().Debug().Stack().Str("table_name", t.Name).TimeDiff("duration", time.Now(), startTime).Str("error_type", errType).Err(err).Msg("table resolver finished with error")
 					return
 				}
 			}
+			sentry.WithScope(func(scope *sentry.Scope) {
+				scope.SetTag("table", t.Name)
+				scope.SetLevel(sentry.LevelError)
+				sentry.CaptureMessage(err.Error())
+			})
 			meta.Logger().Error().Str("table_name", t.Name).TimeDiff("duration", time.Now(), startTime).Err(err).Msg("table resolver finished with error")
 			return
 		}
@@ -190,7 +197,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, syncTime time.Time,
 	totalResources := 0
 	// we want to check for data integrity
 	// in the future we can do that as an optinoal feature via a flag
-	pks := map[string]bool{}
+	// pks := map[string]bool{}
 	// each result is an array of interface{}
 	for elem := range res {
 		objects := helpers.InterfaceSlice(elem)
@@ -211,16 +218,16 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, syncTime time.Time,
 			if t.PostResourceResolver != nil {
 				meta.Logger().Trace().Str("table_name", t.Name).Msg("post resource resolver started")
 				if err := t.PostResourceResolver(ctx, meta, resource); err != nil {
-					meta.Logger().Error().Str("table_name", t.Name).Err(err).Msg("post resource resolver finished with error")
+					meta.Logger().Error().Str("table_name", t.Name).Stack().Err(err).Msg("post resource resolver finished with error")
 				} else {
 					meta.Logger().Trace().Str("table_name", t.Name).Msg("post resource resolver finished successfully")
 				}
 			}
-			if pks[resource.PrimaryKeyValue()] {
-				meta.Logger().Error().Str("table_name", t.Name).Str("primary_key", resource.PrimaryKeyValue()).Msg("duplicate primary key found")
-			} else {
-				pks[resource.PrimaryKeyValue()] = true
-			}
+			// if pks[resource.PrimaryKeyValue()] {
+			// 	meta.Logger().Error().Str("table_name", t.Name).Str("primary_key", resource.PrimaryKeyValue()).Msg("duplicate primary key found")
+			// } else {
+			// 	pks[resource.PrimaryKeyValue()] = true
+			// }
 			resolvedResources <- resource
 			for _, rel := range t.Relations {
 				totalResources += rel.Resolve(ctx, meta, syncTime, resource, resolvedResources)

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -5,10 +5,12 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cloudquery/plugin-sdk/internal/pb"
 	"github.com/cloudquery/plugin-sdk/internal/servers"
 	"github.com/cloudquery/plugin-sdk/plugins"
+	"github.com/getsentry/sentry-go"
 	grpczerolog "github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2"
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -23,6 +25,7 @@ type Options struct {
 	// Required: Source or destination plugin to serve.
 	SourcePlugin      *plugins.SourcePlugin
 	DestinationPlugin plugins.DestinationPlugin
+	SentryDsn         string
 }
 
 // bufSize used for unit testing grpc server and client
@@ -38,6 +41,7 @@ var testListener *bufconn.Listener
 func newCmdServe(opts Options) *cobra.Command {
 	var address string
 	var network string
+	var noSentry bool
 	logLevel := newEnum([]string{"trace", "debug", "info", "warn", "error"}, "info")
 	logFormat := newEnum([]string{"text", "json"}, "text")
 	cmd := &cobra.Command{
@@ -56,6 +60,27 @@ func newCmdServe(opts Options) *cobra.Command {
 			} else {
 				logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}).Level(zerologLevel)
 			}
+			if !noSentry {
+				err = sentry.Init(sentry.ClientOptions{
+					Dsn:     opts.SentryDsn,
+					Release: opts.SourcePlugin.Version(),
+					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
+					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
+						var filteredIntegrations []sentry.Integration
+						for _, integration := range integrations {
+							if integration.Name() == "Modules" {
+								continue
+							}
+							filteredIntegrations = append(filteredIntegrations, integration)
+						}
+						return filteredIntegrations
+					},
+				})
+				if err != nil {
+					log.Error().Err(err).Msg("Error initializing sentry")
+				}
+			}
+
 			// opts.Plugin.Logger = logger
 			var listener net.Listener
 			if network == "test" {
@@ -99,6 +124,8 @@ func newCmdServe(opts Options) *cobra.Command {
 	cmd.Flags().StringVar(&network, "network", "tcp", `the network must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket"`)
 	cmd.Flags().Var(logLevel, "log-level", fmt.Sprintf("log level. one of: %s", strings.Join(logLevel.Allowed, ",")))
 	cmd.Flags().Var(logFormat, "log-format", fmt.Sprintf("log format. one of: %s", strings.Join(logFormat.Allowed, ",")))
+	cmd.Flags().BoolVar(&noSentry, "no-sentry", false, "disable sentry")
+
 	return cmd
 }
 
@@ -112,7 +139,11 @@ func newCmdRoot(opts Options) *cobra.Command {
 }
 
 func Serve(opts Options) {
+	defer func() {
+		sentry.Flush(5 * time.Second)
+	}()
 	if err := newCmdRoot(opts).Execute(); err != nil {
+		sentry.CaptureMessage(err.Error())
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
plugin developers will be able to direct their plugin errors
to their own projects on sentry as we dont want to monitor any
community errors anyway.

Also each plugin should go into it's own project on sentry
because we are using server side grouping which are mostly
project based.

Tested it on gcp - grouping works smoothly with nice title (no more diags.Error) for every single error as we use standard `sentry.Message` as well as using sentry mechanism to group and change title based on tags.

Every error in the ETL process which is not ignore is sent with the error as string + `table_name` as tag.

https://sentry.io/organizations/cloudquery-v2/issues/?project=6720365

hopefully this brings sane error monitoring one step closer :) 🚀 


<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
