### PR TITLE
feat: Test that JSON columns don't receive string values

### DIFF
--- a/plugins/source_testing.go
+++ b/plugins/source_testing.go
@@ -93,6 +93,11 @@ func validateResource(t *testing.T, resource *schema.Resource) {
 		if val != nil {
 			switch resource.Table.Columns.Get(columnName).Type {
 			case schema.TypeJSON:
+				switch val.(type) {
+				case string, []byte:
+					t.Errorf("table: %s JSON column %s is being set with a string or byte slice. Either the unmarhsalled object should be passed in, or the column type should be changed to string", resource.Table.Name, columnName)
+					continue
+				}
 				if _, err := json.Marshal(val); err != nil {
 					t.Errorf("table: %s with invalid json column %s", resource.Table.Name, columnName)
 				}


### PR DESCRIPTION
This catches a new class of bug where an already-marshalled string or byte-slice gets passed to a JSON column. This results in string that gets doubly-marshalled, which is not the intention. Instead, either the unmarshalled object should be passed in, or the column type should be changed to string.