### PR TITLE
fix: TablesForSpec should only return top-level tables

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -120,7 +120,20 @@ func (p *SourcePlugin) TablesForSpec(spec specs.Source) (schema.Tables, error) {
 	if err := spec.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
-	return p.listAndValidateTables(spec.Tables, spec.SkipTables)
+	tables, err := p.listAndValidateTables(spec.Tables, spec.SkipTables)
+	if err != nil {
+		return nil, err
+	}
+	// listAndValidateTables returns a flattened list - we only want to return
+	// the top-level tables from this function.
+	var topLevelTables schema.Tables
+	for _, t := range tables {
+		if t.Parent != nil {
+			continue
+		}
+		topLevelTables = append(topLevelTables, t)
+	}
+	return topLevelTables, nil
 }
 
 // Name return the name of this plugin

--- a/plugins/source_test.go
+++ b/plugins/source_test.go
@@ -50,6 +50,31 @@ func testTableSuccess() *schema.Table {
 	}
 }
 
+func testTableWithChild() *schema.Table {
+	return &schema.Table{
+		Name:     "test_table_parent",
+		Resolver: testResolverSuccess,
+		Columns: []schema.Column{
+			{
+				Name: "test_column",
+				Type: schema.TypeInt,
+			},
+		},
+		Relations: []*schema.Table{
+			{
+				Name:     "test_table_child",
+				Resolver: testResolverSuccess,
+				Columns: []schema.Column{
+					{
+						Name: "test_column",
+						Type: schema.TypeInt,
+					},
+				},
+			},
+		},
+	}
+}
+
 func testTableResolverPanic() *schema.Table {
 	return &schema.Table{
 		Name:     "test_table_resolver_panic",
@@ -299,7 +324,7 @@ func testSyncTable(t *testing.T, tc syncTestCase) {
 
 func TestTablesForSpec(t *testing.T) {
 	tables := []*schema.Table{
-		testTableSuccess(),
+		testTableWithChild(),
 		testTableResolverPanic(),
 	}
 	plugin := NewSourcePlugin(
@@ -314,7 +339,7 @@ func TestTablesForSpec(t *testing.T) {
 			Name: "testSource",
 			Path: "cloudquery/testSource",
 			Tables: []string{
-				"test_table_success",
+				"test_table_parent",
 			},
 			Version:      "v1.0.0",
 			Destinations: []string{"test"},


### PR DESCRIPTION
Related to https://github.com/cloudquery/cloudquery/pull/5294