### PR TITLE
feat: Add PK information to generated docs

### DIFF
--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
@@ -1,10 +1,13 @@
 
 # Table: relation_table
 Description for relational table
+
+The primary key for this table is **_cq_id**.
+
 ## Columns
 | Name          | Type          |
 | ------------- | ------------- |
 |string_col|String|
-|_cq_id|UUID|
+|_cq_id (PK)|UUID|
 |_cq_fetch_time|Timestamp|
 

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
@@ -1,10 +1,15 @@
 
 # Table: test_table
 Description for test table
+
+The composite primary key for this table is (**id_col**, **id_col2**).
+
 ## Columns
 | Name          | Type          |
 | ------------- | ------------- |
 |int_col|Int|
+|id_col (PK)|Int|
+|id_col2 (PK)|Int|
 |_cq_id|UUID|
 |_cq_fetch_time|Timestamp|
 

--- a/plugins/source_docs.go
+++ b/plugins/source_docs.go
@@ -13,11 +13,20 @@ import (
 const tableTmpl = `
 # Table: {{.Name}}
 {{ $.Description }}
+{{ $length := len $.PrimaryKeys -}} 
+{{ if eq $length 1 }}
+The primary key for this table is **{{ index $.PrimaryKeys 0 }}**.
+{{ else }}
+The composite primary key for this table is ({{ range $index, $pk := $.PrimaryKeys -}}
+	{{if $index }}, {{end -}}
+		**{{$pk}}**
+	{{- end -}}).
+{{ end }}
 ## Columns
 | Name          | Type          |
 | ------------- | ------------- |
 {{- range $column := $.Columns }}
-|{{$column.Name}}|{{$column.Type | formatType}}|
+|{{$column.Name}}{{if $column.CreationOptions.PrimaryKey}} (PK){{end}}|{{$column.Type | formatType}}|
 {{- end }}
 `
 

--- a/plugins/source_docs_test.go
+++ b/plugins/source_docs_test.go
@@ -19,6 +19,16 @@ var testTables = []*schema.Table{
 				Name: "int_col",
 				Type: schema.TypeInt,
 			},
+			{
+				Name:            "id_col",
+				Type:            schema.TypeInt,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
+			{
+				Name:            "id_col2",
+				Type:            schema.TypeInt,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
 		},
 		Relations: []*schema.Table{
 			{


### PR DESCRIPTION
This is important information to have, as it will tell users what columns will be used for replacing rows in overwrite mode, as well as inform on good candidates for performing relational joins. 