### PR TITLE
feat: Resolve table relations in parallel

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -32,7 +32,7 @@ type SourcePlugin struct {
 	// resourceSem is a semaphore that limits the number of concurrent resources being fetched
 	resourceSem *semaphore.Weighted
 	// tableSem is a semaphore that limits the number of concurrent tables being fetched
-	tableSem *semaphore.Weighted
+	tableSems []*semaphore.Weighted
 	// maxDepth is the max depth of tables
 	maxDepth uint64
 	// caser
@@ -101,7 +101,6 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 	if p.maxDepth > maxAllowedDepth {
 		panic(fmt.Errorf("max depth of tables is %d, max allowed is %d", p.maxDepth, maxAllowedDepth))
 	}
-
 	return &p
 }
 


### PR DESCRIPTION
This changes the resolver for table relations to work concurrently, like parent tables. To do so safely and without the risk of deadlock, we instantiate one semaphore per depth level. (The size of the semaphore is decreased logarithmically for each depth.)

This change will only improve performance for tables with child relations.

To compare the performance before and after, I used the benchmarks in https://github.com/cloudquery/plugin-sdk/pull/415

## Before
```
goos: darwin
goarch: arm64
pkg: github.com/cloudquery/plugin-sdk/plugins
BenchmarkDefaultConcurrency-8                     	       1	     11957 resources/s	     12626 targetResources/s	73597280 B/op	 1032425 allocs/op
BenchmarkTablesWithChildrenDefaultConcurrency-8   	       1	       545.9 resources/s	     40606 targetResources/s	461622584 B/op	 6690105 allocs/op
PASS
ok  	github.com/cloudquery/plugin-sdk/plugins	150.596s
```

## After
```
goos: darwin
goarch: arm64
pkg: github.com/cloudquery/plugin-sdk/plugins
BenchmarkDefaultConcurrency-8                     	       1	     11373 resources/s	     12626 targetResources/s	73692608 B/op	 1033614 allocs/op
BenchmarkTablesWithChildrenDefaultConcurrency-8   	       1	     30162 resources/s	     40606 targetResources/s	464285672 B/op	 6697508 allocs/op
PASS
ok  	github.com/cloudquery/plugin-sdk/plugins	6.241s
```

## Analysis

This change focuses on the `BenchmarkTablesWithChildrenDefaultConcurrency` case. The change improves `resources/s` from 545.9 to 30162, an improvement of about 55x. Memory and allocs are mostly the same.

The small downward change in `resources/s` in the `BenchmarkDefaultConcurrency` case is likely due to the few additional allocs needed. 

Closes https://github.com/cloudquery/plugin-sdk/issues/358