### PR TITLE
feat: Add information about relations to generated docs

### DIFF
--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
@@ -1,7 +1,5 @@
-
 # Source Plugin: test
 ## Tables
 | Name          | Description   |
 | ------------- | ------------- |
 |test_table|Description for test table|
-

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
@@ -1,8 +1,10 @@
-
 # Table: relation_table
 Description for relational table
 
 The primary key for this table is **_cq_id**.
+
+## Relations
+This table depends on [`test_table`](test_table.md).
 
 ## Columns
 | Name          | Type          |
@@ -10,4 +12,3 @@ The primary key for this table is **_cq_id**.
 |string_col|String|
 |_cq_id (PK)|UUID|
 |_cq_fetch_time|Timestamp|
-

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
@@ -1,8 +1,11 @@
-
 # Table: test_table
 Description for test table
 
 The composite primary key for this table is (**id_col**, **id_col2**).
+
+## Relations
+The following tables depend on `test_table`:
+  - [`relation_table`](relation_table.md)
 
 ## Columns
 | Name          | Type          |
@@ -12,4 +15,3 @@ The composite primary key for this table is (**id_col**, **id_col2**).
 |id_col2 (PK)|Int|
 |_cq_id|UUID|
 |_cq_fetch_time|Timestamp|
-

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -63,6 +63,15 @@ func addInternalColumns(tables []*schema.Table) {
 	}
 }
 
+// Set parent links on relational tables
+func setParents(tables []*schema.Table) {
+	for _, table := range tables {
+		for i := range table.Relations {
+			table.Relations[i].Parent = table
+		}
+	}
+}
+
 // NewSourcePlugin returns a new plugin with a given name, version, tables, newExecutionClient
 // and additional options.
 func NewSourcePlugin(name string, version string, tables []*schema.Table, newExecutionClient SourceNewExecutionClientFunc, opts ...SourceOption) *SourcePlugin {
@@ -76,6 +85,7 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 		opt(&p)
 	}
 	addInternalColumns(p.tables)
+	setParents(p.tables)
 	if err := p.validate(); err != nil {
 		panic(err)
 	}

--- a/plugins/templates/all_tables.go.tpl
+++ b/plugins/templates/all_tables.go.tpl
@@ -1,0 +1,7 @@
+# Source Plugin: {{.Name}}
+## Tables
+| Name          | Description   |
+| ------------- | ------------- |
+{{- range $table := $.Tables }}
+|{{$table.Name}}|{{$table.Description }}|
+{{- end }}

--- a/plugins/templates/table.go.tpl
+++ b/plugins/templates/table.go.tpl
@@ -1,0 +1,32 @@
+# Table: {{.Name}}
+{{ $.Description }}
+{{ $length := len $.PrimaryKeys -}}
+{{ if eq $length 1 }}
+The primary key for this table is **{{ index $.PrimaryKeys 0 }}**.
+{{ else }}
+The composite primary key for this table is ({{ range $index, $pk := $.PrimaryKeys -}}
+	{{if $index }}, {{end -}}
+		**{{$pk}}**
+	{{- end -}}).
+{{ end }}
+
+{{- if or ($.Relations) ($.Parent) }}
+## Relations
+{{- end }}
+{{- if $.Parent }}
+This table depends on [`{{ $.Parent.Name }}`]({{ $.Parent.Name }}.md).
+{{- end}}
+
+{{- if $.Relations }}
+The following tables depend on `{{.Name}}`:
+{{- range $rel := $.Relations }}
+  - [`{{ $rel.Name }}`]({{ $rel.Name }}.md)
+{{- end }}
+{{- end }}
+
+## Columns
+| Name          | Type          |
+| ------------- | ------------- |
+{{- range $column := $.Columns }}
+|{{$column.Name}}{{if $column.CreationOptions.PrimaryKey}} (PK){{end}}|{{$column.Type | formatType}}|
+{{- end }}


### PR DESCRIPTION
This adds a `Relations` section to generated docs, with information about parent- and child relationships. 

For example, a parent table might look like this:

```
## Relations
The following tables depend on `aws_accessanalyzer_analyzers`:
  - [`aws_accessanalyzer_analyzer_findings`](aws_accessanalyzer_analyzer_findings.md)
  - [`aws_accessanalyzer_analyzer_archive_rules`](aws_accessanalyzer_analyzer_archive_rules.md)
```

And a child table will look like this:

```
## Relations
This table depends on [`aws_accessanalyzer_analyzers`](aws_accessanalyzer_analyzers.md).
```