### PR TITLE
feat!: Disable default completion command

### DIFF
--- a/serve/serve.go
+++ b/serve/serve.go
@@ -139,6 +139,7 @@ func newCmdRoot(opts Options) *cobra.Command {
 	}
 	cmd.AddCommand(newCmdServe(opts))
 	cmd.AddCommand(newCmdDoc(opts))
+	cmd.CompletionOptions.DisableDefaultCmd = true
 	return cmd
 }
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Given that plugins only have `doc, help, serve` commands looks like we can disable the built in completion one

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
