### PR TITLE
feat: Remove withComment for codegen

### DIFF
--- a/codegen/table.go
+++ b/codegen/table.go
@@ -23,7 +23,6 @@ type TableDefinition struct {
 	nameTransformer      func(string) string
 	skipFields           []string
 	extraColumns         ColumnDefinitions
-	descriptionsEnabled  bool
 }
 
 type ColumnDefinitions []ColumnDefinition


### PR DESCRIPTION
reading comments from source code is super slow and this is public api which we dont want to support. The best practice/guideline should be just pointing to the original API and not duplicating go documentation to our docs.

#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
