### PR TITLE
feat!: Remove ParentPathResolver

### DIFF
--- a/schema/resolvers.go
+++ b/schema/resolvers.go
@@ -39,10 +39,3 @@ func ParentResourceFieldResolver(name string) ColumnResolver {
 		return r.Set(c.Name, r.Parent.Get(name))
 	}
 }
-
-// ParentPathResolver resolves a field from the parent
-func ParentPathResolver(path string) ColumnResolver {
-	return func(_ context.Context, _ ClientMeta, r *Resource, c Column) error {
-		return r.Set(c.Name, funk.Get(r.Parent.Item, path, funk.WithAllowZero()))
-	}
-}


### PR DESCRIPTION
#### Summary

Related to https://github.com/cloudquery/plugin-sdk/issues/199, I think we can (and should) use `ParentResourceFieldResolver` instead as it operates on the post processed table data of the parent, instead of the pre-processed data of the struct.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
