### PR TITLE
fix: Increment tableResources

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -234,6 +234,7 @@ func (t *Table) Resolve(ctx context.Context, meta ClientMeta, parent *Resource, 
 			continue
 		}
 		for i := range objects {
+			tableResources++
 			i := i
 
 			// right now we support concurrency only for objects/resources of parent tables


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Fixes https://github.com/cloudquery/cloudquery/issues/3201.

The increment was removed in https://github.com/cloudquery/plugin-sdk/pull/224/files#diff-abecd8d935ca8952a3554e15fa6989972dd0cea6de3410b6541931883b0d6d84R219.

I tried to think of a way to use the `summary` to get each table resources, but it will require some refactoring, as each table's summary is merged with its children so we can't use `summary.Resources` to get a table resources (it contains all nested tables too).

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
