### PR TITLE
fix: Add missing comma when generating relations

### DIFF
--- a/codegen/.snapshots/TestGenerateTemplate-should_add_comma_between_relations
+++ b/codegen/.snapshots/TestGenerateTemplate-should_add_comma_between_relations
@@ -1,0 +1,11 @@
+{
+		Name:         "with relations",
+		Columns: []schema.Column{
+
+		},
+
+		Relations: []*schema.Table{
+relation1relation2,
+		},
+
+}

--- a/codegen/.snapshots/TestGenerateTemplate-should_add_comma_between_relations
+++ b/codegen/.snapshots/TestGenerateTemplate-should_add_comma_between_relations
@@ -5,7 +5,9 @@
 		},
 
 		Relations: []*schema.Table{
-relation1relation2,
+relation1,
+relation2,
+
 		},
 
 }

--- a/codegen/golang_test.go
+++ b/codegen/golang_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 )
 
 type testStruct struct {
@@ -98,3 +100,33 @@ func TestTableFromGoStruct(t *testing.T) {
 // func TestReadComments(t *testing.T) {
 // 	readComments("github.com/google/go-cmp/cmp")
 // }
+
+func TestGenerateTemplate(t *testing.T) {
+	type args struct {
+		table *TableDefinition
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "should add comma between relations",
+			args: args{
+				table: &TableDefinition{
+					Name:      "with relations",
+					Relations: []string{"relation1", "relation2"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := bytes.NewBufferString("")
+			err := tt.args.table.GenerateTemplate(buf)
+			require.NoError(t, err)
+			cupaloy.SnapshotT(t, buf.Bytes())
+		})
+	}
+}

--- a/codegen/templates/table.go.tpl
+++ b/codegen/templates/table.go.tpl
@@ -20,7 +20,8 @@
 		},
 {{with .Relations}}
 		Relations: []*schema.Table{
-{{range .}}{{.}}{{end}},
+{{range .}}{{.}},
+{{end}}
 		},
 {{end}}
 }

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 )
 
 require (
+	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
+github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


The `TableDefinition.Relations` accepts a string array but it's a bit confusing to use when you have multiple relations as it doesn't add a comma between relations.
As a result if someone has multiple relations they need to work around the issue by doing either:
- `relations:          []string{"siteAuthSettings(),publishingProfiles(),vnetConnections(),publishingProfiles()"}` (a single string) ([code](https://github.com/erezrokah/cloudquery/blob/1bac8634602c4db2e2cb5d8206f8a92aea6052c4/plugins/source/azure/codegen/recipes/web.go#L29))
or 
- `relations:          []string{"siteAuthSettings(),",  "publishingProfiles(),"}`

This PR fixes the issue (this makes the code consistent with [how we template columns](https://github.com/cloudquery/plugin-sdk/blob/e40466ba450499540a02737ace6655ea184fe42e/codegen/templates/column.go.tpl#L17)).

Another solution is to make relations a string type (instead of an array) to make it clear that it's printed as is.

For clarity the [first commit](https://github.com/cloudquery/plugin-sdk/commit/3bcc2a39d892b110c9d95ef9c92a55277c8c3afd) of this PR adds a test to generate a table template and the second has the fix with the change in the snapshot https://github.com/cloudquery/plugin-sdk/commit/c9d9db296856776f476ae9d4c0a2688a9fcded99 

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
