### PR TITLE
fix: Skip fields that have "-" json tag

### DIFF
--- a/codegen/golang.go
+++ b/codegen/golang.go
@@ -90,6 +90,10 @@ func WithUnwrapAllEmbeddedStructs() TableOptions {
 func defaultTransformer(field reflect.StructField) string {
 	name := field.Name
 	if jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]; len(jsonTag) > 0 {
+		// return empty string if the field is not related api response
+		if jsonTag == "-" {
+			return ""
+		}
 		name = jsonTag
 	}
 	return strcase.ToSnake(name)
@@ -148,6 +152,10 @@ func (t *TableDefinition) addColumnFromField(field reflect.StructField, parent *
 	// generate a PathResolver to use by default
 	pathResolver := fmt.Sprintf(`schema.PathResolver("%s")`, field.Name)
 	name := t.nameTransformer(field)
+	// skip field if there is no name
+	if name == "" {
+		return
+	}
 	if parent != nil {
 		pathResolver = fmt.Sprintf(`schema.PathResolver("%s.%s")`, parent.Name, field.Name)
 		name = t.nameTransformer(*parent) + "_" + name

--- a/codegen/golang_test.go
+++ b/codegen/golang_test.go
@@ -32,6 +32,7 @@ type testStruct struct {
 	TimeCol        time.Time  `json:"time_col,omitempty"`
 	TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
 	JSONTAG        *string    `json:"json_tag"`
+	JSONTAG_SKIP   *string    `json:"-"`
 	NOJSONTAG      *string
 	*embeddedStruct
 }

--- a/codegen/golang_test.go
+++ b/codegen/golang_test.go
@@ -32,7 +32,7 @@ type testStruct struct {
 	TimeCol        time.Time  `json:"time_col,omitempty"`
 	TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
 	JSONTAG        *string    `json:"json_tag"`
-	JSONTAG_SKIP   *string    `json:"-"`
+	SKIPJSONTAG    *string    `json:"-"`
 	NOJSONTAG      *string
 	*embeddedStruct
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->
If field has a `json: "-"` tag that means that it is not the data parsed from api. so such a field should be skipped.

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
