### PR TITLE
fix: Plugin connection using Unix Domain Socket fixed for windows

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,7 +64,7 @@ func NewDestinationClient(ctx context.Context, registry specs.Registry, path str
 	switch registry {
 	case specs.RegistryGrpc:
 		if c.userConn == nil {
-			c.conn, err = grpc.Dial(path, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			c.conn, err = grpc.DialContext(ctx, path, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				return nil, fmt.Errorf("failed to dial grpc source plugin at %s: %w", path, err)
 			}
@@ -127,7 +128,11 @@ func (c *DestinationClient) newManagedClient(ctx context.Context, path string) (
 		}
 	}()
 
-	c.conn, err = grpc.DialContext(ctx, "unix://"+c.grpcSocketName, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+		d := &net.Dialer{}
+		return d.DialContext(ctx, "unix", addr)
+	}
+	c.conn, err = grpc.DialContext(ctx, c.grpcSocketName, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), grpc.WithContextDialer(dialer))
 	if err != nil {
 		if err := cmd.Process.Kill(); err != nil {
 			c.logger.Error().Err(err).Msg("failed to kill plugin process")

--- a/clients/download.go
+++ b/clients/download.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 
@@ -98,7 +97,7 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bad status: %s. downloading %s", resp.Status, url)
 	}
-	bar := progressbar.DefaultBytes(resp.ContentLength, "Downloading: "+path.Base(url))
+	bar := progressbar.DefaultBytes(resp.ContentLength, "Downloading: "+url)
 
 	// Writer the body to file
 	_, err = io.Copy(io.MultiWriter(out, bar), resp.Body)
@@ -109,9 +108,9 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 	return nil
 }
 
-func withBinarySuffix(path string) string {
+func withBinarySuffix(filePath string) string {
 	if runtime.GOOS == "windows" {
-		return path + ".exe"
+		return filePath + ".exe"
 	}
-	return path
+	return filePath
 }

--- a/clients/download.go
+++ b/clients/download.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 
@@ -97,7 +98,7 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bad status: %s. downloading %s", resp.Status, url)
 	}
-	bar := progressbar.DefaultBytes(resp.ContentLength, "Downloading: "+url)
+	bar := progressbar.DefaultBytes(resp.ContentLength, "Downloading: "+path.Base(url))
 
 	// Writer the body to file
 	_, err = io.Copy(io.MultiWriter(out, bar), resp.Body)

--- a/clients/random.go
+++ b/clients/random.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 )
 
@@ -23,5 +23,5 @@ func randSeq(n int) string {
 }
 
 func generateRandomUnixSocketName() string {
-	return path.Join(unixSocketDir, "cq-"+randSeq(16)+".sock")
+	return filepath.Join(unixSocketDir, "cq-"+randSeq(16)+".sock")
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

closes #245 
`grpc.Dial` does not work with "unix://" prefix on windows. protocol should be set in dialer to make it work

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
