### PR TITLE
fix: Revert "feat: Resolve table relations in parallel"

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -32,7 +32,7 @@ type SourcePlugin struct {
 	// resourceSem is a semaphore that limits the number of concurrent resources being fetched
 	resourceSem *semaphore.Weighted
 	// tableSem is a semaphore that limits the number of concurrent tables being fetched
-	tableSems []*semaphore.Weighted
+	tableSem *semaphore.Weighted
 	// maxDepth is the max depth of tables
 	maxDepth uint64
 	// caser
@@ -101,6 +101,7 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 	if p.maxDepth > maxAllowedDepth {
 		panic(fmt.Errorf("max depth of tables is %d, max allowed is %d", p.maxDepth, maxAllowedDepth))
 	}
+
 	return &p
 }
 

--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -23,17 +23,18 @@ const (
 )
 
 func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client schema.ClientMeta, tables schema.Tables, resolvedResources chan<- *schema.Resource) {
+	// current DFS supports only parallelization for top level tables and resources.
+	// it is possible to extend support for multiple levels but this require benchmarking to find a good fit on how to split
+	// gorourtines for each level efficiently.
 	// This is very similar to the concurrent web crawler problem with some minor changes.
-	// We are using DFS to make sure memory usage is capped at O(h) where h is the height of the tree.
-	tableConcurrency := max(spec.Concurrency/minResourceConcurrency, minTableConcurrency)
+	// We are using DFS to make sure memory usage is capped at O(h) where h is the height of the tree/subchilds.
+	tableConcurrency := spec.Concurrency / minResourceConcurrency
+	if tableConcurrency < minTableConcurrency {
+		tableConcurrency = minTableConcurrency
+	}
 	resourceConcurrency := tableConcurrency * minResourceConcurrency
 
-	p.tableSems = make([]*semaphore.Weighted, p.maxDepth)
-	for i := uint64(0); i < p.maxDepth; i++ {
-		p.tableSems[i] = semaphore.NewWeighted(int64(tableConcurrency))
-		// reduce table concurrency logarithmically for every depth level
-		tableConcurrency = max(tableConcurrency/2, minTableConcurrency)
-	}
+	p.tableSem = semaphore.NewWeighted(int64(tableConcurrency))
 	p.resourceSem = semaphore.NewWeighted(int64(resourceConcurrency))
 
 	var wg sync.WaitGroup
@@ -51,7 +52,7 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 		p.metrics.initWithClients(table, clients)
 		for _, client := range clients {
 			client := client
-			if err := p.tableSems[0].Acquire(ctx, 1); err != nil {
+			if err := p.tableSem.Acquire(ctx, 1); err != nil {
 				// This means context was cancelled
 				wg.Wait()
 				return
@@ -59,17 +60,17 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				defer p.tableSems[0].Release(1)
+				defer p.tableSem.Release(1)
 				// not checking for error here as nothing much todo.
 				// the error is logged and this happens when context is cancelled
-				p.resolveTableDfs(ctx, tables, table, client, nil, resolvedResources, 0)
+				p.resolveTableDfs(ctx, tables, table, client, nil, resolvedResources)
 			}()
 		}
 	}
 	wg.Wait()
 }
 
-func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resolvedResources chan<- *schema.Resource, depth int) {
+func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resolvedResources chan<- *schema.Resource) {
 	clientName := client.ID()
 	logger := p.logger.With().Str("table", table.Name).Str("client", clientName).Logger()
 	logger.Info().Msg("table resolver started")
@@ -96,14 +97,14 @@ func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables sc
 	}()
 
 	for r := range res {
-		p.resolveResourcesDfs(ctx, allIncludedTables, table, client, parent, r, resolvedResources, depth)
+		p.resolveResourcesDfs(ctx, allIncludedTables, table, client, parent, r, resolvedResources)
 	}
 
 	// we don't need any waitgroups here because we are waiting for the channel to close
 	logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Msg("fetch table finished")
 }
 
-func (p *SourcePlugin) resolveResourcesDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resources interface{}, resolvedResources chan<- *schema.Resource, depth int) {
+func (p *SourcePlugin) resolveResourcesDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resources interface{}, resolvedResources chan<- *schema.Resource) {
 	resourcesSlice := helpers.InterfaceSlice(resources)
 	if len(resourcesSlice) == 0 {
 		return
@@ -135,31 +136,17 @@ func (p *SourcePlugin) resolveResourcesDfs(ctx context.Context, allIncludedTable
 		wg.Wait()
 	}()
 
-	var wg sync.WaitGroup
 	for resource := range resourcesChan {
-		resource := resource
 		resolvedResources <- resource
 		for _, relation := range resource.Table.Relations {
-			relation := relation
 			if allIncludedTables.GetTopLevel(relation.Name) == nil {
 				// this indicates that child table is skipped by user config,
 				// so we should not sync it
 				continue
 			}
-			if err := p.tableSems[depth].Acquire(ctx, 1); err != nil {
-				// This means context was cancelled
-				wg.Wait()
-				return
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				defer p.tableSems[depth].Release(1)
-				p.resolveTableDfs(ctx, allIncludedTables, relation, client, resource, resolvedResources, depth+1)
-			}()
+			p.resolveTableDfs(ctx, allIncludedTables, relation, client, resource, resolvedResources)
 		}
 	}
-	wg.Wait()
 }
 
 func (p *SourcePlugin) resolveResource(ctx context.Context, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, item interface{}) *schema.Resource {
@@ -221,11 +208,4 @@ func (p *SourcePlugin) resolveColumn(ctx context.Context, logger zerolog.Logger,
 			_ = resource.Set(c.Name, v)
 		}
 	}
-}
-
-func max(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
 }


### PR DESCRIPTION
Reverts cloudquery/plugin-sdk#416

Nothing wrong with it as far as we know, but we want to release it separately from https://github.com/cloudquery/plugin-sdk/pull/421