### PR TITLE
feat: Ignore specific field types

### DIFF
--- a/codegen/table.go
+++ b/codegen/table.go
@@ -73,11 +73,21 @@ func (t *TableDefinition) getUnwrappedFields(field reflect.StructField) []reflec
 	return fields
 }
 
+func isTypeIgnored(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Func, reflect.Chan, reflect.UnsafePointer:
+		return true
+	default:
+		return false
+	}
+}
+
 func (t *TableDefinition) ignoreField(field reflect.StructField) bool {
 	switch {
 	case len(field.Name) == 0,
 		slices.Contains(t.skipFields, field.Name),
-		!field.IsExported():
+		!field.IsExported(),
+		isTypeIgnored(field.Type):
 		return true
 	default:
 		return false

--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -33,6 +33,7 @@ type testStruct struct {
 	JSONTAG        *string    `json:"json_tag"`
 	SKIPJSONTAG    *string    `json:"-"`
 	NOJSONTAG      *string
+	InterfaceCol   interface{}
 
 	*embeddedStruct
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


https://github.com/cloudquery/plugin-sdk/pull/157 changed the behavior of printing a log message on unsupported types (like `interface`) to failing.
~~I'm not sure that's what we want as now the consumer has to skip all the interface fields to make code gen work.~~
~~I kept the failure on custom type transformer as I believe that should be indeed a failure to generate.~~

Changed the code to explicitly specific types

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
