### PR TITLE
feat: Add Support for net.IP in Faker

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -26,7 +26,6 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 		return reflect.Value{}, fmt.Errorf("max_depth reached")
 	}
 	k := t.Kind()
-
 	switch k {
 	case reflect.Ptr:
 		v := reflect.New(t.Elem())
@@ -70,17 +69,29 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 	case reflect.String:
 		return reflect.ValueOf("test string"), nil
 	case reflect.Slice:
-		sliceLen := 1
-		v := reflect.MakeSlice(t, sliceLen, sliceLen)
-		for i := 0; i < v.Len(); i++ {
-			val, err := f.getFakedValue(v.Index(i).Interface())
-			if err != nil {
-				return reflect.Value{}, err
+		switch t.String() {
+		case "net.IP":
+			sliceLen := 4
+			v := reflect.MakeSlice(reflect.TypeOf([]uint8{uint8(123)}), sliceLen, sliceLen)
+			for i := 0; i < v.Len(); i++ {
+				val := reflect.ValueOf(uint8(1))
+				val = val.Convert(v.Index(i).Type())
+				v.Index(i).Set(val)
 			}
-			val = val.Convert(v.Index(i).Type())
-			v.Index(i).Set(val)
+			return v, nil
+		default:
+			sliceLen := 1
+			v := reflect.MakeSlice(t, sliceLen, sliceLen)
+			for i := 0; i < v.Len(); i++ {
+				val, err := f.getFakedValue(v.Index(i).Interface())
+				if err != nil {
+					return reflect.Value{}, err
+				}
+				val = val.Convert(v.Index(i).Type())
+				v.Index(i).Set(val)
+			}
+			return v, nil
 		}
-		return v, nil
 	case reflect.Array:
 		v := reflect.New(t).Elem()
 		for i := 0; i < v.Len(); i++ {

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -49,7 +49,7 @@ func TestFakerWithCustomType(t *testing.T) {
 }
 
 type complexType struct {
-	F net.IP
+	IPAddress net.IP
 }
 
 func TestFakerWithComplexCustomType(t *testing.T) {
@@ -57,6 +57,6 @@ func TestFakerWithComplexCustomType(t *testing.T) {
 	if err := FakeObject(&a); err != nil {
 		t.Fatal(err)
 	}
-	assert.NotEmpty(t, a.F)
-
+	assert.NotEmpty(t, a.IPAddress)
+	assert.Equal(t, "1.1.1.1", a.IPAddress.String())
 }

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -49,7 +49,13 @@ func TestFakerWithCustomType(t *testing.T) {
 }
 
 type complexType struct {
-	IPAddress net.IP
+	IPAddress      net.IP
+	IPAddresses    []net.IP
+	PtrIPAddress   *net.IP
+	PtrIPAddresses []*net.IP
+	NestedComplex  struct {
+		IPAddress net.IP
+	}
 }
 
 func TestFakerCanFakeNetIP(t *testing.T) {
@@ -59,4 +65,16 @@ func TestFakerCanFakeNetIP(t *testing.T) {
 	}
 	assert.NotEmpty(t, a.IPAddress)
 	assert.Equal(t, "1.1.1.1", a.IPAddress.String())
+
+	assert.Equal(t, 1, len(a.IPAddresses))
+	assert.Equal(t, "1.1.1.1", a.IPAddresses[0].String())
+
+	assert.NotEmpty(t, a.PtrIPAddress)
+	assert.Equal(t, "1.1.1.1", a.PtrIPAddress.String())
+
+	assert.Equal(t, 1, len(a.PtrIPAddresses))
+	assert.Equal(t, "1.1.1.1", a.PtrIPAddresses[0].String())
+
+	assert.NotEmpty(t, a.NestedComplex.IPAddress)
+	assert.Equal(t, "1.1.1.1", a.NestedComplex.IPAddress.String())
 }

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -45,4 +46,17 @@ func TestFakerWithCustomType(t *testing.T) {
 	assert.NotEmpty(t, a.B)
 	assert.NotEmpty(t, a.C)
 	assert.NotEmpty(t, a.D)
+}
+
+type complexType struct {
+	F net.IP
+}
+
+func TestFakerWithComplexCustomType(t *testing.T) {
+	a := complexType{}
+	if err := FakeObject(&a); err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEmpty(t, a.F)
+
 }

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -52,7 +52,7 @@ type complexType struct {
 	IPAddress net.IP
 }
 
-func TestFakerWithComplexCustomType(t *testing.T) {
+func TestFakerCanFakeNetIP(t *testing.T) {
 	a := complexType{}
 	if err := FakeObject(&a); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


The Gitlab Plugin I am working on has `net.IP` fields... existing implementation does not produce a valid IP address so needs explicit support


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
