### PR TITLE
fix(faker): Use `MarshalText` for faker timestamps

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -46,7 +46,8 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 		switch t.String() {
 		case "time.Time":
 			ft := time.Now().Add(time.Duration(rand.Int63()))
-			return reflect.ValueOf(ft), nil
+			ftBytes, _ := ft.MarshalText()
+			return reflect.ValueOf(string(ftBytes)), nil
 		default:
 			v := reflect.New(t).Elem()
 			for i := 0; i < v.NumField(); i++ {

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -37,17 +36,5 @@ func TestTimestamptzSet(t *testing.T) {
 		err := r.Set(tt.source)
 		require.NoError(t, err)
 		require.Equal(t, tt.result, r)
-	}
-}
-
-func TestTimestamptzSetString(t *testing.T) {
-	for i := 0; i < 100000; i++ {
-		timeString := time.Now().Add(time.Duration(rand.Int63())).String()
-		_, err := time.Parse(defaultStringFormat, timeString)
-		if err == nil {
-			t.Errorf("time.Parse(%q) should return error", timeString)
-		} else {
-			t.Errorf("time.Parse(%q) should not return error", timeString)
-		}
 	}
 }

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimestamptzSet(t *testing.T) {
@@ -35,8 +35,8 @@ func TestTimestamptzSet(t *testing.T) {
 	for _, tt := range successfulTests {
 		var r Timestamptz
 		err := r.Set(tt.source)
-		assert.NoError(t, err)
-		assert.Equal(t, tt.result, r)
+		require.NoError(t, err)
+		require.Equal(t, tt.result, r)
 	}
 }
 
@@ -44,6 +44,6 @@ func TestTimestamptzSetString(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		timeString := time.Now().Add(time.Duration(rand.Int63())).String()
 		_, err := time.Parse(defaultStringFormat, timeString)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -44,6 +44,10 @@ func TestTimestamptzSetString(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		timeString := time.Now().Add(time.Duration(rand.Int63())).String()
 		_, err := time.Parse(defaultStringFormat, timeString)
-		require.NoError(t, err)
+		if err == nil {
+			t.Errorf("time.Parse(%q) should return error", timeString)
+		} else {
+			t.Errorf("time.Parse(%q) should not return error", timeString)
+		}
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/cloudquery/issues/3627.

**The TLDR** is that we should `MarshalText` when faking time data, as that follows an RFC.

**The DON'T READ part is**:
If we don't do it and default to `String()` that sometimes creates a string that cannot be parsed by `const defaultStringFormat = "2006-01-02 15:04:05.999999999 -0700 MST"`.

You can see an example in https://github.com/cloudquery/cloudquery/issues/3627 that the `2110-10-19 08:53:50.21670207 +0000 UTC m=+2775422040.494306874` string was created.
The reason that the string can't be parsed is because the nano seconds part has 8 digits and not 9, that is `21670207` instead of `216702070`.
The nano seconds string needs to be padded only when adding the `m=+2775422040.494306874` part. This was added in go 1.19 (see https://pkg.go.dev/time#Time.String).
To summarize:
1. `time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2110-10-19 08:53:50.21670207 +0000 UTC")` works
2. `time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2110-10-19 08:53:50.216702070 +0000 UTC  m=+2775422040.494306874")` works
3. `time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2110-10-19 08:53:50.21670207 +0000 UTC  m=+2775422040.494306874")` fails

So technically this could be a bug in go, that needs to pad the nano seconds when adding the `m=+` part, though there is no guarantee on the format of `time.String()`.

I added another test `TestTimestamptzSetString` that shows this behavior. The only way I could find to create a string that has the `m=+` part is using `time.Now()`. It's in the PR to demonstrate the issue and I'll remove it before merging

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
