### PR TITLE
fix: Use plugin name to print usage

### DIFF
--- a/serve/destination.go
+++ b/serve/destination.go
@@ -139,7 +139,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 
 func newCmdDestinationRoot(destination *destinationServe) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "destination-plugin <command>",
+		Use: fmt.Sprintf("%s <command>", destination.plugin.Name()),
 	}
 	cmd.AddCommand(newCmdDestinationServe(destination))
 	cmd.CompletionOptions.DisableDefaultCmd = true

--- a/serve/source.go
+++ b/serve/source.go
@@ -155,7 +155,7 @@ func newCmdSourceDoc(source *sourceServe) *cobra.Command {
 
 func newCmdSourceRoot(source *sourceServe) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "source-plugin <command>",
+		Use: fmt.Sprintf("%s <command>", source.plugin.Name()),
 	}
 	cmd.AddCommand(newCmdSourceServe(source))
 	cmd.AddCommand(newCmdSourceDoc(source))


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Before:
![image](https://user-images.githubusercontent.com/26760571/191242350-376cc405-e921-4fc1-82ee-f4b595241fbc.png)

After:
![image](https://user-images.githubusercontent.com/26760571/191242379-735efb1a-eaa3-4e01-bdc1-f7ec33be0c21.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
