### PR TITLE
fix: Dont use reflection in reverse transformer

### DIFF
--- a/plugins/destination_reverse_transformer.go
+++ b/plugins/destination_reverse_transformer.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"fmt"
 
-	"github.com/cloudquery/plugin-sdk/helpers"
 	"github.com/cloudquery/plugin-sdk/schema"
 )
 
@@ -13,10 +12,9 @@ type DefaultReverseTransformer struct {
 // DefaultReverseTransformer tries best effort to convert a slice of values to CQTypes
 // based on the provided table columns.
 func (*DefaultReverseTransformer) ReverseTransformValues(table *schema.Table, values []interface{}) (schema.CQTypes, error) {
-	valuesSlice := helpers.InterfaceSlice(values)
-	res := make(schema.CQTypes, len(valuesSlice))
+	res := make(schema.CQTypes, len(values))
 
-	for i, v := range valuesSlice {
+	for i, v := range values {
 		t := schema.NewCqTypeFromValueType(table.Columns[i].Type)
 		if err := t.Set(v); err != nil {
 			return nil, fmt.Errorf("failed to convert value %v to type %s: %w", v, table.Columns[i].Type, err)


### PR DESCRIPTION
There is no need for reflection in reverse transformer as it's already an array.