### PR TITLE
feat: Add option to unwrap structs 1 level down

### DIFF
--- a/codegen/golang_test.go
+++ b/codegen/golang_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type embeddedStruct struct {
+	EmbeddedString string
+}
+
 type testStruct struct {
 	// IntCol this is an example documentation comment
 	IntCol    int     `json:"int_col,omitempty"`
@@ -27,79 +31,144 @@ type testStruct struct {
 	StringArrayCol []string   `json:"string_array_col,omitempty"`
 	TimeCol        time.Time  `json:"time_col,omitempty"`
 	TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
+	*embeddedStruct
+}
+
+type testStructWithEmbeddedStruct struct {
+	*testStruct
+	*embeddedStruct
+}
+
+type testStructWithNonEmbeddedStruct struct {
+	TestStruct  *testStruct
+	NonEmbedded *embeddedStruct
+}
+
+var expectedColumns = []ColumnDefinition{
+	{
+		Name:     "int_col",
+		Type:     schema.TypeInt,
+		Resolver: `schema.PathResolver("IntCol")`,
+	},
+	{
+		Name:     "string_col",
+		Type:     schema.TypeString,
+		Resolver: `schema.PathResolver("StringCol")`,
+	},
+	{
+		Name:     "float_col",
+		Type:     schema.TypeFloat,
+		Resolver: `schema.PathResolver("FloatCol")`,
+	},
+	{
+		Name:     "bool_col",
+		Type:     schema.TypeBool,
+		Resolver: `schema.PathResolver("BoolCol")`,
+	},
+	{
+		Name:     "json_col",
+		Type:     schema.TypeJSON,
+		Resolver: `schema.PathResolver("JSONCol")`,
+	},
+	{
+		Name:     "int_array_col",
+		Type:     schema.TypeIntArray,
+		Resolver: `schema.PathResolver("IntArrayCol")`,
+	},
+	{
+		Name:     "string_array_col",
+		Type:     schema.TypeStringArray,
+		Resolver: `schema.PathResolver("StringArrayCol")`,
+	},
+	{
+		Name:     "time_col",
+		Type:     schema.TypeTimestamp,
+		Resolver: `schema.PathResolver("TimeCol")`,
+	},
+	{
+		Name:     "time_pointer_col",
+		Type:     schema.TypeTimestamp,
+		Resolver: `schema.PathResolver("TimePointerCol")`,
+	},
 }
 
 var expectedTestTable = TableDefinition{
+	Name:            "test_struct",
+	Columns:         expectedColumns,
+	nameTransformer: defaultTransformer,
+}
+
+var expectedTestTableEmbeddedStruct = TableDefinition{
+	Name:            "test_struct",
+	Columns:         append(expectedColumns, ColumnDefinition{Name: "embedded_string", Type: schema.TypeString, Resolver: `schema.PathResolver("EmbeddedString")`}),
+	nameTransformer: defaultTransformer,
+}
+
+var expectedTestTableNonEmbeddedStruct = TableDefinition{
 	Name: "test_struct",
-	Columns: []ColumnDefinition{
-		{
-			Name:     "int_col",
-			Type:     schema.TypeInt,
-			Resolver: `schema.PathResolver("IntCol")`,
-		},
-		{
-			Name:     "string_col",
-			Type:     schema.TypeString,
-			Resolver: `schema.PathResolver("StringCol")`,
-		},
-		{
-			Name:     "float_col",
-			Type:     schema.TypeFloat,
-			Resolver: `schema.PathResolver("FloatCol")`,
-		},
-		{
-			Name:     "bool_col",
-			Type:     schema.TypeBool,
-			Resolver: `schema.PathResolver("BoolCol")`,
-		},
-		{
-			Name:     "json_col",
-			Type:     schema.TypeJSON,
-			Resolver: `schema.PathResolver("JSONCol")`,
-		},
-		{
-			Name:     "int_array_col",
-			Type:     schema.TypeIntArray,
-			Resolver: `schema.PathResolver("IntArrayCol")`,
-		},
-		{
-			Name:     "string_array_col",
-			Type:     schema.TypeStringArray,
-			Resolver: `schema.PathResolver("StringArrayCol")`,
-		},
-		{
-			Name:     "time_col",
-			Type:     schema.TypeTimestamp,
-			Resolver: `schema.PathResolver("TimeCol")`,
-		},
-		{
-			Name:     "time_pointer_col",
-			Type:     schema.TypeTimestamp,
-			Resolver: `schema.PathResolver("TimePointerCol")`,
-		},
+	Columns: ColumnDefinitions{
+		// Should not be unwrapped
+		ColumnDefinition{Name: "test_struct", Type: schema.TypeJSON, Resolver: `schema.PathResolver("TestStruct")`},
+		// Should be unwrapped
+		ColumnDefinition{Name: "embedded_string", Type: schema.TypeString, Resolver: `schema.PathResolver("NonEmbedded.EmbeddedString")`},
 	},
 	nameTransformer: defaultTransformer,
 }
 
 func TestTableFromGoStruct(t *testing.T) {
-	table, err := NewTableFromStruct("test_struct", testStruct{})
-	if err != nil {
-		t.Fatal(err)
+	type args struct {
+		testStruct interface{}
+		options    []TableOptions
 	}
-	if diff := cmp.Diff(table, &expectedTestTable,
-		cmpopts.IgnoreUnexported(TableDefinition{})); diff != "" {
-		t.Fatalf("table does not match expected. diff (-got, +want): %v", diff)
-	}
-	buf := bytes.NewBufferString("")
-	if err := table.GenerateTemplate(buf); err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(buf.String())
-}
 
-// func TestReadComments(t *testing.T) {
-// 	readComments("github.com/google/go-cmp/cmp")
-// }
+	tests := []struct {
+		name string
+		args args
+		want TableDefinition
+	}{
+		{
+			name: "should generate table from struct with default options",
+			args: args{
+				testStruct: testStruct{},
+			},
+			want: expectedTestTable,
+		},
+		{
+			name: "should unwrap all embedded structs when option is set",
+			args: args{
+				testStruct: testStructWithEmbeddedStruct{},
+				options:    []TableOptions{WithUnwrapAllEmbeddedStructs()},
+			},
+			want: expectedTestTableEmbeddedStruct,
+		},
+		{
+			name: "should unwrap specific structs when option is set",
+			args: args{
+				testStruct: testStructWithNonEmbeddedStruct{},
+				options:    []TableOptions{WithUnwrapFieldsStructs([]string{"NonEmbedded"})},
+			},
+			want: expectedTestTableNonEmbeddedStruct,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table, err := NewTableFromStruct("test_struct", tt.args.testStruct, tt.args.options...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(table, &tt.want,
+				cmpopts.IgnoreUnexported(TableDefinition{})); diff != "" {
+				t.Fatalf("table does not match expected. diff (-got, +want): %v", diff)
+			}
+			buf := bytes.NewBufferString("")
+			if err := table.GenerateTemplate(buf); err != nil {
+				t.Fatal(err)
+			}
+			fmt.Println(buf.String())
+		})
+	}
+}
 
 func TestGenerateTemplate(t *testing.T) {
 	type args struct {

--- a/codegen/table.go
+++ b/codegen/table.go
@@ -11,18 +11,20 @@ type ResourceDefinition struct {
 
 type TableDefinition struct {
 	Name        string
-	Description string
 	Columns     ColumnDefinitions
+	Description string
 	Relations   []string
 
-	Resolver             string
-	IgnoreError          string
-	Multiplex            string
-	PostResourceResolver string
-	PreResourceResolver  string
-	nameTransformer      func(string) string
-	skipFields           []string
-	extraColumns         ColumnDefinitions
+	Resolver                      string
+	IgnoreError                   string
+	Multiplex                     string
+	PostResourceResolver          string
+	PreResourceResolver           string
+	nameTransformer               func(string) string
+	skipFields                    []string
+	extraColumns                  ColumnDefinitions
+	structFieldsToUnwrap          []string
+	unwrapAllEmbeddedStructFields bool
 }
 
 type ColumnDefinitions []ColumnDefinition


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Adds an option to unwrap fields from embedded structs (1 level down only).
This is common in Azure to have a top level type with another inner struct for the properties.
Currently the properties will get generated as a single JSON column which doesn't make much sense.
Added an option so this is not a breaking change.

See example commit with this change:
https://github.com/cloudquery/cloudquery/pull/1754/commits/3388162b00f99dcc98d613356a589a847d3a520b

In the old code gen/manually written versions we use several inconsistent approaches:
1. Get the inner struct as a relation https://github.com/cloudquery/cloudquery/blob/fb8cb86c624719cb096483b52012c3cc51f64684/plugins/source/azure/resources/services/authorization/role_definitions.go#L117
2. Unwrap all the way down https://github.com/cloudquery/cloudquery/blob/fb8cb86c624719cb096483b52012c3cc51f64684/plugins/source/azure/resources/services/cosmosdb/sql_databases.go#L61 via built in path resolver
3. Resolve it manually https://github.com/cloudquery/cloudquery/blob/fb8cb86c624719cb096483b52012c3cc51f64684/plugins/source/azure/resources/services/monitor/activity_log_alerts.go#L154

Looking at the [changes](https://github.com/cloudquery/cloudquery/pull/1754/commits/3388162b00f99dcc98d613356a589a847d3a520b) generated by this feature unwrapping 1 level down seems like a decent approach, at least for Azure's case

Also looking at the resources we have using the new Azure SDK, it seems it's not needed as they don't have a "Properties" struct embedded into them https://github.com/erezrokah/cloudquery/blob/3388162b00f99dcc98d613356a589a847d3a520b/plugins/source/azure/resources/services/subscriptions/subscriptions.go#L18 

Finally even with this change we have some misses due to inconsistencies with the Azure SDK, for example:
https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization#RoleAssignment has `Properties` as a regular struct, while https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization#RoleDefinition has it as an embedded struct
![image](https://user-images.githubusercontent.com/26760571/188950145-b39584b2-2ba4-473d-8344-1b839fc876b9.png)
![image](https://user-images.githubusercontent.com/26760571/188950256-ed235eb5-1eb2-4940-8f53-c2ee570ea814.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
