### PR TITLE
fix: Silence error log when plugin exits

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -137,7 +137,8 @@ func (c *DestinationClient) newManagedClient(ctx context.Context, path string) e
 		defer c.wg.Done()
 		if err := cmd.Wait(); err != nil {
 			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
-				// process killed by our own signal, this is expected
+				// process interrupted by our own signal, this is expected
+				c.logger.Info().Str("plugin", path).Msg("plugin exited")
 				return
 			}
 			c.cmdWaitErr = err

--- a/clients/destination.go
+++ b/clients/destination.go
@@ -136,7 +136,7 @@ func (c *DestinationClient) newManagedClient(ctx context.Context, path string) e
 		defer c.wg.Done()
 		if err := cmd.Wait(); err != nil {
 			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
-				// process interrupted by our own signal, this is expected
+				// process interrupted by a signal, this is expected
 				c.logger.Info().Str("plugin", path).Msg("plugin exited")
 				return
 			}

--- a/clients/destination.go
+++ b/clients/destination.go
@@ -31,6 +31,7 @@ type DestinationClient struct {
 	pbClient       pb.DestinationClient
 	directory      string
 	cmd            *exec.Cmd
+	commandExited  chan bool
 	logger         zerolog.Logger
 	userConn       *grpc.ClientConn
 	conn           *grpc.ClientConn
@@ -133,9 +134,11 @@ func (c *DestinationClient) newManagedClient(ctx context.Context, path string) e
 	}
 
 	c.wg.Add(1)
+	c.commandExited = make(chan bool)
 	go func() {
 		defer c.wg.Done()
 		if err := cmd.Wait(); err != nil {
+			c.commandExited <- true
 			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
 				// process interrupted by our own signal, this is expected
 				c.logger.Info().Str("plugin", path).Msg("plugin exited")
@@ -179,8 +182,8 @@ func (c *DestinationClient) newManagedClient(ctx context.Context, path string) e
 	}
 	c.conn, err = grpc.DialContext(ctx, c.grpcSocketName, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), grpc.WithContextDialer(dialer))
 	if err != nil {
-		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			c.logger.Error().Err(err).Msg("failed to stop plugin process")
+		if err := cmd.Process.Kill(); err != nil {
+			c.logger.Error().Err(err).Msg("failed to kill plugin process")
 		}
 		return err
 	}
@@ -310,8 +313,20 @@ func (c *DestinationClient) Terminate() error {
 	}
 	if c.cmd != nil && c.cmd.Process != nil {
 		if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			c.logger.Error().Err(err).Msg("failed to stop process")
+			c.logger.Error().Err(err).Msg("failed to stop plugin process")
 			return err
+		}
+
+		// check that plugin has exited after 5 seconds, otherwise kill it
+		timeout := time.After(5 * time.Second)
+		select {
+		case <-c.commandExited:
+			break
+		case <-timeout:
+			c.logger.Error().Msg("killing plugin process after timeout")
+			if err := c.cmd.Process.Kill(); err != nil {
+				c.logger.Error().Err(err).Msg("failed to kill plugin process")
+			}
 		}
 	}
 

--- a/clients/source.go
+++ b/clients/source.go
@@ -141,7 +141,8 @@ func (c *SourceClient) newManagedClient(ctx context.Context, path string) error 
 		defer c.wg.Done()
 		if err := cmd.Wait(); err != nil {
 			if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == -1 {
-				// process killed by our own signal, this is expected
+				// process interrupted by our own signal, this is expected
+				c.logger.Info().Str("plugin", path).Msg("plugin exited")
 				return
 			}
 			c.cmdWaitErr = err


### PR DESCRIPTION
Right now, whenever a plugin gets interrupted by our own signal, an error is logged, even though this is expected to happen under normal circumstances.

This change checks the exit code of the plugin: if it's -1, this indicates the process was interrupted. This is expected, and then we only log an info line.

I'm not sure whether this will work on Windows systems. If not, the behavior there will be the same as before, so then this would only be an improvement for Unix systems (but I haven't tested on Windows). I played around with using sigterm as a nicer way to stop plugins, but realized that likely also [won't work on Windows](https://github.com/golang/go/issues/46345)
