### PR TITLE
fix!: Enable export lin rule and fix option export

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,10 +51,6 @@ linters-settings:
         disabled: true
       - name: deep-exit
         disabled: true
-      - name: exported
-        disabled: false
-        arguments:
-          - "disableStutteringCheck"
       - name: unused-parameter
         disabled: true
       - name: confusing-naming

--- a/faker/faker.go
+++ b/faker/faker.go
@@ -12,7 +12,7 @@ type faker struct {
 	// logger    zerolog.Logger
 }
 
-type FakerOption func(*faker)
+type Option func(*faker)
 
 func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 	t := reflect.TypeOf(a)
@@ -143,13 +143,13 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 	}
 }
 
-func WithMaxDepth(depth int) FakerOption {
+func WithMaxDepth(depth int) Option {
 	return func(f *faker) {
 		f.max_depth = depth
 	}
 }
 
-func FakeObject(obj interface{}, opts ...FakerOption) error {
+func FakeObject(obj interface{}, opts ...Option) error {
 	reflectType := reflect.TypeOf(obj)
 
 	if reflectType.Kind() != reflect.Ptr {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Fixes the following issue:
`exported: type name will be used as faker.FakerOption by other packages, and that stutters; consider calling this Option (revive)`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
