### PR TITLE
chore(docs): Add more godoc to important APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-CloudQuery Plugin SDK ![License](https://img.shields.io/github/license/cloudquery/cloudquery?style=flat-square)
-=======================
+# CloudQuery Plugin SDK
 
-This SDK enables building CloudQuery plugins which allows CloudQuery's users to extract/load/transform existing and popular service providers as well as custom in-house solutions into a SQL Database.
+CloudQuery SDK enables building CloudQuery source and destination plugins.
 
-CloudQuery itself is a tool that transforms your cloud infrastructure into queryable SQL for easy monitoring, governance and security. You can find more about CloudQuery on its website and its GitHub repository.
+Source plugins allows developers to extract information from third party APIs and enjoying built-in transformations, concurrency, logging, testing and database agnostic support via destination plugins.
 
+Destinations plugins allows writing the data from any of the source plugins to an additional database, message queue, storage or any other destination without recompiling any of the source plugins.
 
 ## Getting Started & Documentation
 
-* Homepage: https://cloudquery.io
-* Releases: https://github.com/cloudquery/cloudquery/releases
-* Documentation: https://docs.cloudquery.io
-* Database Configuration: https://docs.cloudquery.io/database-configuration
+- Homepage: https://cloudquery.io
+- Releases: https://github.com/cloudquery/cloudquery/releases
+- Documentation: https://docs.cloudquery.io
 
 ## Supported plugins
 

--- a/clients/doc.go
+++ b/clients/doc.go
@@ -1,0 +1,3 @@
+// package clients is a wrapper around grpc clients so clients can work
+// with non protobuf structs and handle unmarshaling
+package clients

--- a/clients/source.go
+++ b/clients/source.go
@@ -1,5 +1,3 @@
-// package clients is a wrapper around grpc clients so clients can work
-// with non protobuf structs and handle unmarshaling
 package clients
 
 import (
@@ -14,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 )
 
+// SourceClient
 type SourceClient struct {
 	pbClient pb.SourceClient
 }

--- a/codegen/doc.go
+++ b/codegen/doc.go
@@ -1,2 +1,2 @@
-// codgen helps autogenerate tables for CloudQuery source plugins from Go structs (of relrevant SDKs)
+// Package codgen helps autogenerate tables for CloudQuery source plugins from Go structs (of relevant SDKs)
 package codegen

--- a/codegen/doc.go
+++ b/codegen/doc.go
@@ -1,2 +1,2 @@
-// codgen helps autogenerate cloudquery plugins configured by definition
+// codgen helps autogenerate tables for CloudQuery source plugins from Go structs (of relrevant SDKs)
 package codegen

--- a/codegen/golang.go
+++ b/codegen/golang.go
@@ -156,6 +156,7 @@ func (t *TableDefinition) addColumnFromField(field reflect.StructField, parentFi
 	t.Columns = append(t.Columns, column)
 }
 
+// NewTableFromStruct creates a new TableDefinition from a struct by inspecting its fields
 func NewTableFromStruct(name string, obj interface{}, opts ...TableOptions) (*TableDefinition, error) {
 	t := &TableDefinition{
 		Name:            name,

--- a/plugins/docs.go
+++ b/plugins/docs.go
@@ -1,2 +1,2 @@
-// Package plugins defines the main APIs for source and destination plugins
+// Package plugins defines APIs for source and destination plugins
 package plugins

--- a/plugins/docs.go
+++ b/plugins/docs.go
@@ -1,0 +1,2 @@
+// Package plugins defines the main APIs for source and destination plugins
+package plugins

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -59,6 +59,8 @@ func addInternalColumns(tables []*schema.Table) {
 	}
 }
 
+// NewSourcePlugin returns a new plugin with a given name, version, tables, newExecutionClient
+// and additional options.
 func NewSourcePlugin(name string, version string, tables []*schema.Table, newExecutionClient SourceNewExecutionClientFunc, opts ...SourceOption) *SourcePlugin {
 	p := SourcePlugin{
 		name:               name,
@@ -91,27 +93,32 @@ func (p *SourcePlugin) validate() error {
 	return nil
 }
 
+// Tables returns all supported tables by this source plugin
 func (p *SourcePlugin) Tables() schema.Tables {
 	return p.tables
 }
 
+// ExampleConfig returns an example configuration for this source plugin
 func (p *SourcePlugin) ExampleConfig() string {
 	return p.exampleConfig
 }
 
+// Name return the name of this plugin
 func (p *SourcePlugin) Name() string {
 	return p.name
 }
 
+// Version returns the version of this plugin
 func (p *SourcePlugin) Version() string {
 	return p.version
 }
 
+// SetLogger sets the logger for this plugin which will be used in Sync and all other function calls.
 func (p *SourcePlugin) SetLogger(log zerolog.Logger) {
 	p.logger = log
 }
 
-// Sync data from source to the given channel
+// Sync is syncing data from the requested tables in spec to the given channel
 func (p *SourcePlugin) Sync(ctx context.Context, spec specs.Source, res chan<- *schema.Resource) error {
 	c, err := p.newExecutionClient(ctx, p.logger, spec)
 	if err != nil {

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,0 +1,2 @@
+// Package doc defines the main types supported by tables in source plugins
+package schema

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,2 +1,2 @@
-// Package doc defines the main types supported by tables in source plugins
+// Package schema defines types supported by tables in source plugins
 package schema

--- a/serve/doc.go
+++ b/serve/doc.go
@@ -1,4 +1,4 @@
-// Package serve defines the main APIs to serve source and destination plugins
+// Package serve defines APIs to serve (invoke) source and destination plugins
 package serve
 
 import (

--- a/serve/doc.go
+++ b/serve/doc.go
@@ -1,3 +1,4 @@
+// Package serve defines the main APIs to serve source and destination plugins
 package serve
 
 import (

--- a/specs/doc.go
+++ b/specs/doc.go
@@ -1,0 +1,3 @@
+// Package specs specs for source and destination plugins including
+// parsers and readers.
+package specs

--- a/specs/source.go
+++ b/specs/source.go
@@ -16,7 +16,7 @@ type Source struct {
 	// Path is the canonical path to the source plugin in a given registry
 	// For example:
 	// in github the path will be: org/repo
-	// in local the path will be the path to the binary: ./path/to/binary
+	// For the local registry the path will be the path to the binary: ./path/to/binary
 	// in grpc the path will be the address of the grpc server: host:port
 	Path string `json:"path,omitempty"`
 	// Registry can be github,local,grpc.

--- a/specs/source.go
+++ b/specs/source.go
@@ -24,7 +24,7 @@ type Source struct {
 	MaxGoRoutines uint64   `json:"max_goroutines,omitempty"`
 	// Tables to sync from the source plugin
 	Tables []string `json:"tables,omitempty"`
-	// SkipTables mentions tables to skip from the source plugin. Useful if glob is used in Tables
+	// SkipTables defines tables to skip when syncing data. Useful if a glob pattern is used in Tables
 	SkipTables []string `json:"skip_tables,omitempty"`
 	// Destinations names of the destinations to sync the data to
 	Destinations []string `json:"destinations,omitempty"`

--- a/specs/source.go
+++ b/specs/source.go
@@ -26,7 +26,7 @@ type Source struct {
 	Tables []string `json:"tables,omitempty"`
 	// SkipTables defines tables to skip when syncing data. Useful if a glob pattern is used in Tables
 	SkipTables []string `json:"skip_tables,omitempty"`
-	// Destinations names of the destinations to sync the data to
+	// Destinations are the names of destination plugins to send sync data to
 	Destinations []string `json:"destinations,omitempty"`
 	// Spec defines plugin specific configuration
 	// This is different in every source plugin.

--- a/specs/source.go
+++ b/specs/source.go
@@ -17,7 +17,7 @@ type Source struct {
 	// For example:
 	// in github the path will be: org/repo
 	// For the local registry the path will be the path to the binary: ./path/to/binary
-	// in grpc the path will be the address of the grpc server: host:port
+	// For the gRPC registry the path will be the address of the gRPC server: host:port
 	Path string `json:"path,omitempty"`
 	// Registry can be github,local,grpc.
 	Registry      Registry `json:"registry,omitempty"`

--- a/specs/source.go
+++ b/specs/source.go
@@ -7,19 +7,30 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// Source is the shared configuration for all source plugins
+// Source is the spec for a source plugin
 type Source struct {
-	Name    string `json:"name,omitempty"`
+	// Name of the source plugin to use
+	Name string `json:"name,omitempty"`
+	// Version of the source plugin to use
 	Version string `json:"version,omitempty"`
-	// Path is the path in the registry
+	// Path is the canonical path to the source plugin in a given registry
+	// For example:
+	// in github the path will be: org/repo
+	// in local the path will be the path to the binary: ./path/to/binary
+	// in grpc the path will be the address of the grpc server: host:port
 	Path string `json:"path,omitempty"`
-	// Registry can be github,local,grpc. Might support things like https in the future.
-	Registry      Registry    `json:"registry,omitempty"`
-	MaxGoRoutines uint64      `json:"max_goroutines,omitempty"`
-	Tables        []string    `json:"tables,omitempty"`
-	SkipTables    []string    `json:"skip_tables,omitempty"`
-	Destinations  []string    `json:"destinations,omitempty"`
-	Spec          interface{} `json:"spec,omitempty"`
+	// Registry can be github,local,grpc.
+	Registry      Registry `json:"registry,omitempty"`
+	MaxGoRoutines uint64   `json:"max_goroutines,omitempty"`
+	// Tables to sync from the source plugin
+	Tables []string `json:"tables,omitempty"`
+	// SkipTables mentions tables to skip from the source plugin. Useful if glob is used in Tables
+	SkipTables []string `json:"skip_tables,omitempty"`
+	// Destinations names of the destinations to sync the data to
+	Destinations []string `json:"destinations,omitempty"`
+	// Spec is the specific spec defined by an exact source plugin.
+	// This is different in every source plugin.
+	Spec interface{} `json:"spec,omitempty"`
 }
 
 func (s *Source) SetDefaults() {
@@ -37,6 +48,7 @@ func (s *Source) SetDefaults() {
 	}
 }
 
+// UnmarshalSpec unmarshals the internal spec into the given interface
 func (s *Source) UnmarshalSpec(out interface{}) error {
 	b, err := json.Marshal(s.Spec)
 	if err != nil {

--- a/specs/source.go
+++ b/specs/source.go
@@ -28,7 +28,7 @@ type Source struct {
 	SkipTables []string `json:"skip_tables,omitempty"`
 	// Destinations names of the destinations to sync the data to
 	Destinations []string `json:"destinations,omitempty"`
-	// Spec is the specific spec defined by an exact source plugin.
+	// Spec defines plugin specific configuration
 	// This is different in every source plugin.
 	Spec interface{} `json:"spec,omitempty"`
 }


### PR DESCRIPTION
As part of the v2 release we want to improve documentation for developers and for our plugin-sdk. 

Right now we have a bit of mix-match of tutorials and docs https://www.cloudquery.io/docs/developers/sdk/provider/configuration

What we want to achieve:
- SDK documentation in godoc together with docs - https://pkg.go.dev/github.com/cloudquery/plugin-sdk
- Tutorials - https://www.cloudquery.io/docs/developers/sdk/overview

There is still much more documentation to be added with some more examples but this should be a good start.

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
