### PR TITLE
feat!: Remove unused table create options

### DIFF
--- a/codegen/table.go
+++ b/codegen/table.go
@@ -20,7 +20,6 @@ type TableDefinition struct {
 	Multiplex            string
 	PostResourceResolver string
 	PreResourceResolver  string
-	Options              schema.TableCreationOptions
 	nameTransformer      func(string) string
 	skipFields           []string
 	overrideColumns      ColumnDefinitions

--- a/schema/table.go
+++ b/schema/table.go
@@ -50,8 +50,6 @@ type Table struct {
 	// PreResourceResolver is called before all columns are resolved but after Resource is created. The ordering of resolvers is:
 	//  (Table) Resolver → PreResourceResolver → ColumnResolvers → PostResourceResolver
 	PreResourceResolver RowResolver `json:"-"`
-	// Options allow modification of how the table is defined when created
-	Options TableCreationOptions `json:"options"`
 
 	// IgnoreInTests is used to exclude a table from integration tests.
 	// By default, integration tests fetch all resources from cloudquery's test account, and verify all tables
@@ -67,12 +65,6 @@ type Table struct {
 	Serial string `json:"-"`
 
 	columnsMap map[string]int
-}
-
-// TableCreationOptions allow modifying how table is created such as defining primary keys, indices, foreign keys and constraints.
-type TableCreationOptions struct {
-	// List of columns to set as primary keys. If this is empty, a random unique ID is generated.
-	PrimaryKeys []string
 }
 
 func (tt Tables) TableNames() []string {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


I was using this option to set the primary keys on my tables:
https://github.com/erezrokah/cloudquery/blob/28f7db10eadd834769663dc1e8243f04469b0132/plugins/source/azure/codegen/recipes/base.go#L206
to realize it stopped working and I should set it on columns instead

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
