### PR TITLE
chore(refactor): Make `interpolateAllResources` more readable

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -189,17 +189,18 @@ func (p *SourcePlugin) interpolateAllResources(tables []string) ([]string, error
 	if tables == nil {
 		return make([]string, 0), nil
 	}
-	if !funk.ContainsString(tables, "*") {
-		return tables, nil
+
+	if funk.Equal(tables, []string{"*"}) {
+		allResources := make([]string, 0, len(p.tables))
+		for _, k := range p.tables {
+			allResources = append(allResources, k.Name)
+		}
+		return allResources, nil
 	}
 
-	if len(tables) > 1 {
+	if funk.ContainsString(tables, "*") {
 		return nil, fmt.Errorf("invalid \"*\" resource, with explicit resources")
 	}
 
-	allResources := make([]string, 0, len(p.tables))
-	for _, k := range p.tables {
-		allResources = append(allResources, k.Name)
-	}
-	return allResources, nil
+	return tables, nil
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

It took me a bit of time to understand what's the purpose of this function as it uses negated logic and also `len(tables) > 1` hides the equality check.

Did a bit of refactoring to make it easier (I hope) to understand and added tests for it

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
