### PR TITLE
fix: Remove unused docs template function

### DIFF
--- a/plugins/source_docs.go
+++ b/plugins/source_docs.go
@@ -54,9 +54,6 @@ func renderAllTables(t *schema.Table, dir string) error {
 func renderTable(table *schema.Table, dir string) error {
 	t := template.New("").Funcs(map[string]interface{}{
 		"formatType": formatType,
-		"removeLineBreaks": func(text string) string {
-			return strings.ReplaceAll(text, "\n", " ")
-		},
 	})
 	t, err := t.New("table.go.tpl").ParseFS(templatesFS, "templates/table.go.tpl")
 	if err != nil {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


I couldn't find where this template function is being used

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
