### PR TITLE
chore(ci): Upload benchmark results only for ubuntu

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -33,9 +33,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: make benchmark-ci
       - name: Save PR number
-        if: github.event_name == 'pull_request'
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         run: echo ${{ github.event.number }} > ./pr_number
       - name: Upload deltas
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
           name: delta-action-benchmarks


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Follow up to https://github.com/cloudquery/plugin-sdk/pull/441. We should only upload the results when running on Ubuntu

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
