### PR TITLE
fix: Use correct path for Windows zip

### DIFF
--- a/clients/download.go
+++ b/clients/download.go
@@ -50,6 +50,9 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	if org != "cloudquery" {
 		pathInArchive = fmt.Sprintf("cq-%s-%s", typ, name)
 	}
+	if runtime.GOOS == "windows" {
+		pathInArchive += ".exe"
+	}
 
 	fileInArchive, err := archive.Open(pathInArchive)
 	if err != nil {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Hard to test this as we need to release a new SDK, update it in the CLI and then test again via https://github.com/cloudquery/cloudquery/pull/2204.

Similar to the fix in https://github.com/cloudquery/cloudquery/pull/1894

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
