### PR TITLE
fix: Remove description from docs

### DIFF
--- a/docs/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
+++ b/docs/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
@@ -1,0 +1,10 @@
+
+# Table: relation_table
+Description for relational table
+## Columns
+| Name        | Type           |
+| ------------- | ------------- |
+|string_col|String|
+|_cq_id|UUID|
+|_cq_fetch_time|Timestamp|
+

--- a/docs/.snapshots/TestGenerateSourcePluginDocs-test_table.md
+++ b/docs/.snapshots/TestGenerateSourcePluginDocs-test_table.md
@@ -1,0 +1,10 @@
+
+# Table: test_table
+Description for test table
+## Columns
+| Name        | Type           |
+| ------------- | ------------- |
+|int_col|Int|
+|_cq_id|UUID|
+|_cq_fetch_time|Timestamp|
+

--- a/docs/source.go
+++ b/docs/source.go
@@ -16,10 +16,10 @@ const tableTmpl = `
 # Table: {{.Name}}
 {{ $.Description }}
 ## Columns
-| Name        | Type           | Description  |
-| ------------- | ------------- | -----  |
+| Name        | Type           |
+| ------------- | ------------- |
 {{- range $column := $.Columns }}
-|{{$column.Name}}|{{$column.Type | formatType}}|{{$column.Description|removeLineBreaks}}|
+|{{$column.Name}}|{{$column.Type | formatType}}|
 {{- end }}
 `
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

We don't generate the descriptions anymore (I think), so we should not generate them with the docs.
Also switched to snapshot testing so the output files are separated from the code.

Another possible implementation is to add an option to enable/disable the description column

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
