### PR TITLE
fix: Allow PreResourceResolver to skip item

### DIFF
--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -163,6 +163,9 @@ func (p *SourcePlugin) resolveResource(ctx context.Context, table *schema.Table,
 			atomic.AddUint64(&tableMetrics.Errors, 1)
 			return nil
 		}
+		if resource.Item == nil {
+			return nil
+		}
 	}
 
 	for _, c := range table.Columns {


### PR DESCRIPTION
Useful for `NotFound` situations where we don't want the resolving to continue down to relations.

This will help fix https://github.com/cloudquery/cloudquery/issues/4374
