### PR TITLE
fix: Change globbing behavior to include descendants by default

### DIFF
--- a/plugins/source_validate.go
+++ b/plugins/source_validate.go
@@ -35,10 +35,11 @@ func (p *SourcePlugin) listAndValidateTables(tables, skipTables []string) (schem
 		return nil, fmt.Errorf("list of tables is empty")
 	}
 
-	// return an error if a table pattern doesn't match any known tables
 	var includedTables schema.Tables
 	for _, t := range tables {
 		tt := p.tables.GlobMatch(t)
+
+		// return an error if a table pattern doesn't match any known tables
 		if len(tt) == 0 {
 			return nil, fmt.Errorf("tables entry matches no known tables: %q", t)
 		}

--- a/plugins/source_validate_test.go
+++ b/plugins/source_validate_test.go
@@ -39,10 +39,28 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 			wantErr:                 true,
 		},
 		{
-			name:                    "should return only the exact set of tables specified",
-			plugin:                  SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}}}}}},
+			name: "should return the parent and all its descendents",
+			plugin: SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{
+				{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}, Relations: []*schema.Table{
+					{Name: "sub_sub_table", Parent: &schema.Table{Name: "sub_table"}},
+				}}}},
+			},
+			},
 			configurationTables:     []string{"main_table"},
 			configurationSkipTables: []string{},
+			want:                    []string{"main_table", "sub_table", "sub_sub_table"},
+			wantErr:                 false,
+		},
+		{
+			name: "should return the parent and all its descendents, but skip children and their descendents if they are skipped",
+			plugin: SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{
+				{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}, Relations: []*schema.Table{
+					{Name: "sub_sub_table", Parent: &schema.Table{Name: "sub_table"}},
+				}}}},
+			},
+			},
+			configurationTables:     []string{"main_table"},
+			configurationSkipTables: []string{"sub_table"},
 			want:                    []string{"main_table"},
 			wantErr:                 false,
 		},

--- a/plugins/source_validate_test.go
+++ b/plugins/source_validate_test.go
@@ -40,10 +40,14 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 		},
 		{
 			name: "should return the parent and all its descendents",
-			plugin: SourcePlugin{tables: []*schema.Table{{Name: "main_table", Relations: []*schema.Table{
-				{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}, Relations: []*schema.Table{
-					{Name: "sub_sub_table", Parent: &schema.Table{Name: "sub_table"}},
-				}}}},
+			plugin: SourcePlugin{tables: []*schema.Table{
+				{Name: "other_table", Relations: []*schema.Table{
+					{Name: "other_sub_table", Parent: &schema.Table{Name: "main_table"}}},
+				},
+				{Name: "main_table", Relations: []*schema.Table{
+					{Name: "sub_table", Parent: &schema.Table{Name: "main_table"}, Relations: []*schema.Table{
+						{Name: "sub_sub_table", Parent: &schema.Table{Name: "sub_table"}},
+					}}}},
 			},
 			},
 			configurationTables:     []string{"main_table"},

--- a/schema/table.go
+++ b/schema/table.go
@@ -83,15 +83,16 @@ func (tt Tables) Get(name string) *Table {
 	return nil
 }
 
-// GlobMatch returns a list of tables that match a given glob
+// GlobMatch returns a list of tables that match a given glob. If a parent table is matched,
+// it will also return all its children as part of the list.
 func (tt Tables) GlobMatch(pattern string) Tables {
 	tables := make([]*Table, 0, 10)
 	for _, t := range tt {
 		if glob.Glob(pattern, t.Name) {
 			tables = append(tables, t)
 		}
-		// recurse down to also match against child tables
-		tables = append(tables, t.Relations.GlobMatch(pattern)...)
+		// recurse down to get all child tables
+		tables = append(tables, t.Relations.GlobMatch("*")...)
 	}
 	return tables
 }

--- a/schema/table.go
+++ b/schema/table.go
@@ -90,9 +90,11 @@ func (tt Tables) GlobMatch(pattern string) Tables {
 	for _, t := range tt {
 		if glob.Glob(pattern, t.Name) {
 			tables = append(tables, t)
+			// recurse down to get all child tables
+			tables = append(tables, t.Relations.GlobMatch("*")...)
 		}
-		// recurse down to get all child tables
-		tables = append(tables, t.Relations.GlobMatch("*")...)
+		// also try to match against child tables, even if the parent didn't match
+		tables = append(tables, t.Relations.GlobMatch(pattern)...)
 	}
 	return tables
 }

--- a/schema/table.go
+++ b/schema/table.go
@@ -92,6 +92,7 @@ func (tt Tables) GlobMatch(pattern string) Tables {
 			tables = append(tables, t)
 			// recurse down to get all child tables
 			tables = append(tables, t.Relations.GlobMatch("*")...)
+			continue
 		}
 		// also try to match against child tables, even if the parent didn't match
 		tables = append(tables, t.Relations.GlobMatch(pattern)...)


### PR DESCRIPTION
Follow-up to https://github.com/cloudquery/plugin-sdk/pull/398 to ensure that all descendants of a parent table are added (or skipped) by default. This makes it a non-breaking change.