### PR TITLE
fix(codegen)!: Column type for slices

### DIFF
--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -32,7 +32,7 @@ type (
 			StringCol string `json:"string_col,omitempty"`
 		}
 		IntArrayCol    []int  `json:"int_array_col,omitempty"`
-		IntArrayColToo []*int `json:"int_array_col_too,omitempty"`
+		IntPointerArrayCol []*int `json:"int_pointer_array_col,omitempty"`
 
 		StringArrayCol    []string  `json:"string_array_col,omitempty"`
 		StringArrayColToo []*string `json:"string_array_col_too,omitempty"`

--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -31,8 +31,12 @@ type (
 			IntCol    int    `json:"int_col,omitempty"`
 			StringCol string `json:"string_col,omitempty"`
 		}
-		IntArrayCol    []int      `json:"int_array_col,omitempty"`
-		StringArrayCol []string   `json:"string_array_col,omitempty"`
+		IntArrayCol    []int  `json:"int_array_col,omitempty"`
+		IntArrayColToo []*int `json:"int_array_col_too,omitempty"`
+
+		StringArrayCol    []string  `json:"string_array_col,omitempty"`
+		StringArrayColToo []*string `json:"string_array_col_too,omitempty"`
+
 		TimeCol        time.Time  `json:"time_col,omitempty"`
 		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
 		JSONTag        *string    `json:"json_tag"`
@@ -115,9 +119,19 @@ var (
 			Resolver: `schema.PathResolver("IntArrayCol")`,
 		},
 		{
+			Name:     "int_array_col_too",
+			Type:     schema.TypeIntArray,
+			Resolver: `schema.PathResolver("IntArrayColToo")`,
+		},
+		{
 			Name:     "string_array_col",
 			Type:     schema.TypeStringArray,
 			Resolver: `schema.PathResolver("StringArrayCol")`,
+		},
+		{
+			Name:     "string_array_col_too",
+			Type:     schema.TypeStringArray,
+			Resolver: `schema.PathResolver("StringArrayColToo")`,
 		},
 		{
 			Name:     "time_col",

--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -35,7 +35,7 @@ type (
 		IntPointerArrayCol []*int `json:"int_pointer_array_col,omitempty"`
 
 		StringArrayCol    []string  `json:"string_array_col,omitempty"`
-		StringArrayColToo []*string `json:"string_array_col_too,omitempty"`
+		StringPointerArrayColToo []*string `json:"string_pointer_array_col,omitempty"`
 
 		TimeCol        time.Time  `json:"time_col,omitempty"`
 		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`

--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -31,11 +31,11 @@ type (
 			IntCol    int    `json:"int_col,omitempty"`
 			StringCol string `json:"string_col,omitempty"`
 		}
-		IntArrayCol    []int  `json:"int_array_col,omitempty"`
+		IntArrayCol        []int  `json:"int_array_col,omitempty"`
 		IntPointerArrayCol []*int `json:"int_pointer_array_col,omitempty"`
 
-		StringArrayCol    []string  `json:"string_array_col,omitempty"`
-		StringPointerArrayColToo []*string `json:"string_pointer_array_col,omitempty"`
+		StringArrayCol        []string  `json:"string_array_col,omitempty"`
+		StringPointerArrayCol []*string `json:"string_pointer_array_col,omitempty"`
 
 		TimeCol        time.Time  `json:"time_col,omitempty"`
 		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
@@ -119,9 +119,9 @@ var (
 			Resolver: `schema.PathResolver("IntArrayCol")`,
 		},
 		{
-			Name:     "int_array_col_too",
+			Name:     "int_pointer_array_col",
 			Type:     schema.TypeIntArray,
-			Resolver: `schema.PathResolver("IntArrayColToo")`,
+			Resolver: `schema.PathResolver("IntPointerArrayCol")`,
 		},
 		{
 			Name:     "string_array_col",
@@ -129,9 +129,9 @@ var (
 			Resolver: `schema.PathResolver("StringArrayCol")`,
 		},
 		{
-			Name:     "string_array_col_too",
+			Name:     "string_pointer_array_col",
 			Type:     schema.TypeStringArray,
-			Resolver: `schema.PathResolver("StringArrayColToo")`,
+			Resolver: `schema.PathResolver("StringPointerArrayCol")`,
 		},
 		{
 			Name:     "time_col",

--- a/codegen/transformers.go
+++ b/codegen/transformers.go
@@ -54,11 +54,10 @@ func defaultGoTypeToSchemaType(v reflect.Type) (schema.ValueType, error) {
 		}
 		return schema.TypeJSON, nil
 	case reflect.Slice:
-		switch v.Elem().Kind() {
-		case reflect.String:
+		switch elemValueType, _ := defaultGoTypeToSchemaType(v.Elem()); elemValueType {
+		case schema.TypeString:
 			return schema.TypeStringArray, nil
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case schema.TypeInt:
 			return schema.TypeIntArray, nil
 		default:
 			return schema.TypeJSON, nil


### PR DESCRIPTION
#### Summary

* `[]*string` will become `schema.TypeStringArray`
* `[]*int(8|16|32|64)` will become `schema.TypeIntArray`

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
