### PR TITLE
fix: Use MarshalText when serializing timestamps when applicable

### DIFF
--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -2,6 +2,7 @@
 package schema
 
 import (
+	"encoding"
 	"fmt"
 	"time"
 )
@@ -22,10 +23,6 @@ const (
 
 type TimestamptzTransformer interface {
 	TransformTimestamptz(*Timestamptz) interface{}
-}
-
-type TextMarshaler interface {
-	MarshalText() ([]byte, error)
 }
 
 type Timestamptz struct {
@@ -94,7 +91,7 @@ func (dst *Timestamptz) Set(src interface{}) error {
 		if originalSrc, ok := underlyingTimeType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		if value, ok := value.(TextMarshaler); ok {
+		if value, ok := value.(encoding.TextMarshaler); ok {
 			s, err := value.MarshalText()
 			if err == nil {
 				return dst.Set(string(s))

--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -96,6 +96,7 @@ func (dst *Timestamptz) Set(src interface{}) error {
 			if err == nil {
 				return dst.Set(string(s))
 			}
+			// fall through to String() method
 		}
 		if value, ok := value.(fmt.Stringer); ok {
 			s := value.String()

--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -24,6 +24,10 @@ type TimestamptzTransformer interface {
 	TransformTimestamptz(*Timestamptz) interface{}
 }
 
+type TextMarshaler interface {
+	MarshalText() ([]byte, error)
+}
+
 type Timestamptz struct {
 	Time             time.Time
 	Status           Status
@@ -89,6 +93,12 @@ func (dst *Timestamptz) Set(src interface{}) error {
 	default:
 		if originalSrc, ok := underlyingTimeType(src); ok {
 			return dst.Set(originalSrc)
+		}
+		if value, ok := value.(TextMarshaler); ok {
+			s, err := value.MarshalText()
+			if err == nil {
+				return dst.Set(string(s))
+			}
 		}
 		if value, ok := value.(fmt.Stringer); ok {
 			s := value.String()

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -3,8 +3,6 @@ package schema
 import (
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 type Timestamp struct {
@@ -36,10 +34,15 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: Timestamp{timeInstance}, result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
 	}
 
-	for _, tt := range successfulTests {
+	for i, tt := range successfulTests {
 		var r Timestamptz
 		err := r.Set(tt.source)
-		require.NoError(t, err)
-		require.Equal(t, tt.result, r)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if !r.Equal(&tt.result) {
+			t.Errorf("%d: %v != %v", i, r, tt.result)
+		}
 	}
 }

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -3,10 +3,19 @@ package schema
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
+
+type Timestamp struct {
+	time.Time
+}
 
 func TestTimestamptzSet(t *testing.T) {
 	type _time time.Time
+
+	timeInstance := time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC)
+	timeRFC3339NanoBytes, _ := timeInstance.MarshalText()
 
 	successfulTests := []struct {
 		source interface{}
@@ -21,19 +30,16 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: _time(time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)), result: Timestamptz{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local), Status: Present}},
 		{source: Infinity, result: Timestamptz{InfinityModifier: Infinity, Status: Present}},
 		{source: NegativeInfinity, result: Timestamptz{InfinityModifier: NegativeInfinity, Status: Present}},
-		{source: "2105-07-23 22:23:37.133334968 +0300 UTC m=+2610529275.484148261", result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 133334968, time.UTC), Status: Present}},
-		// {source: "2020-04-05 06:07:08Z", result: Timestamptz{Time: time.Date(2020, 4, 5, 6, 7, 8, 0, time.UTC), Status: Present}},
+		{source: string(timeRFC3339NanoBytes), result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
+		{source: "2150-10-15 07:25:09.75007611 +0000 UTC", result: Timestamptz{Time: time.Date(2150, 10, 15, 7, 25, 9, 750076110, time.UTC), Status: Present}},
+		{source: timeInstance.String(), result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
+		{source: Timestamp{timeInstance}, result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
 	}
 
-	for i, tt := range successfulTests {
+	for _, tt := range successfulTests {
 		var r Timestamptz
 		err := r.Set(tt.source)
-		if err != nil {
-			t.Errorf("%d: %v", i, err)
-		}
-
-		if !r.Equal(&tt.result) {
-			t.Errorf("%d: %v != %v", i, r, tt.result)
-		}
+		require.NoError(t, err)
+		require.Equal(t, tt.result, r)
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Proper fix for https://github.com/cloudquery/plugin-sdk/pull/373

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
