### PR TITLE
fix: Sync Metrics for Long running plugins

### DIFF
--- a/plugins/source_metrics.go
+++ b/plugins/source_metrics.go
@@ -54,15 +54,15 @@ func (s *SourceMetrics) Equal(other *SourceMetrics) bool {
 }
 
 func (s *SourceMetrics) initWithTables(tables schema.Tables) {
+	s.TableClient = make(map[string]map[string]*TableClientMetrics)
 	for _, table := range tables {
-		if _, ok := s.TableClient[table.Name]; !ok {
-			s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
-		}
+		s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
 		s.initWithTables(table.Relations)
 	}
 }
 
 func (s *SourceMetrics) initWithClients(table *schema.Table, clients []schema.ClientMeta) {
+	s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
 	for _, client := range clients {
 		s.TableClient[table.Name][client.ID()] = &TableClientMetrics{}
 		for _, relation := range table.Relations {

--- a/plugins/source_metrics.go
+++ b/plugins/source_metrics.go
@@ -64,9 +64,7 @@ func (s *SourceMetrics) initWithTables(tables schema.Tables) {
 
 func (s *SourceMetrics) initWithClients(table *schema.Table, clients []schema.ClientMeta) {
 	for _, client := range clients {
-		if _, ok := s.TableClient[table.Name][client.ID()]; !ok {
-			s.TableClient[table.Name][client.ID()] = &TableClientMetrics{}
-		}
+		s.TableClient[table.Name][client.ID()] = &TableClientMetrics{}
 		for _, relation := range table.Relations {
 			s.initWithClients(relation, clients)
 		}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Prior to this change resource, error, and panic count were only reset when a plugin was relaunched. This means if a plugin is being run via direct gRPC calls then the summary was a total of all of the runs.


This PR reinitializes the metrics for each sync

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
