### PR TITLE
fix: Create doc directory if doesn't exist

### DIFF
--- a/plugins/source_docs.go
+++ b/plugins/source_docs.go
@@ -17,6 +17,10 @@ var templatesFS embed.FS
 // GenerateSourcePluginDocs creates table documentation for the source plugin based on its list of tables
 func (p *SourcePlugin) GenerateSourcePluginDocs(dir string) error {
 	for _, table := range p.Tables() {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			fmt.Printf("failed to create directory %q: %v", dir, err)
+			return err
+		}
 		if err := renderAllTables(table, dir); err != nil {
 			fmt.Printf("render table %s error: %s", table.Name, err)
 			return err

--- a/plugins/source_docs.go
+++ b/plugins/source_docs.go
@@ -16,11 +16,10 @@ var templatesFS embed.FS
 
 // GenerateSourcePluginDocs creates table documentation for the source plugin based on its list of tables
 func (p *SourcePlugin) GenerateSourcePluginDocs(dir string) error {
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
 	for _, table := range p.Tables() {
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-			fmt.Printf("failed to create directory %q: %v", dir, err)
-			return err
-		}
 		if err := renderAllTables(table, dir); err != nil {
 			fmt.Printf("render table %s error: %s", table.Name, err)
 			return err


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

If you run the `doc` command and the output directory doesn't exist, the command will fail. This fixes it

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
