### PR TITLE
chore: Remove benchmark comments for now

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -31,12 +31,13 @@ jobs:
       - name: Run benchmark
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
-      - name: Delta
-        uses: netlify/delta-action@v4.1.0
-        with:
-          title: "⏱️ Benchmark results"
-          style: "text"
-          token: ${{ secrets.GH_CQ_BOT }}
+#        Commented out until we find a way to safely comment on PRs from forked repos
+#      - name: Delta
+#        uses: netlify/delta-action@v4.1.0
+#        with:
+#          title: "⏱️ Benchmark results"
+#          style: "text"
+#          token: ${{ secrets.GH_CQ_BOT }}
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'
         run: go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
The fix in https://github.com/cloudquery/plugin-sdk/pull/436 didn't work; looks like you can't use the GH bot token from a forked repo PR either.