### PR TITLE
fix: Use correct binary path on Windows

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -88,6 +88,7 @@ func NewDestinationClient(ctx context.Context, registry specs.Registry, path str
 		}
 		org, name := pathSplit[0], pathSplit[1]
 		localPath := filepath.Join(c.directory, "plugins", string(PluginTypeDestination), org, name, version, "plugin")
+		localPath = withBinarySuffix(localPath)
 		if err := DownloadPluginFromGithub(ctx, localPath, org, name, version, PluginTypeDestination, c.writers...); err != nil {
 			return nil, err
 		}

--- a/clients/download.go
+++ b/clients/download.go
@@ -50,9 +50,7 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	if org != "cloudquery" {
 		pathInArchive = fmt.Sprintf("cq-%s-%s", typ, name)
 	}
-	if runtime.GOOS == "windows" {
-		pathInArchive += ".exe"
-	}
+	pathInArchive = withBinarySuffix(pathInArchive)
 
 	fileInArchive, err := archive.Open(pathInArchive)
 	if err != nil {
@@ -107,4 +105,11 @@ func downloadFile(ctx context.Context, localPath string, url string, writers ...
 	}
 
 	return nil
+}
+
+func withBinarySuffix(path string) string {
+	if runtime.GOOS == "windows" {
+		return path + ".exe"
+	}
+	return path
 }

--- a/clients/source.go
+++ b/clients/source.go
@@ -94,6 +94,7 @@ func NewSourceClient(ctx context.Context, registry specs.Registry, path string, 
 		}
 		org, name := pathSplit[0], pathSplit[1]
 		localPath := filepath.Join(c.directory, "plugins", string(PluginTypeSource), org, name, version, "plugin")
+		localPath = withBinarySuffix(localPath)
 		if err := DownloadPluginFromGithub(ctx, localPath, org, name, version, PluginTypeSource, c.writers...); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Based on `go` source code binaries on Windows must end in `exe`, `cmd`, etc. See https://github.com/golang/go/blob/f6d844510d5f1e3b3098eba255d9b633d45eac3b/src/os/exec/lp_windows.go#L39
⬆️ Is the code that looks up the binary when you use the `exec` package

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
