### PR TITLE
fix: Increase GRPC message size limit to 50MiB

### DIFF
--- a/clients/constants.go
+++ b/clients/constants.go
@@ -1,5 +1,5 @@
 package clients
 
 const (
-	maxMsgSize = 20 * 1024 * 1024 // 20 MiB
+	maxMsgSize = 20 * 1024 * 1024 // 50 MiB
 )

--- a/clients/constants.go
+++ b/clients/constants.go
@@ -1,5 +1,5 @@
 package clients
 
 const (
-	maxMsgSize = 20 * 1024 * 1024 // 50 MiB
+	maxMsgSize = 50 * 1024 * 1024 // 50 MiB
 )

--- a/clients/constants.go
+++ b/clients/constants.go
@@ -1,0 +1,5 @@
+package clients
+
+const (
+	maxMsgSize = 20 * 1024 * 1024 // 20 MiB
+)

--- a/clients/destination.go
+++ b/clients/destination.go
@@ -77,7 +77,13 @@ func NewDestinationClient(ctx context.Context, registry specs.Registry, path str
 	switch registry {
 	case specs.RegistryGrpc:
 		if c.userConn == nil {
-			c.conn, err = grpc.DialContext(ctx, path, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			c.conn, err = grpc.DialContext(ctx, path,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithDefaultCallOptions(
+					grpc.MaxCallRecvMsgSize(maxMsgSize),
+					grpc.MaxCallSendMsgSize(maxMsgSize),
+				),
+			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to dial grpc source plugin at %s: %w", path, err)
 			}

--- a/clients/source.go
+++ b/clients/source.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 )
 
@@ -252,7 +251,7 @@ func (c *SourceClient) Sync(ctx context.Context, spec specs.Source, res chan<- [
 	}
 	stream, err := c.pbClient.Sync(ctx, &pb.Sync_Request{
 		Spec: b,
-	}, grpc.UseCompressor(gzip.Name))
+	})
 	if err != nil {
 		return fmt.Errorf("failed to call Sync: %w", err)
 	}

--- a/serve/constants.go
+++ b/serve/constants.go
@@ -8,5 +8,5 @@ const (
 	// bufSize used for unit testing grpc server and client
 	testBufSize       = 1024 * 1024
 	flushTimeout      = 5 * time.Second
-	maxReceiveMsgSize = 20 * 1024 * 1024 // 20MiB
+	maxReceiveMsgSize = 20 * 1024 * 1024 // 50MiB
 )

--- a/serve/constants.go
+++ b/serve/constants.go
@@ -8,5 +8,5 @@ const (
 	// bufSize used for unit testing grpc server and client
 	testBufSize       = 1024 * 1024
 	flushTimeout      = 5 * time.Second
-	maxReceiveMsgSize = 20 * 1024 * 1024 // 50MiB
+	maxReceiveMsgSize = 50 * 1024 * 1024 // 50 MiB
 )

--- a/serve/constants.go
+++ b/serve/constants.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	// bufSize used for unit testing grpc server and client
-	testBufSize       = 1024 * 1024
-	flushTimeout      = 5 * time.Second
-	maxReceiveMsgSize = 50 * 1024 * 1024 // 50 MiB
+	testBufSize  = 1024 * 1024
+	flushTimeout = 5 * time.Second
+	maxMsgSize   = 50 * 1024 * 1024 // 50 MiB
 )

--- a/serve/constants.go
+++ b/serve/constants.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	// bufSize used for unit testing grpc server and client
-	testBufSize  = 1024 * 1024
-	flushTimeout = 5 * time.Second
+	testBufSize       = 1024 * 1024
+	flushTimeout      = 5 * time.Second
+	maxReceiveMsgSize = 20 * 1024 * 1024 // 20MiB
 )

--- a/serve/destination.go
+++ b/serve/destination.go
@@ -107,6 +107,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 				grpc.ChainStreamInterceptor(
 					logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger)),
 				),
+				grpc.MaxRecvMsgSize(maxReceiveMsgSize),
 			)
 			pb.RegisterDestinationServer(s, &servers.DestinationServer{
 				Plugin: destination.plugin,

--- a/serve/destination.go
+++ b/serve/destination.go
@@ -107,7 +107,8 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 				grpc.ChainStreamInterceptor(
 					logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger)),
 				),
-				grpc.MaxRecvMsgSize(maxReceiveMsgSize),
+				grpc.MaxRecvMsgSize(maxMsgSize),
+				grpc.MaxSendMsgSize(maxMsgSize),
 			)
 			pb.RegisterDestinationServer(s, &servers.DestinationServer{
 				Plugin: destination.plugin,

--- a/serve/source.go
+++ b/serve/source.go
@@ -113,7 +113,8 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 				grpc.ChainStreamInterceptor(
 					logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger)),
 				),
-				grpc.MaxRecvMsgSize(maxReceiveMsgSize),
+				grpc.MaxRecvMsgSize(maxMsgSize),
+				grpc.MaxSendMsgSize(maxMsgSize),
 			)
 			source.plugin.SetLogger(logger)
 			pb.RegisterSourceServer(s, &servers.SourceServer{

--- a/serve/source.go
+++ b/serve/source.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	_ "google.golang.org/grpc/encoding/gzip" // to register GRPC gzip compression
+
 	"github.com/cloudquery/plugin-sdk/internal/pb"
 	"github.com/cloudquery/plugin-sdk/internal/servers"
 	"github.com/cloudquery/plugin-sdk/plugins"
@@ -113,6 +115,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 				grpc.ChainStreamInterceptor(
 					logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(logger)),
 				),
+				grpc.MaxRecvMsgSize(maxReceiveMsgSize),
 			)
 			source.plugin.SetLogger(logger)
 			pb.RegisterSourceServer(s, &servers.SourceServer{

--- a/serve/source.go
+++ b/serve/source.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	_ "google.golang.org/grpc/encoding/gzip" // to register GRPC gzip compression
-
 	"github.com/cloudquery/plugin-sdk/internal/pb"
 	"github.com/cloudquery/plugin-sdk/internal/servers"
 	"github.com/cloudquery/plugin-sdk/plugins"


### PR DESCRIPTION
The default was 4MiB, and users have reported running into this limit on occasion. If 50MiB isn't enough, we'll probably need to implement some logic to drop messages at that point since they'll be too big to be useful for many databases anyway. Let's see if increasing the limit to 50MiB solves the problem first though.

https://github.com/cloudquery/cloudquery/issues/4834