### PR TITLE
chore(ci): Bring back benchmark comment

### DIFF
--- a/.github/workflows/unittest-post.yml
+++ b/.github/workflows/unittest-post.yml
@@ -27,5 +27,6 @@ jobs:
       - name: Post deltas to GitHub
         uses: netlify/delta-action@v4
         with:
-          title: "📊 Benchmark results"
+          title: "⏱️ Benchmark results"
+          style: "text"
           pr_number: ${{ steps.pr_number.outputs.pr_number }}

--- a/.github/workflows/unittest-post.yml
+++ b/.github/workflows/unittest-post.yml
@@ -1,0 +1,31 @@
+name: Post Unit Tests
+
+on:
+  workflow_run:
+    workflows: [Unit tests]
+    types:
+      - completed
+
+jobs:
+  post-unitests:
+    runs-on: ubuntu-latest
+    steps:
+      # This posts the status to the PR/commit
+      - uses: haya14busa/action-workflow_run-status@v1
+      - name: Download benchmarks
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          # This is the workflow that triggered this run
+          workflow: ${{ github.event.workflow.id }}
+          workflow_conclusion: success
+          name: delta-action-benchmarks
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get PR number
+        if: github.event.workflow_run.event == 'pull_request'
+        id: pr_number
+        run: echo "pr_number=$(cat pr_number)" >> $GITHUB_OUTPUT
+      - name: Post deltas to GitHub
+        uses: netlify/delta-action@v4
+        with:
+          title: "📊 Benchmark results"
+          pr_number: ${{ steps.pr_number.outputs.pr_number }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   unitests:
@@ -31,13 +32,17 @@ jobs:
       - name: Run benchmark
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
-#        Commented out until we find a way to safely comment on PRs from forked repos
-#      - name: Delta
-#        uses: netlify/delta-action@v4.1.0
-#        with:
-#          title: "⏱️ Benchmark results"
-#          style: "text"
-#          token: ${{ secrets.GH_CQ_BOT }}
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.number }} > ./pr_number
+      - name: Upload deltas
+        uses: actions/upload-artifact@v3
+        with:
+          name: delta-action-benchmarks
+          retention-days: 7
+          path: |
+            .delta.*
+            pr_number
       - name: Generate coverage report
         if: always() && matrix.os == 'ubuntu-latest'
         run: go tool cover -html coverage.out -o coverage.html


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Brings back the benchmark comment based on https://github.com/cloudquery/plugin-sdk/pull/437#issuecomment-1329194054

This should only start working post merge (I hope) as the workflow file needs to be on the `main` branch

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
