### PR TITLE
chore: Run benchmarks in CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.2
+        uses: hermanschaaf/delta-action@v1.0.3
         with:
           title: "⏱️ Benchmark results"
           style: "graph"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: netlify/delta-action@v1.1.0
+        uses: hermanschaaf/delta-action@latest
         with:
           title: "⏱️ Benchmark results"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Delta
         uses: netlify/delta-action@v1.1.0
         with:
+          title: "⏱️ Benchmark results"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: netlify/delta-action@v3
+        uses: netlify/delta-action@v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
         uses: hermanschaaf/delta-action@v1.0.7
         with:
           title: "⏱️ Benchmark results"
-          style: "graph"
+          style: "text"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.6
+        uses: hermanschaaf/delta-action@v1.0.7
         with:
           title: "⏱️ Benchmark results"
           style: "text"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.4
+        uses: hermanschaaf/delta-action@v1.0.5
         with:
           title: "⏱️ Benchmark results"
           style: "graph"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
         uses: hermanschaaf/delta-action@v1.0.7
         with:
           title: "⏱️ Benchmark results"
-          style: "text"
+          style: "graph"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.3
+        uses: hermanschaaf/delta-action@v1.0.4
         with:
           title: "⏱️ Benchmark results"
           style: "graph"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,9 +32,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.0
+        uses: hermanschaaf/delta-action@v1.0.1
         with:
           title: "⏱️ Benchmark results"
+          style: "default"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
         uses: hermanschaaf/delta-action@v1.0.1
         with:
           title: "⏱️ Benchmark results"
-          style: "default"
+          style: "graph"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.5
+        uses: hermanschaaf/delta-action@v1.0.6
         with:
           title: "⏱️ Benchmark results"
           style: "text"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@latest
+        uses: hermanschaaf/delta-action@v1.0.0
         with:
           title: "⏱️ Benchmark results"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,10 +24,17 @@ jobs:
       - run: go build ./...
       - name: Run tests
         if: matrix.os != 'ubuntu-latest'
-        run: go test ./...
+        run: go test -race ./...
       - name: Run tests
         if: matrix.os == 'ubuntu-latest'
-        run: go test -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out ./...
+      - name: Run benchmark
+        if: matrix.os == 'ubuntu-latest'
+        run: make benchmark-ci
+      - name: Delta
+        uses: netlify/delta-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'
         run: go tool cover -html coverage.out -o coverage.html

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.1
+        uses: hermanschaaf/delta-action@v1.0.2
         with:
           title: "⏱️ Benchmark results"
           style: "graph"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
         uses: hermanschaaf/delta-action@v1.0.5
         with:
           title: "⏱️ Benchmark results"
-          style: "graph"
+          style: "text"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ config.hcl
 .vscode
 vendor
 cover.out
+.delta.*
+bench.json

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ gen-proto:
 
 .PHONY: gen-proto
 benchmark:
-	go test -bench=Benchmark -run=^$ ./...
+	go test -bench=Benchmark -run="^$$" ./...
 
 benchmark-ci:
 	go test -bench . -benchmem ./... -run="^$$" | gobenchdata --json bench.json

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,11 @@ lint:
 .PHONY: gen-proto
 gen-proto:
 	protoc --proto_path=. --go_out . --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative internal/pb/base.proto internal/pb/source.proto internal/pb/destination.proto
+
+.PHONY: gen-proto
+benchmark:
+	go test -bench=Benchmark -run=^$ ./...
+
+benchmark-ci:
+	go test -bench . -benchmem ./... -run="^$$" | gobenchdata --json bench.json
+	rm -rf .delta.* && go run scripts/benchmark-delta/main.go bench.json

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,6 @@ benchmark:
 	go test -bench=Benchmark -run="^$$" ./...
 
 benchmark-ci:
+	go install go.bobheadxi.dev/gobenchdata@v1.2.1
 	go test -bench . -benchmem ./... -run="^$$" | gobenchdata --json bench.json
 	rm -rf .delta.* && go run scripts/benchmark-delta/main.go bench.json

--- a/scripts/benchmark-delta/main.go
+++ b/scripts/benchmark-delta/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+type benchdata []struct {
+	Suites []struct {
+		Benchmarks []struct {
+			Name    string
+			Runs    int
+			NsPerOp float64
+			Mem     struct {
+				BytesPerOp  int64
+				AllocsPerOp int64
+			}
+			Custom map[string]float64
+		}
+	}
+}
+
+type deltaResult struct {
+	Name   string  // file name that will be used
+	Metric string  // human-friendly name for metric
+	Value  float64 // value
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Usage: %s <path to benchdata JSON file>", os.Args[0])
+	}
+	fileName := os.Args[1]
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		log.Fatalf("failed to read file: %v", err)
+	}
+
+	var d benchdata
+	err = json.Unmarshal(b, &d)
+	if err != nil {
+		log.Fatalf("failed to unmarshal benchdata JSON file: %v", err)
+	}
+	var deltaResults []deltaResult
+	for _, run := range d {
+		for _, suite := range run.Suites {
+			for _, bm := range suite.Benchmarks {
+				if bm.NsPerOp > 0 {
+					fmt.Println(bm.Name, "ns/op", bm.NsPerOp)
+					deltaResults = append(deltaResults, deltaResult{
+						Name:   bm.Name + "_ns_per_op",
+						Metric: "ns/op",
+						Value:  bm.NsPerOp,
+					})
+				}
+				for k, v := range bm.Custom {
+					if k == "targetResources/s" {
+						// skip, this is a calculated target that isn't expected to change
+						// between runs
+						continue
+					}
+					fmt.Println(bm.Name, k, v)
+					deltaResults = append(deltaResults, deltaResult{
+						Name:   bm.Name + "_" + strings.ReplaceAll(k, "/", "_per_"),
+						Metric: k,
+						Value:  v,
+					})
+				}
+			}
+		}
+	}
+	for _, dr := range deltaResults {
+		name := fmt.Sprintf(".delta.%s", dr.Name)
+		fmt.Printf("Writing to %s\n", name)
+		data := []byte(fmt.Sprintf("%v (%s)", dr.Value, dr.Metric))
+		err := os.WriteFile(name, data, 0664)
+		if err != nil {
+			log.Fatalf("failed to write %v: %v", name, err)
+		}
+	}
+}

--- a/scripts/benchmark-delta/main.go
+++ b/scripts/benchmark-delta/main.go
@@ -29,6 +29,10 @@ type deltaResult struct {
 	Value  float64 // value
 }
 
+func prettyName(name string) string {
+	return strings.Trim(strings.TrimPrefix(name, "Benchmark"), "_")
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		log.Fatalf("Usage: %s <path to benchdata JSON file>", os.Args[0])
@@ -52,7 +56,7 @@ func main() {
 					fmt.Println(bm.Name, "ns/op", bm.NsPerOp)
 					deltaResults = append(deltaResults, deltaResult{
 						Name:   bm.Name + "_ns_per_op",
-						Metric: "ns/op",
+						Metric: prettyName(bm.Name) + " " + "ns/op",
 						Value:  bm.NsPerOp,
 					})
 				}
@@ -65,7 +69,7 @@ func main() {
 					fmt.Println(bm.Name, k, v)
 					deltaResults = append(deltaResults, deltaResult{
 						Name:   bm.Name + "_" + strings.ReplaceAll(k, "/", "_per_"),
-						Metric: k,
+						Metric: prettyName(bm.Name) + " " + k,
 						Value:  v,
 					})
 				}


### PR DESCRIPTION
Adds a Github Action step to run benchmarks in CI and report on the differences with `main`.

It uses a combination of [gobenchdata](https://github.com/bobheadxi/gobenchdata), the [netlify/delta-action](https://github.com/netlify/delta-action) and a simple Go script to glue them together.

Example from lower down in this PR:
![Screenshot 2022-11-22 at 18 56 21](https://user-images.githubusercontent.com/1121616/203398189-b8a0b94c-bb1b-416d-94d4-84cf71feb176.png)

Closes https://github.com/cloudquery/plugin-sdk/issues/424
