### PR TITLE
chore(makefile): Install protoc dependecies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+ifeq ($(OS),Windows_NT)
+    protoc_install :=
+else ifeq ($(shell uname -s),Darwin)
+    protoc_install := brew install protobuf
+else ifeq ($(shell uname -s),Linux)
+    protoc_install := apt install -y protobuf-compiler
+endif
+
 .PHONY: test
 test:
 	go test ./...
@@ -8,4 +16,7 @@ lint:
 
 .PHONY: gen-proto
 gen-proto:
+	$(protoc_install)
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 	protoc --proto_path=. --go_out . --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative internal/pb/base.proto internal/pb/source.proto internal/pb/destination.proto


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

`make gen-proto` requires quite a few dependencies to be installed.
This PR ensures those get installed before running the target (tested on MacOS, not sure what do do on Windows).
More information in https://grpc.io/docs/protoc-installation/

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
