### PR TITLE
fix: Recover panic in table resolver and object resolver flows

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -180,6 +180,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, r
 					sentry.CurrentHub().CaptureMessage(stack)
 				})
 				meta.Logger().Error().Interface("error", err).Str("table", t.Name).TimeDiff("duration", time.Now(), startTime).Str("stack", stack).Msg("table resolver finished with panic")
+				//nolint:all as we use atomic. (false positive)
 				atomic.AddUint64(&summary.Panics, 1)
 			}
 			close(res)
@@ -187,6 +188,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, r
 		meta.Logger().Debug().Str("table", t.Name).Msg("table resolver started")
 		if err := t.Resolver(ctx, meta, parent, res); err != nil {
 			meta.Logger().Error().Str("table", t.Name).TimeDiff("duration", time.Now(), startTime).Err(err).Msg("table resolver finished with error")
+			//nolint:all as we use atomic. (false positive)
 			atomic.AddUint64(&summary.Errors, 1)
 			return
 		}

--- a/schema/table.go
+++ b/schema/table.go
@@ -70,7 +70,7 @@ type Table struct {
 	columnsMap map[string]int
 }
 
-func (s *SyncSummary) Merge(other *SyncSummary) {
+func (s *SyncSummary) Merge(other SyncSummary) {
 	atomic.AddUint64(&s.Resources, other.Resources)
 	atomic.AddUint64(&s.Errors, other.Errors)
 	atomic.AddUint64(&s.Panics, other.Panics)
@@ -165,11 +165,9 @@ func (t Table) TableNames() []string {
 }
 
 // Call the table resolver with with all of it's relation for every reolved resource
-func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, resolvedResources chan<- *Resource) (summary *SyncSummary) {
-	summary = &SyncSummary{}
+func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, resolvedResources chan<- *Resource) (summary SyncSummary) {
 	tableStartTime := time.Now()
 	meta.Logger().Info().Str("table", t.Name).Msg("table resolver started")
-	summary = &SyncSummary{}
 
 	res := make(chan interface{})
 	startTime := time.Now()
@@ -209,8 +207,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, r
 	return summary
 }
 
-func (t Table) resolveObject(ctx context.Context, meta ClientMeta, parent *Resource, item interface{}, resolvedResources chan<- *Resource) (summary *SyncSummary) {
-	summary = &SyncSummary{}
+func (t Table) resolveObject(ctx context.Context, meta ClientMeta, parent *Resource, item interface{}, resolvedResources chan<- *Resource) (summary SyncSummary) {
 	resource := NewResourceData(&t, parent, item)
 	objectStartTime := time.Now()
 	csr := caser.New()

--- a/schema/table.go
+++ b/schema/table.go
@@ -166,8 +166,10 @@ func (t Table) TableNames() []string {
 
 // Call the table resolver with with all of it's relation for every reolved resource
 func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, resolvedResources chan<- *Resource) (summary *SyncSummary) {
+	summary = &SyncSummary{}
 	tableStartTime := time.Now()
 	meta.Logger().Info().Str("table", t.Name).Msg("table resolver started")
+	summary = &SyncSummary{}
 
 	res := make(chan interface{})
 	startTime := time.Now()
@@ -208,6 +210,7 @@ func (t Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, r
 }
 
 func (t Table) resolveObject(ctx context.Context, meta ClientMeta, parent *Resource, item interface{}, resolvedResources chan<- *Resource) (summary *SyncSummary) {
+	summary = &SyncSummary{}
 	resource := NewResourceData(&t, parent, item)
 	objectStartTime := time.Now()
 	csr := caser.New()
@@ -270,8 +273,7 @@ func (t Table) resolveObject(ctx context.Context, meta ClientMeta, parent *Resou
 	resolvedResources <- resource
 
 	for _, rel := range t.Relations {
-		relationSummary := rel.Resolve(ctx, meta, resource, resolvedResources)
-		summary.Merge(relationSummary)
+		summary.Merge(rel.Resolve(ctx, meta, resource, resolvedResources))
 	}
 
 	return summary

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -11,7 +11,7 @@ import (
 type tableTestCase struct {
 	Table     *Table
 	Resources []*Resource
-	Summary *SyncSummary
+	Summary   *SyncSummary
 }
 
 type testClient struct {
@@ -145,25 +145,25 @@ var tableTestCases = []tableTestCase{
 			},
 		},
 		Summary: &SyncSummary{
-			Resources: 1,	
+			Resources: 1,
 		},
 	},
 	{
-		Table: testTableResolverPanic(),
+		Table:     testTableResolverPanic(),
 		Resources: nil,
 		Summary: &SyncSummary{
 			Panics: 1,
 		},
 	},
 	{
-		Table: testPreResourceResolverPanic(),
+		Table:     testPreResourceResolverPanic(),
 		Resources: []*Resource{},
 		Summary: &SyncSummary{
 			Panics: 1,
 		},
 	},
 	{
-		Table: testColumnResolverPanic(),
+		Table:     testColumnResolverPanic(),
 		Resources: []*Resource{},
 		Summary: &SyncSummary{
 			Panics: 1,
@@ -197,7 +197,7 @@ var tableTestCases = []tableTestCase{
 			},
 		},
 		Summary: &SyncSummary{
-			Panics: 1,
+			Panics:    1,
 			Resources: 1,
 		},
 	},
@@ -214,7 +214,7 @@ func TestTableExecution(t *testing.T) {
 		t.Run(tc.Table.Name, func(t *testing.T) {
 			m := testClient{}
 			resources := make(chan *Resource)
-			summary := SyncSummary{}
+			var summary *SyncSummary
 			go func() {
 				defer close(resources)
 				summary = tc.Table.Resolve(ctx, m, nil, resources)
@@ -238,8 +238,6 @@ func TestTableExecution(t *testing.T) {
 			if tc.Summary.Panics != summary.Panics {
 				t.Errorf("expected %d panics, got %d", tc.Summary.Panics, summary.Panics)
 			}
-
 		})
 	}
 }
-

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -9,38 +9,196 @@ import (
 )
 
 type tableTestCase struct {
-	Table     Table
+	Table     *Table
 	Resources []*Resource
+	Summary *SyncSummary
 }
 
 type testClient struct {
 }
 
-var tableTestCases = []tableTestCase{
-	{
-		Table: Table{
-			Name: "testResolver",
-			Columns: []Column{
-				{
-					Name: "test",
-					Type: TypeInt,
-				},
-			},
-			Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
-				res <- []map[string]interface{}{
-					{
-						"test": 1,
-					},
-				}
-				return nil
+func testTableSuccess() *Table {
+	return &Table{
+		Name: "testTableSuccess",
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			res <- map[string]interface{}{
+				"TestColumn": 3,
+			}
+			return nil
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
 			},
 		},
+	}
+}
+
+func testTableRelationSuccess() *Table {
+	return &Table{
+		Name: "testTableRelationSuccess",
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			res <- map[string]interface{}{
+				"TestColumn": 3,
+			}
+			return nil
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
+			},
+		},
+		Relations: []*Table{
+			testTableSuccess(),
+		},
+	}
+}
+
+func testTableRelationPanic() *Table {
+	return &Table{
+		Name: "testTableRelationSuccess",
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			res <- map[string]interface{}{
+				"TestColumn": 3,
+			}
+			return nil
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
+			},
+		},
+		Relations: []*Table{
+			testTableResolverPanic(),
+		},
+	}
+}
+
+func testTableResolverPanic() *Table {
+	return &Table{
+		Name: "testTableResolverPanic",
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			panic("Resolver")
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
+			},
+		},
+	}
+}
+
+func testPreResourceResolverPanic() *Table {
+	return &Table{
+		Name: "testPreResourceResolverPanic",
+		PreResourceResolver: func(ctx context.Context, meta ClientMeta, resource *Resource) error {
+			panic("PreResourceResolver")
+		},
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			res <- map[string]interface{}{
+				"TestColumn": 3,
+			}
+			return nil
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
+			},
+		},
+	}
+}
+
+func testColumnResolverPanic() *Table {
+	return &Table{
+		Name: "testColumnResolverPanic",
+		Resolver: func(ctx context.Context, meta ClientMeta, parent *Resource, res chan<- interface{}) error {
+			res <- map[string]interface{}{
+				"TestColumn": 3,
+			}
+			return nil
+		},
+		Columns: []Column{
+			{
+				Name: "test_column",
+				Type: TypeInt,
+				Resolver: func(ctx context.Context, meta ClientMeta, resource *Resource, c Column) error {
+					panic("ColumnResolver")
+				},
+			},
+		},
+	}
+}
+
+var tableTestCases = []tableTestCase{
+	{
+		Table: testTableSuccess(),
 		Resources: []*Resource{
 			{
 				Data: map[string]interface{}{
 					"test": 1,
 				},
 			},
+		},
+		Summary: &SyncSummary{
+			Resources: 1,	
+		},
+	},
+	{
+		Table: testTableResolverPanic(),
+		Resources: nil,
+		Summary: &SyncSummary{
+			Panics: 1,
+		},
+	},
+	{
+		Table: testPreResourceResolverPanic(),
+		Resources: []*Resource{},
+		Summary: &SyncSummary{
+			Panics: 1,
+		},
+	},
+	{
+		Table: testColumnResolverPanic(),
+		Resources: []*Resource{},
+		Summary: &SyncSummary{
+			Panics: 1,
+		},
+	},
+	{
+		Table: testTableRelationSuccess(),
+		Resources: []*Resource{
+			{
+				Data: map[string]interface{}{
+					"test": 1,
+				},
+			},
+			{
+				Data: map[string]interface{}{
+					"test": 1,
+				},
+			},
+		},
+		Summary: &SyncSummary{
+			Resources: 2,
+		},
+	},
+	{
+		Table: testTableRelationPanic(),
+		Resources: []*Resource{
+			{
+				Data: map[string]interface{}{
+					"test": 1,
+				},
+			},
+		},
+		Summary: &SyncSummary{
+			Panics: 1,
+			Resources: 1,
 		},
 	},
 }
@@ -56,17 +214,32 @@ func TestTableExecution(t *testing.T) {
 		t.Run(tc.Table.Name, func(t *testing.T) {
 			m := testClient{}
 			resources := make(chan *Resource)
+			summary := SyncSummary{}
 			go func() {
 				defer close(resources)
-				tc.Table.Resolve(ctx, m, nil, resources)
+				summary = tc.Table.Resolve(ctx, m, nil, resources)
 			}()
-			var i = 0
+			var i = uint64(0)
 			for resource := range resources {
 				if reflect.DeepEqual(resource.Data, tc.Resources[i].Data) {
 					t.Errorf("expected %v, got %v", tc.Resources[i].Data, resource)
 				}
 				i++
 			}
+			if tc.Summary.Resources != i {
+				t.Errorf("expected %d resources, got %d", tc.Summary.Resources, i)
+			}
+			if tc.Summary.Resources != summary.Resources {
+				t.Errorf("expected %d summary resources, got %d", tc.Summary.Resources, summary.Resources)
+			}
+			if tc.Summary.Errors != summary.Errors {
+				t.Errorf("expected %d errors, got %d", tc.Summary.Errors, summary.Errors)
+			}
+			if tc.Summary.Panics != summary.Panics {
+				t.Errorf("expected %d panics, got %d", tc.Summary.Panics, summary.Panics)
+			}
+
 		})
 	}
 }
+

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -214,7 +214,7 @@ func TestTableExecution(t *testing.T) {
 		t.Run(tc.Table.Name, func(t *testing.T) {
 			m := testClient{}
 			resources := make(chan *Resource)
-			var summary *SyncSummary
+			var summary SyncSummary
 			go func() {
 				defer close(resources)
 				summary = tc.Table.Resolve(ctx, m, nil, resources)


### PR DESCRIPTION
This also adds quite needed tests for our scheduler


