### PR TITLE
chore: Use GH_CQ_BOT token to comment on Benchmark results

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           title: "⏱️ Benchmark results"
           style: "text"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_CQ_BOT }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'
         run: go tool cover -html coverage.out -o coverage.html

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Delta
-        uses: hermanschaaf/delta-action@v1.0.7
+        uses: netlify/delta-action@v4.1.0
         with:
           title: "⏱️ Benchmark results"
           style: "text"


### PR DESCRIPTION
We need slightly elevated permissions to make a comment when the PR comes from a fork, and I believe this should do the trick.

Github Actions security when it comes to external PRs is a bit of a minefield, but because we're avoiding the `pull_request_target` trigger here, and not running any repository code in the delta-action itself, I believe this is safe.

This should fix the issue we're seeing here https://github.com/cloudquery/plugin-sdk/pull/430