### PR TITLE
feat: Support ${file:./path} expansion in spec

### DIFF
--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -12,10 +13,30 @@ type SpecReader struct {
 	Destinations map[string]*Destination
 }
 
+var fileRegex = regexp.MustCompile(`\$\{file:(.+)\}`)
+
+func expandFileConfig(cfg []byte) ([]byte, error) {
+	var expandErr error
+	cfg = fileRegex.ReplaceAllFunc(cfg, func(match []byte) []byte {
+		filename := fileRegex.FindSubmatch(match)[1]
+		content, err := os.ReadFile(string(filename))
+		if err != nil {
+			expandErr = err
+			return nil
+		}
+		return content
+	})
+	return cfg, expandErr
+}
+
 func (r *SpecReader) loadSpecsFromFile(path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	data, err = expandFileConfig(data)
+	if err != nil {
+		return fmt.Errorf("failed to expand file variable in file %s: %w", path, err)
 	}
 	data = []byte(os.ExpandEnv(string(data)))
 

--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -13,7 +13,7 @@ type SpecReader struct {
 	Destinations map[string]*Destination
 }
 
-var fileRegex = regexp.MustCompile(`\$\{file:(.+)\}`)
+var fileRegex = regexp.MustCompile(`\$\{file:([^}]+)\}`)
 
 func expandFileConfig(cfg []byte) ([]byte, error) {
 	var expandErr error

--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -133,8 +133,11 @@ spec:
 		credentials: ${file:./testdata/creds2.txt}
 		otherstuff: 2
 	`)
-	expectedErr := `open ./testdata/creds2.txt: no such file or directory`
 	_, err = expandFileConfig(badCfg)
+	expectedErr := `open ./testdata/creds2.txt: no such file or directory`
+	if runtime.GOOS == "windows" {
+		expectedErr = `open ./testdata/creds2.txt: The system cannot find the file specified.`
+	}
 	if err.Error() != expectedErr {
 		t.Fatalf("expected: '%s' got: %s", expectedErr, err)
 	}

--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -106,7 +106,7 @@ spec:
 		otherstuff: 2
 		credentials1: ${file:./testdata/creds1.txt}
 	`)
-	expectedCfg :=  []byte(`
+	expectedCfg := []byte(`
 kind: source
 spec:
 	name: test
@@ -136,6 +136,6 @@ spec:
 	expectedErr := `open ./testdata/creds2.txt: no such file or directory`
 	_, err = expandFileConfig(badCfg)
 	if err.Error() != expectedErr {
-		t.Fatalf("expected: '%s' got: %s", expectedErr, err)	
+		t.Fatalf("expected: '%s' got: %s", expectedErr, err)
 	}
 }

--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"bytes"
+	"os"
 	"path"
 	"runtime"
 	"testing"
@@ -104,7 +105,7 @@ spec:
 	spec:
 		credentials: ${file:./testdata/creds.txt}
 		otherstuff: 2
-		credentials1: ${file:./testdata/creds1.txt}
+		credentials1: [${file:./testdata/creds.txt}, ${file:./testdata/creds1.txt}]
 	`)
 	expectedCfg := []byte(`
 kind: source
@@ -114,7 +115,7 @@ spec:
 	spec:
 		credentials: mytestcreds
 		otherstuff: 2
-		credentials1: anothercredtest
+		credentials1: [mytestcreds, anothercredtest]
 	`)
 	expandedCfg, err := expandFileConfig(cfg)
 	if err != nil {
@@ -134,11 +135,7 @@ spec:
 		otherstuff: 2
 	`)
 	_, err = expandFileConfig(badCfg)
-	expectedErr := `open ./testdata/creds2.txt: no such file or directory`
-	if runtime.GOOS == "windows" {
-		expectedErr = `open ./testdata/creds2.txt: The system cannot find the file specified.`
-	}
-	if err.Error() != expectedErr {
-		t.Fatalf("expected: '%s' got: %s", expectedErr, err)
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected error: %s, got: %s", os.ErrNotExist, err)
 	}
 }

--- a/specs/testdata/creds.txt
+++ b/specs/testdata/creds.txt
@@ -1,0 +1,1 @@
+mytestcreds

--- a/specs/testdata/creds1.txt
+++ b/specs/testdata/creds1.txt
@@ -1,0 +1,1 @@
+anothercredtest

--- a/specs/testdata/gcp.yml
+++ b/specs/testdata/gcp.yml
@@ -14,3 +14,5 @@ spec:
   version: v1.0.0
   registry: grpc
   write_mode: overwrite
+  spec:
+    credentials: ${file:./testdata/creds.txt}


### PR DESCRIPTION
Per user request. we had a similar version of that in v0 but now it is generic and available to all specs and not only to a specific destination.