### PR TITLE
fix: Remove descriptions from table docs

### DIFF
--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-README.md
@@ -1,5 +1,7 @@
 # Source Plugin: test
 ## Tables
-| Name          | Relations | Description   |
-| ------------- | --------- | ------------- |
-| [test_table](test_table.md)| [relation_table](relation_table.md)<br />[relation_table2](relation_table2.md)| Description for test table|
+| Name          |
+| ------------- |
+| [test_table](test_table.md) |
+| ↳ [relation_table](relation_table.md) |
+| ↳ [relation_table2](relation_table2.md) |

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-relation_table.md
@@ -5,7 +5,7 @@ Description for relational table
 The primary key for this table is **_cq_id**.
 
 ## Relations
-This table depends on [`test_table`](test_table.md).
+This table depends on [test_table](test_table.md).
 
 ## Columns
 | Name          | Type          |

--- a/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
+++ b/plugins/.snapshots/TestGenerateSourcePluginDocs-test_table.md
@@ -5,9 +5,9 @@ Description for test table
 The composite primary key for this table is (**id_col**, **id_col2**).
 
 ## Relations
-The following tables depend on `test_table`:
-  - [`relation_table`](relation_table.md)
-  - [`relation_table2`](relation_table2.md)
+The following tables depend on test_table:
+  - [relation_table](relation_table.md)
+  - [relation_table2](relation_table2.md)
 
 ## Columns
 | Name          | Type          |

--- a/plugins/templates/all_tables.go.tpl
+++ b/plugins/templates/all_tables.go.tpl
@@ -1,7 +1,10 @@
 # Source Plugin: {{.Name}}
 ## Tables
-| Name          | Relations | Description   |
-| ------------- | --------- | ------------- |
+| Name          |
+| ------------- |
 {{- range $table := $.Tables }}
-| [{{$table.Name}}]({{$table.Name}}.md)| {{range $index, $rel := $table.Relations}}{{if $index}}<br />{{end}}[{{$rel.Name}}]({{$rel.Name}}.md){{end}}| {{$table.Description }}|
+| [{{$table.Name}}]({{$table.Name}}.md) |
+{{- range $index, $rel := $table.Relations}}
+| ↳ [{{$rel.Name}}]({{$rel.Name}}.md) |
+{{- end}}
 {{- end }}

--- a/plugins/templates/table.go.tpl
+++ b/plugins/templates/table.go.tpl
@@ -15,13 +15,13 @@ The composite primary key for this table is ({{ range $index, $pk := $.PrimaryKe
 ## Relations
 {{- end }}
 {{- if $.Parent }}
-This table depends on [`{{ $.Parent.Name }}`]({{ $.Parent.Name }}.md).
+This table depends on [{{ $.Parent.Name }}]({{ $.Parent.Name }}.md).
 {{- end}}
 
 {{- if $.Relations }}
-The following tables depend on `{{.Name}}`:
+The following tables depend on {{.Name}}:
 {{- range $rel := $.Relations }}
-  - [`{{ $rel.Name }}`]({{ $rel.Name }}.md)
+  - [{{ $rel.Name }}]({{ $rel.Name }}.md)
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Descriptions are too detailed for the summary table, and are removed in this PR. 

I'm also changing the format of the table a little bit: instead of having child tables in a separate column, I'm experimenting with having them in their own rows but indicated as a child table with an arrow. Not sure this will be the final version, but I think it looks a bit better than what we had before.