### PR TITLE
chore: Golangci: remove deprecated plugins (and decorder)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,8 +68,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
-    - decorder
     - depguard
     - dupl
     - errcheck
@@ -85,8 +83,6 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - unconvert
     - unparam
     - unused
-    - varcheck


### PR DESCRIPTION
Some plugins are no longer supported and can be removed. I am also proposing we remove decorder: until it has the ability to automatically fix the issues it reports, we are wasting our time for (imo) little gain.

As for the deprecated plugins, here is the message from latest golanci-lint:

```
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```