### PR TITLE
fix: Ignore sentry in development, case-insensitive for source plugins

### DIFF
--- a/serve/destination.go
+++ b/serve/destination.go
@@ -99,7 +99,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 			})
 			version := destination.plugin.Version()
 
-			if destination.sentryDSN != "" && version != "development" {
+			if destination.sentryDSN != "" && !strings.EqualFold(version, "development") {
 				err = sentry.Init(sentry.ClientOptions{
 					Dsn:              destination.sentryDSN,
 					Debug:            false,

--- a/serve/source.go
+++ b/serve/source.go
@@ -101,7 +101,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 			})
 			version := source.plugin.Version()
 
-			if source.sentryDSN != "" && version != "development" {
+			if source.sentryDSN != "" && strings.EqualFold(version, "development") {
 				err = sentry.Init(sentry.ClientOptions{
 					Dsn:              source.sentryDSN,
 					Debug:            false,


### PR DESCRIPTION
Same as https://github.com/cloudquery/plugin-sdk/pull/273 but for source plugins