### PR TITLE
feat: Make NewSourceClient (and dest) as one interface

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -38,7 +38,7 @@ func WithDestinationLogger(logger zerolog.Logger) func(*DestinationClient) {
 	}
 }
 
-func WithDesintationDirectory(directory string) func(*DestinationClient) {
+func WithDestinationDirectory(directory string) func(*DestinationClient) {
 	return func(c *DestinationClient) {
 		c.directory = directory
 	}

--- a/clients/destination_test.go
+++ b/clients/destination_test.go
@@ -30,7 +30,7 @@ func TestDestinationClient(t *testing.T) {
 	for _, tc := range newDestinationClientTestCases {
 		t.Run(tc.Path+"_"+tc.Version, func(t *testing.T) {
 			dirName := t.TempDir()
-			c, err := NewDestinationClient(ctx, tc.Registry, tc.Path, tc.Version, WithDestinationLogger(l), WithDesintationDirectory(dirName))
+			c, err := NewDestinationClient(ctx, tc.Registry, tc.Path, tc.Version, WithDestinationLogger(l), WithDestinationDirectory(dirName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/clients/destination_test.go
+++ b/clients/destination_test.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/specs"
@@ -31,11 +30,7 @@ func TestDestinationClient(t *testing.T) {
 	for _, tc := range newDestinationClientTestCases {
 		t.Run(tc.Path+"_"+tc.Version, func(t *testing.T) {
 			dirName := t.TempDir()
-			localPath := path.Join(dirName, "plugin")
-			if err := DownloadPluginFromGithub(ctx, localPath, tc.Path, tc.Version, PluginTypeDestination); err != nil {
-				t.Fatal(err)
-			}
-			c, err := NewManagedDestinationClient(ctx, localPath, WithDestinationLogger(l))
+			c, err := NewDestinationClient(ctx, tc.Registry, tc.Path, tc.Version, WithDestinationLogger(l), WithDesintationDirectory(dirName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/clients/download.go
+++ b/clients/download.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 type PluginType string
@@ -19,12 +18,7 @@ const (
 	PluginTypeDestination PluginType = "destination"
 )
 
-func DownloadPluginFromGithub(ctx context.Context, localPath string, githubPath string, version string, typ PluginType, writers ...io.Writer) error {
-	pathSplit := strings.Split(githubPath, "/")
-	if len(pathSplit) != 2 {
-		return fmt.Errorf("invalid github path. should be in format: owner/repo")
-	}
-	org, name := pathSplit[0], pathSplit[1]
+func DownloadPluginFromGithub(ctx context.Context, localPath string, org string, name string, version string, typ PluginType, writers ...io.Writer) error {
 	downloadDir := filepath.Dir(localPath)
 	pluginZipPath := localPath + ".zip"
 	// https://github.com/cloudquery/cloudquery/releases/download/plugins-source-test-v1.1.5/test_darwin_amd64.zip

--- a/clients/source.go
+++ b/clients/source.go
@@ -50,7 +50,7 @@ func WithSourceDirectory(directory string) func(*SourceClient) {
 	}
 }
 
-func WithSourceGrpcConn(userConn *grpc.ClientConn) func(*SourceClient) {
+func WithSourceGRPCConnection(userConn *grpc.ClientConn) func(*SourceClient) {
 	return func(c *SourceClient) {
 		// we use a different variable here because we don't want to close a connection that wasn't created by us.
 		c.userConn = userConn

--- a/clients/source.go
+++ b/clients/source.go
@@ -8,12 +8,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/cloudquery/plugin-sdk/internal/pb"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/specs"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -21,8 +22,10 @@ import (
 // SourceClient
 type SourceClient struct {
 	pbClient       pb.SourceClient
+	directory      string
 	cmd            *exec.Cmd
 	logger         zerolog.Logger
+	userConn       *grpc.ClientConn
 	conn           *grpc.ClientConn
 	grpcSocketName string
 	cmdWaitErr     error
@@ -40,22 +43,61 @@ func WithSourceLogger(logger zerolog.Logger) func(*SourceClient) {
 	}
 }
 
-// NewSourceClient connect to gRPC server running source plugin and returns a new SourceClient
-func NewSourceClient(cc grpc.ClientConnInterface) *SourceClient {
-	return &SourceClient{
-		pbClient: pb.NewSourceClient(cc),
+func WithSourceDirectory(directory string) func(*SourceClient) {
+	return func(c *SourceClient) {
+		c.directory = directory
 	}
 }
 
-// NewManagedSourceClient starts a new source plugin process, connects to it via gRPC server
-// and returns a new SourceClient
-func NewManagedSourceClient(ctx context.Context, path string, opts ...SourceClientOption) (*SourceClient, error) {
+func WithSourceGrpcConn(userConn *grpc.ClientConn) func(*SourceClient) {
+	return func(c *SourceClient) {
+		// we use a different variable here because we don't want to close a connection that wasn't created by us.
+		c.userConn = userConn
+	}
+}
+
+// NewSourceClient connect to gRPC server running source plugin and returns a new SourceClient
+func NewSourceClient(ctx context.Context, registry specs.Registry, path string, version string, opts ...SourceClientOption) (*SourceClient, error) {
+	var err error
 	c := &SourceClient{
-		logger: log.Logger,
+		directory: "./",
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
+	switch registry {
+	case specs.RegistryGrpc:
+		if c.userConn == nil {
+			c.conn, err = grpc.Dial(path, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				return nil, fmt.Errorf("failed to dial grpc source plugin at %s: %w", path, err)
+			}
+			c.pbClient = pb.NewSourceClient(c.conn)
+		} else {
+			c.pbClient = pb.NewSourceClient(c.userConn)
+		}
+		return c, nil
+	case specs.RegistryLocal:
+		return c.newManagedClient(ctx, path)
+	case specs.RegistryGithub:
+		pathSplit := strings.Split(path, "/")
+		if len(pathSplit) != 2 {
+			return nil, fmt.Errorf("invalid github plugin path: %s. format should be owner/repo", path)
+		}
+		org, name := pathSplit[0], pathSplit[1]
+		localPath := filepath.Join(c.directory, "plugins", string(PluginTypeSource), org, name, version, "plugin")
+		if err := DownloadPluginFromGithub(ctx, localPath, org, name, version, PluginTypeSource); err != nil {
+			return nil, err
+		}
+		return c.newManagedClient(ctx, localPath)
+	default:
+		return nil, fmt.Errorf("unsupported registry %s", registry)
+	}
+}
+
+// newManagedClient starts a new source plugin process from local path, connects to it via gRPC server
+// and returns a new SourceClient
+func (c *SourceClient) newManagedClient(ctx context.Context, path string) (*SourceClient, error) {
 	c.grpcSocketName = generateRandomUnixSocketName()
 	// spawn the plugin first and then connect
 	cmd := exec.CommandContext(ctx, path, "serve", "--network", "unix", "--address", c.grpcSocketName,

--- a/clients/source_test.go
+++ b/clients/source_test.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/cloudquery/plugin-sdk/specs"
@@ -31,11 +30,7 @@ func TestSourceClient(t *testing.T) {
 	for _, tc := range newSourceClientTestCases {
 		t.Run(tc.Path+"_"+tc.Version, func(t *testing.T) {
 			dirName := t.TempDir()
-			localPath := path.Join(dirName, "plugin")
-			if err := DownloadPluginFromGithub(ctx, localPath, tc.Path, tc.Version, PluginTypeSource); err != nil {
-				t.Fatal(err)
-			}
-			c, err := NewManagedSourceClient(ctx, localPath, WithSourceLogger(l))
+			c, err := NewSourceClient(ctx, tc.Registry, tc.Path, tc.Version, WithSourceLogger(l), WithSourceDirectory(dirName))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/serve/destination.go
+++ b/serve/destination.go
@@ -77,7 +77,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 			var listener net.Listener
 			if network == "test" {
 				listener = bufconn.Listen(testBufSize)
-				testListener = listener.(*bufconn.Listener)
+				testDestinationListener = listener.(*bufconn.Listener)
 			} else {
 				listener, err = net.Listen(network, address)
 				if err != nil {

--- a/serve/destination_test.go
+++ b/serve/destination_test.go
@@ -1,0 +1,97 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cloudquery/plugin-sdk/clients"
+	"github.com/cloudquery/plugin-sdk/plugins"
+	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/cloudquery/plugin-sdk/specs"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func bufDestinationDialer(context.Context, string) (net.Conn, error) {
+	return testDestinationListener.Dial()
+}
+
+type testDestinationClient struct {
+}
+
+func (*testDestinationClient) Name() string {
+	return "testDestinationPlugin"
+}
+func (*testDestinationClient) Version() string {
+	return "development"
+}
+func (*testDestinationClient) Initialize(context.Context, specs.Destination) error {
+	return nil
+}
+func (*testDestinationClient) Migrate(context.Context, schema.Tables) error {
+	return nil
+}
+func (*testDestinationClient) Write(context.Context, string, map[string]interface{}) error {
+	return nil
+}
+func (*testDestinationClient) SetLogger(zerolog.Logger) {
+}
+
+func TestDestination(t *testing.T) {
+	plugin := plugins.DestinationPlugin(&testDestinationClient{})
+	s := &destinationServe{
+		plugin: plugin,
+	}
+
+	cmd := newCmdDestinationRoot(s)
+	cmd.SetArgs([]string{"serve", "--network", "test"})
+
+	var serveErr error
+	go func() {
+		serveErr = cmd.Execute()
+	}()
+
+	// wait for the server to start
+	for {
+		if testDestinationListener != nil {
+			break
+		}
+		t.Log("waiting for grpc server to start")
+		time.Sleep(time.Millisecond * 200)
+		if serveErr != nil {
+			t.Fatal(serveErr)
+		}
+	}
+
+	// https://stackoverflow.com/questions/42102496/testing-a-grpc-service
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDestinationDialer), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	c, err := clients.NewDestinationClient(ctx, specs.RegistryGrpc, "", "", clients.WithDestinationGrpcConn(conn))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resources := make(chan []byte)
+	wg := errgroup.Group{}
+	wg.Go(func() error {
+		defer close(resources)
+		name, err := c.Name(ctx)
+		if err != nil {
+			return err
+		}
+		if name != "testDestinationPlugin" {
+			return fmt.Errorf("expected name to be testDestinationPlugin but got %s", name)
+		}
+		return nil
+	})
+	if err := wg.Wait(); err != nil {
+		t.Fatalf("Failed to get name from destination plugin: %v", err)
+	}
+}

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -22,4 +22,5 @@ const (
 )
 
 // lis used for unit testing grpc server and client
-var testListener *bufconn.Listener
+var testSourceListener *bufconn.Listener
+var testDestinationListener *bufconn.Listener

--- a/serve/source.go
+++ b/serve/source.go
@@ -77,7 +77,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 			var listener net.Listener
 			if network == "test" {
 				listener = bufconn.Listen(testBufSize)
-				testListener = listener.(*bufconn.Listener)
+				testSourceListener = listener.(*bufconn.Listener)
 			} else {
 				listener, err = net.Listen(network, address)
 				if err != nil {

--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -64,11 +64,11 @@ func newTestExecutionClient(context.Context, zerolog.Logger, specs.Source) (sche
 	return &testExecutionClient{}, nil
 }
 
-func bufDialer(context.Context, string) (net.Conn, error) {
-	return testListener.Dial()
+func bufSourceDialer(context.Context, string) (net.Conn, error) {
+	return testSourceListener.Dial()
 }
 
-func TestServe(t *testing.T) {
+func TestServeSource(t *testing.T) {
 	plugin := plugins.NewSourcePlugin(
 		"testSourcePlugin",
 		"v1.0.0",
@@ -89,7 +89,7 @@ func TestServe(t *testing.T) {
 
 	// wait for the server to start
 	for {
-		if testListener != nil {
+		if testSourceListener != nil {
 			break
 		}
 		t.Log("waiting for grpc server to start")
@@ -101,7 +101,7 @@ func TestServe(t *testing.T) {
 
 	// https://stackoverflow.com/questions/42102496/testing-a-grpc-service
 	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufSourceDialer), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}

--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -105,7 +105,7 @@ func TestServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c, err := clients.NewSourceClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGrpcConn(conn))
+	c, err := clients.NewSourceClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGRPCConnection(conn))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -105,7 +105,10 @@ func TestServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c := clients.NewSourceClient(conn)
+	c, err := clients.NewSourceClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGrpcConn(conn))
+	if err != nil {
+		t.Fatal(err)
+	}
 	resources := make(chan []byte)
 	wg := errgroup.Group{}
 	wg.Go(func() error {


### PR DESCRIPTION
#### Summary

I think I finally nailed the Client interface. This will remove completely the need for "PluginManager" in the CLI and yet another abstraction layer and prop drilling with WithOptions duplicates for every abstraction layer.

Also, the SDK is aware of `registry`, `path` and `version` so I really think it should be here. it turns the CLI intro real CLI finally. 
