### PR TITLE
fix: Add error-handling to transformer

### DIFF
--- a/schema/bool.go
+++ b/schema/bool.go
@@ -7,7 +7,7 @@ import (
 )
 
 type BoolTransformer interface {
-	TransformBool(*Bool) interface{}
+	TransformBool(*Bool) (interface{}, error)
 }
 
 type Bool struct {

--- a/schema/bytea.go
+++ b/schema/bytea.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ByteaTransformer interface {
-	TransformBytea(*Bytea) interface{}
+	TransformBytea(*Bytea) (interface{}, error)
 }
 
 type Bytea struct {

--- a/schema/cidr.go
+++ b/schema/cidr.go
@@ -5,7 +5,7 @@ import "encoding/json"
 type CIDR Inet
 
 type CIDRTransformer interface {
-	TransformCIDR(*CIDR) interface{}
+	TransformCIDR(*CIDR) (interface{}, error)
 }
 
 func (*CIDR) Type() ValueType {

--- a/schema/cidr_array.go
+++ b/schema/cidr_array.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CIDRArrayTransformer interface {
-	TransformCIDRArray(*CIDRArray) interface{}
+	TransformCIDRArray(*CIDRArray) (interface{}, error)
 }
 
 type CIDRArray struct {

--- a/schema/float8.go
+++ b/schema/float8.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Float8Transformer interface {
-	TransformFloat8(*Float8) interface{}
+	TransformFloat8(*Float8) (interface{}, error)
 }
 
 type Float8 struct {

--- a/schema/inet.go
+++ b/schema/inet.go
@@ -10,7 +10,7 @@ import (
 )
 
 type InetTransformer interface {
-	TransformInet(*Inet) interface{}
+	TransformInet(*Inet) (interface{}, error)
 }
 
 // workaround this Golang bug: https://github.com/golang/go/issues/35727

--- a/schema/inet_array.go
+++ b/schema/inet_array.go
@@ -9,7 +9,7 @@ import (
 )
 
 type InetArrayTransformer interface {
-	TransformInetArray(*InetArray) interface{}
+	TransformInetArray(*InetArray) (interface{}, error)
 }
 
 type InetArray struct {

--- a/schema/int8.go
+++ b/schema/int8.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Int8Transformer interface {
-	TransformInt8(*Int8) interface{}
+	TransformInt8(*Int8) (interface{}, error)
 }
 
 type Int8 struct {

--- a/schema/int8_array.go
+++ b/schema/int8_array.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Int8ArrayTransformer interface {
-	TransformInt8Array(*Int8Array) interface{}
+	TransformInt8Array(*Int8Array) (interface{}, error)
 }
 
 type Int8Array struct {

--- a/schema/json.go
+++ b/schema/json.go
@@ -8,7 +8,7 @@ import (
 )
 
 type JSONTransformer interface {
-	TransformJSON(*JSON) interface{}
+	TransformJSON(*JSON) (interface{}, error)
 }
 
 type JSON struct {

--- a/schema/macaddr.go
+++ b/schema/macaddr.go
@@ -7,7 +7,7 @@ import (
 )
 
 type MacaddrTransformer interface {
-	TransformMacaddr(*Macaddr) interface{}
+	TransformMacaddr(*Macaddr) (interface{}, error)
 }
 
 type Macaddr struct {

--- a/schema/macaddr_array.go
+++ b/schema/macaddr_array.go
@@ -9,7 +9,7 @@ import (
 )
 
 type MacaddrArrayTransformer interface {
-	TransformMacaddrArray(*MacaddrArray) interface{}
+	TransformMacaddrArray(*MacaddrArray) (interface{}, error)
 }
 
 type MacaddrArray struct {

--- a/schema/text.go
+++ b/schema/text.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TextTransformer interface {
-	TransformText(*Text) interface{}
+	TransformText(*Text) (interface{}, error)
 }
 
 type Text struct {

--- a/schema/text_array.go
+++ b/schema/text_array.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TextArrayTransformer interface {
-	TransformTextArray(*TextArray) interface{}
+	TransformTextArray(*TextArray) (interface{}, error)
 }
 
 type TextArray struct {

--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -22,7 +22,7 @@ const (
 )
 
 type TimestamptzTransformer interface {
-	TransformTimestamptz(*Timestamptz) interface{}
+	TransformTimestamptz(*Timestamptz) (interface{}, error)
 }
 
 type Timestamptz struct {

--- a/schema/transformer.go
+++ b/schema/transformer.go
@@ -20,118 +20,123 @@ type CQTypeTransformer interface {
 	UUIDTransformer
 }
 
-func TransformWithTransformer(transformer CQTypeTransformer, values CQTypes) []interface{} {
+func TransformWithTransformer(transformer CQTypeTransformer, values CQTypes) ([]interface{}, error) {
 	res := make([]interface{}, len(values))
+	var err error
 	for i, v := range values {
 		switch v.Type() {
 		case TypeBool:
-			res[i] = transformer.TransformBool(v.(*Bool))
+			res[i], err = transformer.TransformBool(v.(*Bool))
 		case TypeByteArray:
-			res[i] = transformer.TransformBytea(v.(*Bytea))
+			res[i], err = transformer.TransformBytea(v.(*Bytea))
 		case TypeCIDRArray:
-			res[i] = transformer.TransformCIDRArray(v.(*CIDRArray))
+			res[i], err = transformer.TransformCIDRArray(v.(*CIDRArray))
 		case TypeCIDR:
-			res[i] = transformer.TransformCIDR(v.(*CIDR))
+			res[i], err = transformer.TransformCIDR(v.(*CIDR))
 		case TypeFloat:
-			res[i] = transformer.TransformFloat8(v.(*Float8))
+			res[i], err = transformer.TransformFloat8(v.(*Float8))
 		case TypeInetArray:
-			res[i] = transformer.TransformInetArray(v.(*InetArray))
+			res[i], err = transformer.TransformInetArray(v.(*InetArray))
 		case TypeInet:
-			res[i] = transformer.TransformInet(v.(*Inet))
+			res[i], err = transformer.TransformInet(v.(*Inet))
 		case TypeIntArray:
-			res[i] = transformer.TransformInt8Array(v.(*Int8Array))
+			res[i], err = transformer.TransformInt8Array(v.(*Int8Array))
 		case TypeInt:
-			res[i] = transformer.TransformInt8(v.(*Int8))
+			res[i], err = transformer.TransformInt8(v.(*Int8))
 		case TypeJSON:
-			res[i] = transformer.TransformJSON(v.(*JSON))
+			res[i], err = transformer.TransformJSON(v.(*JSON))
 		case TypeMacAddrArray:
-			res[i] = transformer.TransformMacaddrArray(v.(*MacaddrArray))
+			res[i], err = transformer.TransformMacaddrArray(v.(*MacaddrArray))
 		case TypeMacAddr:
-			res[i] = transformer.TransformMacaddr(v.(*Macaddr))
+			res[i], err = transformer.TransformMacaddr(v.(*Macaddr))
 		case TypeStringArray:
-			res[i] = transformer.TransformTextArray(v.(*TextArray))
+			res[i], err = transformer.TransformTextArray(v.(*TextArray))
 		case TypeString:
-			res[i] = transformer.TransformText(v.(*Text))
+			res[i], err = transformer.TransformText(v.(*Text))
 		case TypeTimestamp:
-			res[i] = transformer.TransformTimestamptz(v.(*Timestamptz))
+			res[i], err = transformer.TransformTimestamptz(v.(*Timestamptz))
 		case TypeUUIDArray:
-			res[i] = transformer.TransformUUIDArray(v.(*UUIDArray))
+			res[i], err = transformer.TransformUUIDArray(v.(*UUIDArray))
 		case TypeUUID:
-			res[i] = transformer.TransformUUID(v.(*UUID))
+			res[i], err = transformer.TransformUUID(v.(*UUID))
 		default:
 			panic("unknown type " + v.Type().String())
 		}
+
+		if err != nil {
+			return nil, err
+		}
 	}
-	return res
+	return res, nil
 }
 
 type DefaultTransformer struct {
 }
 
-func (*DefaultTransformer) TransformBool(v *Bool) interface{} {
-	return v
+func (*DefaultTransformer) TransformBool(v *Bool) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformBytea(v *Bytea) interface{} {
-	return v
+func (*DefaultTransformer) TransformBytea(v *Bytea) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformFloat8(v *Float8) interface{} {
-	return v
+func (*DefaultTransformer) TransformFloat8(v *Float8) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformInt8(v *Int8) interface{} {
-	return v
+func (*DefaultTransformer) TransformInt8(v *Int8) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformInt8Array(v *Int8Array) interface{} {
-	return v
+func (*DefaultTransformer) TransformInt8Array(v *Int8Array) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformJSON(v *JSON) interface{} {
-	return v
+func (*DefaultTransformer) TransformJSON(v *JSON) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformText(v *Text) interface{} {
-	return v
+func (*DefaultTransformer) TransformText(v *Text) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformTextArray(v *TextArray) interface{} {
-	return v
+func (*DefaultTransformer) TransformTextArray(v *TextArray) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformTimestamptz(v *Timestamptz) interface{} {
-	return v
+func (*DefaultTransformer) TransformTimestamptz(v *Timestamptz) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformUUID(v *UUID) interface{} {
-	return v
+func (*DefaultTransformer) TransformUUID(v *UUID) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformUUIDArray(v *UUIDArray) interface{} {
-	return v
+func (*DefaultTransformer) TransformUUIDArray(v *UUIDArray) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformCIDR(v *CIDR) interface{} {
-	return v
+func (*DefaultTransformer) TransformCIDR(v *CIDR) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformCIDRArray(v *CIDRArray) interface{} {
-	return v
+func (*DefaultTransformer) TransformCIDRArray(v *CIDRArray) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformInet(v *Inet) interface{} {
-	return v
+func (*DefaultTransformer) TransformInet(v *Inet) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformInetArray(v *InetArray) interface{} {
-	return v
+func (*DefaultTransformer) TransformInetArray(v *InetArray) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformMacaddr(v *Macaddr) interface{} {
-	return v
+func (*DefaultTransformer) TransformMacaddr(v *Macaddr) (interface{}, error) {
+	return v, nil
 }
 
-func (*DefaultTransformer) TransformMacaddrArray(v *MacaddrArray) interface{} {
-	return v
+func (*DefaultTransformer) TransformMacaddrArray(v *MacaddrArray) (interface{}, error) {
+	return v, nil
 }

--- a/schema/transformer_test.go
+++ b/schema/transformer_test.go
@@ -10,7 +10,10 @@ func TestTransformWithTransformer(t *testing.T) {
 		}
 		cqTypes = append(cqTypes, NewCqTypeFromValueType(i))
 	}
-	transformedVal := TransformWithTransformer(&DefaultTransformer{}, cqTypes)
+	transformedVal, err := TransformWithTransformer(&DefaultTransformer{}, cqTypes)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if transformedVal == nil {
 		t.Fatal("expected not nil")
 	}

--- a/schema/uuid.go
+++ b/schema/uuid.go
@@ -7,7 +7,7 @@ import (
 )
 
 type UUIDTransformer interface {
-	TransformUUID(*UUID) interface{}
+	TransformUUID(*UUID) (interface{}, error)
 }
 
 type UUID struct {

--- a/schema/uuid_array.go
+++ b/schema/uuid_array.go
@@ -8,7 +8,7 @@ import (
 )
 
 type UUIDArrayTransformer interface {
-	TransformUUIDArray(*UUIDArray) interface{}
+	TransformUUIDArray(*UUIDArray) (interface{}, error)
 }
 
 type UUIDArray struct {


### PR DESCRIPTION
#### Summary

Required to fix batch-write-failures due to postgresql TEXT fields containing NULL bytes.

```
2022-11-30T12:00:11Z ERR failed to execute batch with pgerror error="ERROR: invalid byte sequence for encoding \"UTF8\": 0x00 (SQLSTATE 22021)" module=pg-dest
```
