### PR TITLE
fix: Make path a required config parameter

### DIFF
--- a/plugins/source_test.go
+++ b/plugins/source_test.go
@@ -257,6 +257,7 @@ func testSyncTable(t *testing.T, tc syncTestCase) {
 	plugin.SetLogger(zerolog.New(zerolog.NewTestWriter(t)))
 	spec := specs.Source{
 		Name:         "testSource",
+		Path:         "cloudquery/testSource",
 		Tables:       []string{"*"},
 		Version:      "v1.0.0",
 		Destinations: []string{"test"},

--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -143,6 +143,7 @@ func TestServeSource(t *testing.T) {
 		specs.Source{
 			Name:         "testSourcePlugin",
 			Version:      "v1.0.0",
+			Path:         "cloudquery/testSourcePlugin",
 			Registry:     specs.RegistryGithub,
 			Tables:       []string{"*"},
 			Spec:         TestSourcePluginSpec{Accounts: []string{"cloudquery/plugin-sdk"}},

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -118,6 +118,7 @@ spec:`,
 		`kind: destination
 spec:
   name: test
+  path: cloudquery/test
 `,
 		"version is required",
 		nil,
@@ -127,6 +128,7 @@ spec:
 		`kind: destination
 spec:
   name: test
+  path: cloudquery/test
   version: 1.1.0
 `,
 		"version must start with v",
@@ -167,6 +169,7 @@ spec:
 		`kind: destination
 spec:
   name: test
+  path: cloudquery/test
   version: v1.1.0
 `,
 		"",

--- a/specs/source_test.go
+++ b/specs/source_test.go
@@ -79,10 +79,20 @@ spec:`,
 		nil,
 	},
 	{
+		"required_path",
+		`kind: source
+spec:
+  name: test
+`,
+		"path is required",
+		nil,
+	},
+	{
 		"required_version",
 		`kind: source
 spec:
   name: test
+  path: cloudquery/test
 `,
 		"version is required",
 		nil,
@@ -92,6 +102,7 @@ spec:
 		`kind: source
 spec:
   name: test
+  path: cloudquery/test
   version: 1.1.0
 `,
 		"version must start with v",
@@ -102,6 +113,7 @@ spec:
 		`kind: source
 spec:
   name: test
+  path: cloudquery/test
   version: v1.1.0
 `,
 		"at least one destination is required",
@@ -112,6 +124,7 @@ spec:
 		`kind: source
 spec:
   name: test
+  path: cloudquery/test
   version: v1.1.0
   destinations: ["test"]
 `,

--- a/specs/testdata/multiple_sources.yml
+++ b/specs/testdata/multiple_sources.yml
@@ -15,6 +15,7 @@ spec:
 kind: destination
 spec:
   name: postgresql
+  path: cloudquery/postgresql
   version: v1.6.3
   spec:
     connection_string: postgresql://postgres:pass@localhost:5432/postgres


### PR DESCRIPTION
This updates (and replaces) this earlier PR for making `path` a required config parameter: https://github.com/cloudquery/plugin-sdk/pull/265

We have received numerous user reports of the distinction between name and path being confusing, so rather than infer path from name in some circumstances (and not in some others), this change makes things consistent by always requiring both. I've also added a small hint for users running into this error when upgrading from earlier versions.

We will not consider this a breaking SDK change, as it doesn't change any protocols, but it will be a breaking CLI change.

- relates to https://github.com/cloudquery/plugin-sdk/issues/317 
- closes https://github.com/cloudquery/plugin-sdk/issues/256 