### PR TITLE
feat: Addition and hopefully soon removal of gen command

### DIFF
--- a/specs/registry.go
+++ b/specs/registry.go
@@ -17,11 +17,32 @@ const (
 func (r Registry) String() string {
 	return [...]string{"github", "local", "grpc"}[r]
 }
+
 func (r Registry) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(r.String())
 	buffer.WriteString(`"`)
 	return buffer.Bytes(), nil
+}
+
+// This to implement to implement flag interface so we can use it with cobra
+// https://github.com/spf13/pflag/blob/master/flag.go#L187
+func (r Registry) Type() string {
+	return "string"
+}
+
+func (r *Registry) Set(value string) error {
+	switch value {
+	case "github":
+		*r = RegistryGithub
+	case "local":
+		*r = RegistryLocal
+	case "grpc":
+		*r = RegistryGrpc
+	default:
+		return fmt.Errorf("invalid registry %s", value)
+	}
+	return nil
 }
 
 func (r *Registry) UnmarshalJSON(data []byte) (err error) {

--- a/specs/source_test.go
+++ b/specs/source_test.go
@@ -1,6 +1,9 @@
 package specs
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 type testSourceSpec struct {
 	Accounts []string `json:"accounts"`
@@ -19,6 +22,52 @@ func TestSourceSetDefaults(t *testing.T) {
 	}
 	if source.Version != "latest" {
 		t.Fatalf("expected latest, got %s", source.Version)
+	}
+}
+
+const expectedSourceExample = `kind: "source"
+spec:
+  # Name of the plugin.
+  name: "testSource"
+
+  # Version of the plugin to use.
+  version: "v0.1.0"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "github"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "cloudquery/testSource"
+
+  # List of tables to sync.
+  tables: ["*"]
+
+  ## Tables to skip during sync. Optional.
+  # skip_tables: []
+
+  # Names of destination plugins to sync to.
+  destinations: ["postgresql"]
+
+  ## Approximate cap on number of requests to perform concurrently. Optional.
+  # concurrency: 1000
+
+  # Plugin-specific configuration.
+  spec:
+    # Check documentation here: https://github.com/cloudquery/cloudquery/tree/main/plugins/source/testSource`
+
+func TestSourceWriteExample(t *testing.T) {
+	spec := Source{
+		Name: "testSource",
+		Version: "v0.1.0",
+		Path: "cloudquery/testSource",
+		Registry: RegistryGithub,
+	}
+	var sb strings.Builder
+	if err := spec.WriteExample(&sb); err != nil {
+		t.Fatalf("failed to write example: %v", err)
+	}
+	if sb.String() != expectedSourceExample {
+		t.Fatalf("expected example:\n%s\ngot\n%s\n", expectedSourceExample, sb.String())
 	}
 }
 

--- a/specs/templates/destination.go.tpl
+++ b/specs/templates/destination.go.tpl
@@ -1,0 +1,20 @@
+kind: "destination"
+spec:
+  # Name of the plugin.
+  name: "{{.Name}}"
+
+  # Version of the plugin to use.
+  version: "{{.Version}}"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "{{.Registry}}"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "{{.Path}}"
+
+  # Write mode (either "overwrite" or "append").
+  write_mode: "{{.WriteMode}}"
+
+  # Plugin-specific configuration.
+  spec:
+    # {{.Spec}}

--- a/specs/templates/source.go.tpl
+++ b/specs/templates/source.go.tpl
@@ -1,0 +1,29 @@
+kind: "source"
+spec:
+  # Name of the plugin.
+  name: "{{.Name}}"
+
+  # Version of the plugin to use.
+  version: "{{.Version}}"
+
+  # Registry to use (one of "github", "local" or "grpc").
+  registry: "{{.Registry}}"
+
+  # Path to plugin. Required format depends on the registry.
+  path: "{{.Path}}"
+
+  # List of tables to sync.
+  tables: ["*"]
+
+  ## Tables to skip during sync. Optional.
+  # skip_tables: []
+
+  # Names of destination plugins to sync to.
+  destinations: ["postgresql"]
+
+  ## Approximate cap on number of requests to perform concurrently. Optional.
+  # concurrency: 1000
+
+  # Plugin-specific configuration.
+  spec:
+    # {{ if .Spec }}{{.Spec}}{{ end }}


### PR DESCRIPTION
While I was  working on fixing bugs in the gen command, moving it to the SDK (from the CLI after moving it from from the SDK 2 two weeks ago :) , protocol changes, tests, templates), adding flags to the gen command (testing the gen command)  I realised once again that we are slowly becoming a yaml automation company (https://xkcd.com/1319/) and now we have to make sure the "example config" that our baked cli example config should be up to date with the non-existent documentation (which is actually more important then the baked gen command). 

I believe we should drop the gen command as there is very little difference or time saving between the following:

```
cloudquery gen source aws --output example/config.yml
cloudquery gen destination postgresql --output example/config
```

vs

create those two files

```
kind: source
name: aws
```

```
kind: destination
name: postgresql
```

I believe we should stop maintaing this command before releasing v2 pre-release and maintain this public api as we can put our effort in better places by providing up-to-date documentation and consistent behaviour. 

Also, a bit more context on defaults:

if plugins have defaults this can work with the above small files as we shouldn't create defaults by saving those into a string and then outputing them back into a file and reading them back to the spec :) 

