### PR TITLE
fix: Revert "fix(faker): Use `MarshalText` for faker timestamps (#373)"

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -46,8 +46,7 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 		switch t.String() {
 		case "time.Time":
 			ft := time.Now().Add(time.Duration(rand.Int63()))
-			ftBytes, _ := ft.MarshalText()
-			return reflect.ValueOf(string(ftBytes)), nil
+			return reflect.ValueOf(ft), nil
 		default:
 			v := reflect.New(t).Elem()
 			for i := 0; i < v.NumField(); i++ {

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -2,6 +2,7 @@ package faker
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -10,6 +11,7 @@ type testFakerStruct struct {
 	A int
 	B string
 	C *string
+	D time.Time
 	E interface{}
 }
 
@@ -21,6 +23,7 @@ func TestFaker(t *testing.T) {
 	assert.NotEmpty(t, a.A)
 	assert.NotEmpty(t, a.B)
 	assert.NotEmpty(t, a.C)
+	assert.NotEmpty(t, a.D)
 	assert.Empty(t, a.E) // empty interfaces are not faked
 }
 

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -3,15 +3,10 @@ package schema
 import (
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTimestamptzSet(t *testing.T) {
 	type _time time.Time
-
-	timeInstance := time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC)
-	timeRFC3339NanoBytes, _ := timeInstance.MarshalText()
 
 	successfulTests := []struct {
 		source interface{}
@@ -26,15 +21,19 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)), result: Timestamptz{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local), Status: Present}},
 		{source: Infinity, result: Timestamptz{InfinityModifier: Infinity, Status: Present}},
 		{source: NegativeInfinity, result: Timestamptz{InfinityModifier: NegativeInfinity, Status: Present}},
-		{source: string(timeRFC3339NanoBytes), result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
-		{source: "2150-10-15 07:25:09.75007611 +0000 UTC", result: Timestamptz{Time: time.Date(2150, 10, 15, 7, 25, 9, 750076110, time.UTC), Status: Present}},
-		{source: timeInstance.String(), result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
+		{source: "2105-07-23 22:23:37.133334968 +0300 UTC m=+2610529275.484148261", result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 133334968, time.UTC), Status: Present}},
+		// {source: "2020-04-05 06:07:08Z", result: Timestamptz{Time: time.Date(2020, 4, 5, 6, 7, 8, 0, time.UTC), Status: Present}},
 	}
 
-	for _, tt := range successfulTests {
+	for i, tt := range successfulTests {
 		var r Timestamptz
 		err := r.Set(tt.source)
-		require.NoError(t, err)
-		require.Equal(t, tt.result, r)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if !r.Equal(&tt.result) {
+			t.Errorf("%d: %v != %v", i, r, tt.result)
+		}
 	}
 }


### PR DESCRIPTION
This reverts commit a29143861b22432c81cdc8b04650d9d8d0ac9671.

#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Reverts https://github.com/cloudquery/plugin-sdk/issues/373 as I applied that fix in the wrong place. I think the fix should be where we serialize/deserialize `time.time`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
