### PR TITLE
fix: Fix Destination testing suite

### DIFF
--- a/plugins/destination_test.go
+++ b/plugins/destination_test.go
@@ -13,11 +13,7 @@ import (
 func TestDestinationPlugin(t *testing.T) {
 	p := NewDestinationPlugin("test", "development", NewTestDestinationMemDBClient)
 	DestinationPluginTestSuiteRunner(t, p, nil,
-		DestinationTestSuiteTests{
-			Overwrite:   true,
-			DeleteStale: true,
-			Append:      true,
-		})
+		DestinationTestSuiteTests{})
 }
 
 func TestDestinationOnNewError(t *testing.T) {

--- a/plugins/destination_testing.go
+++ b/plugins/destination_testing.go
@@ -19,9 +19,9 @@ type destinationTestSuite struct {
 }
 
 type DestinationTestSuiteTests struct {
-	Overwrite   bool
-	DeleteStale bool
-	Append      bool
+	SkipOverwrite   bool
+	SkipDeleteStale bool
+	SkipAppend      bool
 }
 
 func getTestLogger(t *testing.T) zerolog.Logger {
@@ -106,7 +106,7 @@ func (s *destinationTestSuite) destinationPluginTestWriteOverwrite(ctx context.C
 		return fmt.Errorf("expected data to be %v, got %v", resource.Data, resourcesRead[1])
 	}
 
-	if s.tests.DeleteStale {
+	if !s.tests.SkipDeleteStale {
 		if err := p.DeleteStale(ctx, tables, sourceName, secondSyncTime); err != nil {
 			return fmt.Errorf("failed to delete stale data second time: %w", err)
 		}
@@ -199,7 +199,7 @@ func DestinationPluginTestSuiteRunner(t *testing.T, p *DestinationPlugin, spec i
 
 	t.Run("TestWriteOverwrite", func(t *testing.T) {
 		t.Helper()
-		if suite.tests.Overwrite {
+		if suite.tests.SkipOverwrite {
 			t.Skip("skipping TestWriteOverwrite")
 			return
 		}
@@ -210,7 +210,7 @@ func DestinationPluginTestSuiteRunner(t *testing.T, p *DestinationPlugin, spec i
 
 	t.Run("TestWriteAppend", func(t *testing.T) {
 		t.Helper()
-		if suite.tests.Append {
+		if suite.tests.SkipAppend {
 			t.Skip("skipping TestWriteAppend")
 			return
 		}


### PR DESCRIPTION
Seems we weren't running some tests. I had to invert the variables which actually also make sense so they will be enabled by default. Let's say we add a new test this will detect if a plugin is not supporting a new mode.