### PR TITLE
feat: Add links to tables in table README.md, and list of relations

### DIFF
--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
@@ -1,5 +1,5 @@
 # Source Plugin: test
 ## Tables
-| Name          | Description   |
-| ------------- | ------------- |
-|test_table|Description for test table|
+| Name          | Relations | Description   |
+| ------------- | --------- | ------------- |
+| [test_table](test_table.md)| [relation_table](relation_table.md)<br />[relation_table2](relation_table2.md)| Description for test table|

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
@@ -7,6 +7,7 @@ The composite primary key for this table is (**id_col**, **id_col2**).
 ## Relations
 The following tables depend on `test_table`:
   - [`relation_table`](relation_table.md)
+  - [`relation_table2`](relation_table2.md)
 
 ## Columns
 | Name          | Type          |

--- a/plugins/source_docs_test.go
+++ b/plugins/source_docs_test.go
@@ -41,6 +41,16 @@ var testTables = []*schema.Table{
 					},
 				},
 			},
+			{
+				Name:        "relation_table2",
+				Description: "Description for second relational table",
+				Columns: []schema.Column{
+					{
+						Name: "string_col",
+						Type: schema.TypeString,
+					},
+				},
+			},
 		},
 	},
 }

--- a/plugins/templates/all_tables.go.tpl
+++ b/plugins/templates/all_tables.go.tpl
@@ -1,7 +1,7 @@
 # Source Plugin: {{.Name}}
 ## Tables
-| Name          | Description   |
-| ------------- | ------------- |
+| Name          | Relations | Description   |
+| ------------- | --------- | ------------- |
 {{- range $table := $.Tables }}
-|{{$table.Name}}|{{$table.Description }}|
+| [{{$table.Name}}]({{$table.Name}}.md)| {{range $index, $rel := $table.Relations}}{{if $index}}<br />{{end}}[{{$rel.Name}}]({{$rel.Name}}.md){{end}}| {{$table.Description }}|
 {{- end }}


### PR DESCRIPTION
This updates the README for table docs in two ways:
 - links to the table (right now when you land on [this page](https://github.com/cloudquery/cloudquery/blob/main/plugins/source/aws/docs/tables/README.md) for example, there's no indication that there is actually more information)
 - adds information about relations, if any

I'm happy to take suggestions about how to better present these; I just think it's important we improve the discoverability a little bit now and keep making incremental improvements afterwards.