### PR TITLE
feat: Validate source plugin table and column names

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -82,8 +82,12 @@ func (p *SourcePlugin) validate() error {
 		return fmt.Errorf("found duplicate tables in source plugin: %s: %w", p.name, err)
 	}
 
-	if err := p.tables.ValidateNames(); err != nil {
+	if err := p.tables.ValidateTableNames(); err != nil {
 		return fmt.Errorf("found table with invalid name in source plugin: %s: %w", p.name, err)
+	}
+
+	if err := p.tables.ValidateColumnNames(); err != nil {
+		return fmt.Errorf("found column with invalid name in source plugin: %s: %w", p.name, err)
 	}
 
 	return nil

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -82,6 +82,10 @@ func (p *SourcePlugin) validate() error {
 		return fmt.Errorf("found duplicate tables in source plugin: %s: %w", p.name, err)
 	}
 
+	if err := p.tables.ValidateNames(); err != nil {
+		return fmt.Errorf("found table with invalid name in source plugin: %s: %w", p.name, err)
+	}
+
 	return nil
 }
 

--- a/plugins/source_test.go
+++ b/plugins/source_test.go
@@ -19,7 +19,7 @@ var _ schema.ClientMeta = &testExecutionClient{}
 
 func testTable() *schema.Table {
 	return &schema.Table{
-		Name: "testTable",
+		Name: "test_table",
 		Resolver: func(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
 			res <- map[string]interface{}{
 				"TestColumn": 3,
@@ -71,7 +71,7 @@ func TestSync(t *testing.T) {
 	})
 
 	for resource := range resources {
-		if resource.Table.Name != "testTable" {
+		if resource.Table.Name != "test_table" {
 			t.Fatalf("unexpected resource table name: %s", resource.Table.Name)
 		}
 		obj := resource.Get("test_column")

--- a/schema/resolvers_test.go
+++ b/schema/resolvers_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var resolverTestTable = &Table{
-	Name: "testTable",
+	Name: "test_table",
 	Columns: []Column{
 		{
 			Name: "string_column",

--- a/schema/table.go
+++ b/schema/table.go
@@ -68,6 +68,7 @@ type Table struct {
 }
 
 var reValidTableName = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
+var reValidColumnName = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
 
 func (s *SyncSummary) Merge(other SyncSummary) {
 	atomic.AddUint64(&s.Resources, other.Resources)
@@ -83,9 +84,18 @@ func (tt Tables) TableNames() []string {
 	return ret
 }
 
-func (tt Tables) ValidateNames() error {
+func (tt Tables) ValidateTableNames() error {
 	for _, t := range tt {
 		if err := t.ValidateName(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tt Tables) ValidateColumnNames() error {
+	for _, t := range tt {
+		if err := t.ValidateColumnNames(); err != nil {
 			return err
 		}
 	}
@@ -131,6 +141,16 @@ func (t *Table) ValidateDuplicateColumns() error {
 	for _, rel := range t.Relations {
 		if err := rel.ValidateDuplicateColumns(); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (t *Table) ValidateColumnNames() error {
+	for _, c := range t.Columns {
+		ok := reValidColumnName.MatchString(c.Name)
+		if !ok {
+			return fmt.Errorf("column name %q on table %q is not valid: column names must contain only lower-case letters, numbers and underscores, and must start with a lower-case letter or underscore", c.Name, t.Name)
 		}
 	}
 	return nil

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -258,7 +258,8 @@ func TestTable_ValidateName(t *testing.T) {
 		{Give: "table123", WantError: false},
 		{Give: "table123_v2", WantError: false},
 		{Give: "table_name", WantError: false},
-		{Give: "Table_name_with_underscore", WantError: true},
+		{Give: "table_name_with_underscore", WantError: false},
+		{Give: "TableNameWithUpperCase", WantError: true},
 		{Give: "table name with spaces", WantError: true},
 		{Give: "table-with-dashes", WantError: true},
 	}
@@ -269,6 +270,42 @@ func TestTable_ValidateName(t *testing.T) {
 		gotError := err != nil
 		if gotError != tc.WantError {
 			t.Errorf("ValidateName() for table %q returned error, but expected none", tc.Give)
+		}
+	}
+}
+
+func TestTable_ValidateColumnNames(t *testing.T) {
+	cases := []struct {
+		GiveColumns []string
+		WantError   bool
+	}{
+		{GiveColumns: []string{"ok", "a"}, WantError: false},
+		{GiveColumns: []string{"ok", "_"}, WantError: false},
+		{GiveColumns: []string{"ok", "_abc"}, WantError: false},
+		{GiveColumns: []string{"ok", "_123"}, WantError: false},
+		{GiveColumns: []string{"ok", "123"}, WantError: true},
+		{GiveColumns: []string{"ok", "123abc"}, WantError: true},
+		{GiveColumns: []string{"ok", "123_abc"}, WantError: true},
+		{GiveColumns: []string{"ok", "col_123"}, WantError: false},
+		{GiveColumns: []string{"ok", "col123"}, WantError: false},
+		{GiveColumns: []string{"ok", "col123_v2"}, WantError: false},
+		{GiveColumns: []string{"ok", "col_name"}, WantError: false},
+		{GiveColumns: []string{"ok", "column_name_with_underscore"}, WantError: false},
+		{GiveColumns: []string{"ok", "columnNameWithUpperCase"}, WantError: true},
+		{GiveColumns: []string{"ok", "table name with spaces"}, WantError: true},
+		{GiveColumns: []string{"ok", "table-with-dashes"}, WantError: true},
+	}
+
+	for _, tc := range cases {
+		cols := make([]Column, 0)
+		for _, name := range tc.GiveColumns {
+			cols = append(cols, Column{Name: name})
+		}
+		table := Table{Name: "table", Columns: cols}
+		err := table.ValidateColumnNames()
+		gotError := err != nil
+		if gotError != tc.WantError {
+			t.Errorf("ValidateColumnNames() for columns %q returned error, but expected none", tc.GiveColumns)
 		}
 	}
 }

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -241,3 +241,34 @@ func TestTableExecution(t *testing.T) {
 		})
 	}
 }
+
+func TestTable_ValidateName(t *testing.T) {
+	cases := []struct {
+		Give      string
+		WantError bool
+	}{
+		{Give: "a", WantError: false},
+		{Give: "_", WantError: false},
+		{Give: "_abc", WantError: false},
+		{Give: "_123", WantError: false},
+		{Give: "123", WantError: true},
+		{Give: "123abc", WantError: true},
+		{Give: "123_abc", WantError: true},
+		{Give: "table_123", WantError: false},
+		{Give: "table123", WantError: false},
+		{Give: "table123_v2", WantError: false},
+		{Give: "table_name", WantError: false},
+		{Give: "Table_name_with_underscore", WantError: true},
+		{Give: "table name with spaces", WantError: true},
+		{Give: "table-with-dashes", WantError: true},
+	}
+
+	for _, tc := range cases {
+		table := Table{Name: tc.Give}
+		err := table.ValidateName()
+		gotError := err != nil
+		if gotError != tc.WantError {
+			t.Errorf("ValidateName() for table %q returned error, but expected none", tc.Give)
+		}
+	}
+}


### PR DESCRIPTION
This sets expectations for table and column names (currently enforced only through convention) that ensure we don't accidentally add resources with invalid table or column names.

Closes https://github.com/cloudquery/plugin-sdk/issues/255