### PR TITLE
fix: Set Sentry server name to empty to avoid sending it

### DIFF
--- a/serve/destination.go
+++ b/serve/destination.go
@@ -105,7 +105,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
-					ServerName:       "", // left empty on purpose to avoid sending any identifying information
+					ServerName:       "-", // left empty on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration

--- a/serve/destination.go
+++ b/serve/destination.go
@@ -105,6 +105,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
+					ServerName:       "", // left empty on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration

--- a/serve/destination.go
+++ b/serve/destination.go
@@ -105,7 +105,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
-					ServerName:       "-", // left empty on purpose to avoid sending any identifying information
+					ServerName:       "oss", // set to "oss" on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration

--- a/serve/source.go
+++ b/serve/source.go
@@ -107,6 +107,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
+					ServerName:       "", // left empty on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration

--- a/serve/source.go
+++ b/serve/source.go
@@ -107,7 +107,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
-					ServerName:       "", // left empty on purpose to avoid sending any identifying information
+					ServerName:       "-", // left empty on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration

--- a/serve/source.go
+++ b/serve/source.go
@@ -107,7 +107,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: true,
 					Release:          version,
-					ServerName:       "-", // left empty on purpose to avoid sending any identifying information
+					ServerName:       "oss", // set to "oss" on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {
 						var filteredIntegrations []sentry.Integration


### PR DESCRIPTION
Sentry [does not consider server name PII](https://forum.sentry.io/t/sentry-python-sdk-dont-send-server-name/5815/2), as it's not a unique identifier, but we'd rather have our data be fully anonymous.