### PR TITLE
feat: Handle resolving of empty maps and slices

### DIFF
--- a/schema/json_test.go
+++ b/schema/json_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 )
 
+type Foo struct {
+	Num int
+}
+
 func TestJSONSet(t *testing.T) {
 	successfulTests := []struct {
 		source interface{}
@@ -13,8 +17,25 @@ func TestJSONSet(t *testing.T) {
 		{source: []byte("{}"), result: JSON{Bytes: []byte("{}"), Status: Present}},
 		{source: ([]byte)(nil), result: JSON{Status: Null}},
 		{source: (*string)(nil), result: JSON{Status: Null}},
+
 		{source: []int{1, 2, 3}, result: JSON{Bytes: []byte("[1,2,3]"), Status: Present}},
+		{source: []int(nil), result: JSON{Bytes: []byte(`[]`), Status: Present}},
+		{source: []int{}, result: JSON{Bytes: []byte(`[]`), Status: Present}},
+		{source: []Foo(nil), result: JSON{Bytes: []byte(`[]`), Status: Present}},
+		{source: []Foo{}, result: JSON{Bytes: []byte(`[]`), Status: Present}},
+		{source: []Foo{{1}}, result: JSON{Bytes: []byte(`[{"Num":1}]`), Status: Present}},
+
 		{source: map[string]interface{}{"foo": "bar"}, result: JSON{Bytes: []byte(`{"foo":"bar"}`), Status: Present}},
+		{source: map[string]interface{}(nil), result: JSON{Bytes: []byte(`{}`), Status: Present}},
+		{source: map[string]interface{}{}, result: JSON{Bytes: []byte(`{}`), Status: Present}},
+		{source: map[string]string{"foo": "bar"}, result: JSON{Bytes: []byte(`{"foo":"bar"}`), Status: Present}},
+		{source: map[string]string(nil), result: JSON{Bytes: []byte(`{}`), Status: Present}},
+		{source: map[string]string{}, result: JSON{Bytes: []byte(`{}`), Status: Present}},
+		{source: map[string]Foo{"foo": {1}}, result: JSON{Bytes: []byte(`{"foo":{"Num":1}}`), Status: Present}},
+		{source: map[string]Foo(nil), result: JSON{Bytes: []byte(`{}`), Status: Present}},
+		{source: map[string]Foo{}, result: JSON{Bytes: []byte(`{}`), Status: Present}},
+
+		{source: nil, result: JSON{Status: Null}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
In fields like 'Tags', 'Annotations' - it is more consistent if empty/null dictionaries show up as an empty JSON object `{}`, rather than being a postgres "null" or a JSON "null".

#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
