### PR TITLE
fix: Call Release on resource semaphore

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -207,6 +207,7 @@ func (t *Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, 
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					defer resourcesSem.Release(1)
 					//nolint:all
 					summary.Merge(t.resolveObject(ctx, meta, parent, objects[i], resolvedResources))
 				}()

--- a/schema/table.go
+++ b/schema/table.go
@@ -206,8 +206,8 @@ func (t *Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, 
 				}
 				wg.Add(1)
 				go func() {
-					defer wg.Done()
 					defer resourcesSem.Release(1)
+					defer wg.Done()
 					//nolint:all
 					summary.Merge(t.resolveObject(ctx, meta, parent, objects[i], resolvedResources))
 				}()


### PR DESCRIPTION
We were missing a `Release` call on the `resource_concurrency` semaphore.