### PR TITLE
fix: Make concurrency change backwards-compatible

### DIFF
--- a/specs/source.go
+++ b/specs/source.go
@@ -26,6 +26,7 @@ type Source struct {
 	Path string `json:"path,omitempty"`
 	// Registry can be github,local,grpc.
 	Registry            Registry `json:"registry,omitempty"`
+	Concurrency         uint64   `json:"concurrency,omitempty"` // deprecated: use TableConcurrency and ResourceConcurrency instead
 	TableConcurrency    uint64   `json:"table_concurrency,omitempty"`
 	ResourceConcurrency uint64   `json:"resource_concurrency,omitempty"`
 	// Tables to sync from the source plugin
@@ -53,6 +54,12 @@ func (s *Source) SetDefaults() {
 		s.Tables = []string{"*"}
 	}
 
+	if s.Concurrency != 0 {
+		// attempt to make a sensible backwards-compatible choice, but the CLI
+		// should raise a warning about this until concurrency is fully removed.
+		s.TableConcurrency = s.Concurrency
+		s.ResourceConcurrency = s.Concurrency
+	}
 	if s.TableConcurrency == 0 {
 		s.TableConcurrency = defaultTableConcurrency
 	}

--- a/specs/source.go
+++ b/specs/source.go
@@ -54,9 +54,9 @@ func (s *Source) SetDefaults() {
 		s.Tables = []string{"*"}
 	}
 
-	if s.Concurrency != 0 {
+	if s.Concurrency != 0 && s.TableConcurrency == 0 && s.ResourceConcurrency == 0 {
 		// attempt to make a sensible backwards-compatible choice, but the CLI
-		// should raise a warning about this until concurrency is fully removed.
+		// should raise a warning about this until the `concurrency` option is fully removed.
 		s.TableConcurrency = s.Concurrency
 		s.ResourceConcurrency = s.Concurrency
 	}


### PR DESCRIPTION
This makes https://github.com/cloudquery/plugin-sdk/pull/268 backwards-compatible with prior versions, as support for `concurrency` is retained for now.