### PR TITLE
chore(ci): Trigger renovate after SDK release

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,3 +31,15 @@ jobs:
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
         with:
           prerelease: true
+      - name: Trigger Renovate
+        uses: actions/github-script@v6
+        if: steps.release.outputs.release_created && steps.semver_parser.outputs.prerelease == ''
+        with:
+          github-token: ${{ secrets.GH_CQ_BOT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'cloudquery',
+              repo: '.github',
+              workflow_id: 'renovate.yml',
+              ref: 'main',
+            })


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

This is a small optimization to how we do SDK updates in the monorepo. At the moment renovate runs every 15 minutes to handle dependencies updates. We run it every 15 minutes to ensure speedy updates to the SDK.
With this PR we'll run it immediately after the SDK has been released.
This should also allow us to save some build minuted by reducing the renovate schedule to 1 hour for example

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
