### PR TITLE
fix: Progressbar should go into stdout

### DIFF
--- a/clients/download.go
+++ b/clients/download.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/schollz/progressbar/v3"
 )
@@ -97,8 +98,8 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bad status: %s. downloading %s", resp.Status, url)
 	}
-	fmt.Fprintf(os.Stderr, "Downloading %s\n", url)
-	bar := progressbar.DefaultBytes(resp.ContentLength, "")
+	fmt.Printf("Downloading %s\n", url)
+	bar := downloadProgressBar(resp.ContentLength, "Downloading")
 
 	// Writer the body to file
 	_, err = io.Copy(io.MultiWriter(out, bar), resp.Body)
@@ -107,6 +108,28 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 	}
 
 	return nil
+}
+
+func downloadProgressBar(maxBytes int64, description ...string) *progressbar.ProgressBar {
+	desc := ""
+	if len(description) > 0 {
+		desc = description[0]
+	}
+	return progressbar.NewOptions64(
+		maxBytes,
+		progressbar.OptionSetDescription(desc),
+		progressbar.OptionSetWriter(os.Stdout),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(10),
+		progressbar.OptionThrottle(65*time.Millisecond),
+		progressbar.OptionShowCount(),
+		progressbar.OptionOnCompletion(func() {
+			fmt.Fprint(os.Stdout, "\n")
+		}),
+		progressbar.OptionSpinnerType(14),
+		progressbar.OptionFullWidth(),
+		progressbar.OptionSetRenderBlankState(true),
+	)
 }
 
 func withBinarySuffix(filePath string) string {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

This PR and this https://github.com/cloudquery/cloudquery/pull/2459 should ensure logs and stdout are not running over each other.

The convention should be the following fmt.Print* -> stdout, logs -> stderr
this way it's easy to turn off one stream or the other depending on the need
