### PR TITLE
fix: Set default download directory to `.cq`

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -62,7 +62,7 @@ func WithDestinationGrpcConn(userConn *grpc.ClientConn) func(*DestinationClient)
 func NewDestinationClient(ctx context.Context, registry specs.Registry, path string, version string, opts ...DestinationClientOption) (*DestinationClient, error) {
 	var err error
 	c := &DestinationClient{
-		directory: "./",
+		directory: DefaultDownloadDir,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/clients/download.go
+++ b/clients/download.go
@@ -16,6 +16,7 @@ type PluginType string
 const (
 	PluginTypeSource      PluginType = "source"
 	PluginTypeDestination PluginType = "destination"
+	DefaultDownloadDir               = ".cq"
 )
 
 func DownloadPluginFromGithub(ctx context.Context, localPath string, org string, name string, version string, typ PluginType, writers ...io.Writer) error {

--- a/clients/source.go
+++ b/clients/source.go
@@ -68,7 +68,7 @@ func WithSourceWriters(writers ...io.Writer) func(*SourceClient) {
 func NewSourceClient(ctx context.Context, registry specs.Registry, path string, version string, opts ...SourceClientOption) (*SourceClient, error) {
 	var err error
 	c := &SourceClient{
-		directory: "./",
+		directory: DefaultDownloadDir,
 	}
 	for _, opt := range opts {
 		opt(c)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Currently plugins are downloaded to `CWD/plugins/*`. This PR changes it so they are downloaded to `CWD/.cq/plugins/*`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
