### PR TITLE
fix: Remove DisallowUnknownFields from Source plugin server

### DIFF
--- a/internal/servers/source.go
+++ b/internal/servers/source.go
@@ -61,7 +61,7 @@ func (s *SourceServer) Sync(req *pb.Sync_Request, stream pb.Source_SyncServer) e
 	var spec specs.Source
 	dec := json.NewDecoder(bytes.NewReader(req.Spec))
 	dec.UseNumber()
-	dec.DisallowUnknownFields()
+	// TODO: warn about unknown fields
 	if err := dec.Decode(&spec); err != nil {
 		return status.Errorf(codes.InvalidArgument, "failed to decode spec: %v", err)
 	}


### PR DESCRIPTION
See https://github.com/cloudquery/cloudquery/issues/2612 for an explanation.

Notes:
 - We weren't using `DisallowUnknownFields` on the destination plugin side
 - We don't currently have a mechanism to warn about unknown fields, but we are working on it https://github.com/cloudquery/plugin-sdk/pull/272
 - This will unfortunately not fix plugins that have already been released. Our next CLI release that adds new fields will have to be breaking, but after that they can be backwards-compatible.