### PR TITLE
fix: Context cancelled too early for delete stale mode

### DIFF
--- a/clients/destination.go
+++ b/clients/destination.go
@@ -289,7 +289,7 @@ func (c *DestinationClient) Write2(ctx context.Context, tables schema.Tables, so
 		if err := saveClient.Send(&pb.Write2_Request{
 			Resource: resource,
 		}); err != nil {
-			return fmt.Errorf("failed to call Write.Send: %w", err)
+			return fmt.Errorf("failed to call Write2.Send: %w", err)
 		}
 	}
 	_, err = saveClient.CloseAndRecv()
@@ -330,7 +330,7 @@ func (c *DestinationClient) Terminate() error {
 
 	if c.grpcSocketName != "" {
 		defer func() {
-			if err := os.Remove(c.grpcSocketName); err != nil {
+			if err := os.RemoveAll(c.grpcSocketName); err != nil {
 				c.logger.Error().Err(err).Msg("failed to remove destination socket file")
 			}
 		}()

--- a/clients/source.go
+++ b/clients/source.go
@@ -301,7 +301,7 @@ func (c *SourceClient) Terminate() error {
 
 	if c.grpcSocketName != "" {
 		defer func() {
-			if err := os.Remove(c.grpcSocketName); err != nil {
+			if err := os.RemoveAll(c.grpcSocketName); err != nil {
 				c.logger.Error().Err(err).Msg("failed to remove source socket file")
 			}
 		}()

--- a/plugins/destination.go
+++ b/plugins/destination.go
@@ -137,12 +137,12 @@ func (p *DestinationPlugin) Write(ctx context.Context, tables schema.Tables, sou
 	syncTime = syncTime.UTC()
 	SetDestinationManagedCqColumns(tables)
 	ch := make(chan *ClientResource)
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, gctx := errgroup.WithContext(ctx)
 	// given most destination plugins writing in batch we are using a worker pool to write in parallel
 	// it might not generalize well and we might need to move it to each destination plugin implementation.
 	for i := 0; i < writeWorkers; i++ {
 		eg.Go(func() error {
-			return p.client.Write(ctx, tables, ch)
+			return p.client.Write(gctx, tables, ch)
 		})
 	}
 	sourceColumn := &schema.Text{}


### PR DESCRIPTION
This is a fix for this error, encountered when postgresql plugin is run with overwrite-delete-stale mode:

```
Error: failed to write for gcp->postgresql: failed to CloseAndRecv client: rpc error: code = Canceled desc = got EOF. failed to wait for plugin: failed to execute batch: context canceled
2022-11-09T10:11:35Z ERR exiting with error error="failed to write for gcp->postgresql: failed to CloseAndRecv client: rpc error: code = Canceled desc = got EOF. failed to wait for plugin: failed to execute batch: context canceled" module=cli
```

The reason it didn't work before is that the grouperr context gets cancelled as soon as Wait() returns. We should be using the original `ctx` for the subsequent delete stale call.

This also fixes this error:

```
2022-11-09T10:02:22Z ERR failed to remove source socket file error="remove /var/folders/_c/hm9lkvfj7fz_rykn71rmr8gh0000gn/T/cq-WDwWDgDPiakfRkxi.sock: no such file or directory" module=cli
```

by using `os.RemoveAll` so that the file is removed if it is there, or ignored otherwise.