### PR TITLE
fix: Check for missing parent tables

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -134,8 +134,8 @@ func filterParentTables(tables schema.Tables, filter []string) schema.Tables {
 		return tables
 	}
 	for _, name := range filter {
-		if tables.Get(name) != nil {
-			res = append(res, tables.Get(name))
+		if t := tables.Get(name); t != nil {
+			res = append(res, t)
 		}
 	}
 	return res

--- a/plugins/source_validate.go
+++ b/plugins/source_validate.go
@@ -83,13 +83,9 @@ func (p *SourcePlugin) listAndValidateTables(tables, skipTables []string) ([]str
 		selectedTables[t] = true
 	}
 	for _, t := range tables {
-		for _, tt := range p.tables {
-			if tt.Name != t {
-				continue
-			}
-			if tt.Parent != nil && !selectedTables[tt.Parent.Name] {
-				return nil, fmt.Errorf("table %s is a child table, and requires its parent table %s to also be synced", t, tt.Parent.Name)
-			}
+		tt := p.tables.Get(t)
+		if tt.Parent != nil && !selectedTables[tt.Parent.Name] {
+			return nil, fmt.Errorf("table %s is a child table, and requires its parent table %s to also be synced", t, tt.Parent.Name)
 		}
 	}
 

--- a/plugins/source_validate_test.go
+++ b/plugins/source_validate_test.go
@@ -83,12 +83,6 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 			configurationTables: []string{"sub_table"},
 			wantErr:             true,
 		},
-		{
-			name:                "should return both tables if both child and parent are specified",
-			plugin:              SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}}}}}},
-			configurationTables: []string{"main_table", "sub_table"},
-			want:                []string{"main_table", "sub_table"},
-		},
 	}
 
 	for _, tt := range tests {

--- a/plugins/source_validate_test.go
+++ b/plugins/source_validate_test.go
@@ -79,9 +79,15 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 		},
 		{
 			name:                "should return an error if child table is without its parent",
-			plugin:              SourcePlugin{tables: []*schema.Table{{Name: "table 1", Parent: &schema.Table{Name: "table 2"}}, {Name: "table 2"}}},
-			configurationTables: []string{"table 1"},
+			plugin:              SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}}}}}},
+			configurationTables: []string{"sub_table"},
 			wantErr:             true,
+		},
+		{
+			name:                "should return both tables if both child and parent are specified",
+			plugin:              SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}}}}}},
+			configurationTables: []string{"main_table", "sub_table"},
+			want:                []string{"main_table", "sub_table"},
 		},
 	}
 
@@ -89,11 +95,11 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.plugin.listAndValidateTables(tt.configurationTables, tt.configurationSkipTables)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SourcePlugin.interpolateAllResources() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("SourcePlugin.listAndValidateTables() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SourcePlugin.interpolateAllResources() = %v, want %v", got, tt.want)
+				t.Errorf("SourcePlugin.listAndValidateTables() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Previously this didn't work because `p.tables` does not contain child tables.