### PR TITLE
fix: Pre-aggregate metrics before sending

### DIFF
--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -188,7 +188,7 @@ func TestServeSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientStats := stats.TableClient["test_table"]["testExecutionClient"]
+	clientStats := stats.TableClient[""][""]
 	if clientStats.Resources != 1 {
 		t.Fatalf("Expected 1 resource but got %d", clientStats.Resources)
 	}


### PR DESCRIPTION
This is a short-term fix for https://github.com/cloudquery/cloudquery/issues/3962 while we work on a better solution. It pre-aggregates metric results before sending it from the server, so that only a small map gets sent over the wire. We can do this because we know the CloudQuery CLI right now only makes use of the aggregated data in any case.