### PR TITLE
fix!: Rename MaxGoRoutines and enforce it

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -162,7 +162,7 @@ func (p *SourcePlugin) Sync(ctx context.Context, spec specs.Source, res chan<- *
 	jobs := make(chan workerJob, jobsCount)
 	results := make(chan workerResult, jobsCount)
 
-	for w := uint64(1); w <= concurrency; w++ {
+	for i := uint64(0); i < concurrency; i++ {
 		go worker(jobs, results)
 	}
 

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -32,7 +32,7 @@ type SourcePlugin struct {
 
 type SourceOption func(*SourcePlugin)
 
-const defaultConcurrency = 1
+const defaultConcurrency = 20
 
 func WithSourceExampleConfig(exampleConfig string) SourceOption {
 	return func(p *SourcePlugin) {

--- a/schema/table.go
+++ b/schema/table.go
@@ -178,7 +178,6 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, syncTime time.Time,
 		if len(objects) == 0 {
 			continue
 		}
-		totalResources += len(objects)
 		for i := range objects {
 			resource := NewResourceData(&t, parent, syncTime, objects[i])
 			if t.PreResourceResolver != nil {
@@ -198,6 +197,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, syncTime time.Time,
 				}
 			}
 
+			totalResources++
 			resolvedResources <- resource
 			for _, rel := range t.Relations {
 				totalResources += rel.Resolve(ctx, meta, syncTime, resource, resolvedResources)

--- a/specs/source.go
+++ b/specs/source.go
@@ -14,12 +14,12 @@ type Source struct {
 	// Path is the path in the registry
 	Path string `json:"path,omitempty"`
 	// Registry can be github,local,grpc. Might support things like https in the future.
-	Registry      Registry    `json:"registry,omitempty"`
-	MaxGoRoutines uint64      `json:"max_goroutines,omitempty"`
-	Tables        []string    `json:"tables,omitempty"`
-	SkipTables    []string    `json:"skip_tables,omitempty"`
-	Destinations  []string    `json:"destinations,omitempty"`
-	Spec          interface{} `json:"spec,omitempty"`
+	Registry     Registry    `json:"registry,omitempty"`
+	Concurrency  uint64      `json:"concurrency,omitempty"`
+	Tables       []string    `json:"tables,omitempty"`
+	SkipTables   []string    `json:"skip_tables,omitempty"`
+	Destinations []string    `json:"destinations,omitempty"`
+	Spec         interface{} `json:"spec,omitempty"`
 }
 
 func (s *Source) SetDefaults() {

--- a/specs/source_schema.json
+++ b/specs/source_schema.json
@@ -5,8 +5,8 @@
   "description": "Generic Source Configuration Schema",
   "type": "object",
   "properties": {
-    "max_goroutines": {
-      "description": "Max GoRoutines to use",
+    "concurrency": {
+      "description": "Concurrency level",
       "type": "integer"
     },
     "tables": {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


When testing the Azure plugin I noticed we print a message on the number of Go routines used. From the other logs it seemed that the number is not enforced (All table fetch start logs were printed at the same time).
Since we can't really enforce a number of Go routines as sometimes we'd like to fetch related resources in parallel and we don't know those in advance, I renamed the configuration to `Concurrency` as I think we should still have a setting to control the load CloudQuery puts on the APIs (right now it creates a Go routine per top level table).
Also I switched to using channels instead of semaphore as seems more suitable for this use case, and we use channels in other places in the code.



---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
