### PR TITLE
fix: Use 'source' in error message instead of 'destination'

### DIFF
--- a/clients/source.go
+++ b/clients/source.go
@@ -113,7 +113,7 @@ func NewSourceClient(ctx context.Context, registry specs.Registry, path string, 
 	if protocolVersion < versions.SourceProtocolVersion {
 		return nil, fmt.Errorf("source plugin protocol version %d is lower than client version %d. Try updating client", protocolVersion, versions.SourceProtocolVersion)
 	} else if protocolVersion > versions.SourceProtocolVersion {
-		return nil, fmt.Errorf("source plugin protocol version %d is higher than client version %d. Try updating destination plugin", protocolVersion, versions.SourceProtocolVersion)
+		return nil, fmt.Errorf("source plugin protocol version %d is higher than client version %d. Try updating source plugin", protocolVersion, versions.SourceProtocolVersion)
 	}
 
 	return c, nil


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Follow up to https://github.com/cloudquery/plugin-sdk/pull/294

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
