### PR TITLE
chore(codegen): Sort columns

### DIFF
--- a/codegen/column.go
+++ b/codegen/column.go
@@ -3,8 +3,11 @@ package codegen
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/thoas/go-funk"
+	"golang.org/x/exp/slices"
 )
 
 type (
@@ -18,6 +21,30 @@ type (
 	}
 	ColumnDefinitions []ColumnDefinition
 )
+
+// sorted returns a copy of sorted columns
+func (c ColumnDefinitions) sorted() ColumnDefinitions {
+	columns := make(ColumnDefinitions, len(c))
+	copy(columns, c)
+
+	const cqPrefix = "_cq"
+	slices.SortStableFunc(columns, func(a, b ColumnDefinition) bool {
+		switch {
+		case strings.HasPrefix(a.Name, cqPrefix):
+			return !strings.HasPrefix(b.Name, cqPrefix) || a.Name < b.Name
+		case strings.HasPrefix(b.Name, cqPrefix):
+			return false
+		case a.Options.PrimaryKey:
+			return !b.Options.PrimaryKey || a.Name < b.Name
+		case b.Options.PrimaryKey:
+			return false
+		default:
+			return a.Name < b.Name
+		}
+	})
+
+	return columns
+}
 
 func (c ColumnDefinitions) GetByName(name string) *ColumnDefinition {
 	for _, col := range c {
@@ -77,5 +104,24 @@ func (t *TableDefinition) addColumnFromField(field reflect.StructField, parent *
 			Resolver: resolver,
 		},
 	)
+	return nil
+}
+
+func (t *TableDefinition) postProcessColumns() error {
+	// add PK options
+	columns := make(ColumnDefinitions, 0, len(t.Columns))
+	for _, column := range t.Columns {
+		if _, ok := t.extraPKColumns[column.Name]; ok {
+			column.Options.PrimaryKey = true
+			delete(t.extraPKColumns, column.Name)
+		}
+		columns = append(columns, column)
+	}
+	if len(t.extraPKColumns) > 0 {
+		return fmt.Errorf("%s table definition has %d extra PK keys: %v", t.Name, len(t.extraPKColumns), funk.Keys(t.extraPKColumns))
+	}
+
+	t.Columns = columns.sorted()
+
 	return nil
 }

--- a/codegen/table.go
+++ b/codegen/table.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/rs/zerolog"
-	"github.com/thoas/go-funk"
 	"golang.org/x/exp/slices"
 )
 
@@ -96,19 +95,9 @@ func NewTableFromStruct(name string, obj interface{}, opts ...TableOption) (*Tab
 		}
 	}
 
-	// add PK options
-	columns := make(ColumnDefinitions, 0, len(t.Columns))
-	for _, column := range t.Columns {
-		if _, ok := t.extraPKColumns[column.Name]; ok {
-			column.Options.PrimaryKey = true
-			delete(t.extraPKColumns, column.Name)
-		}
-		columns = append(columns, column)
+	if err := t.postProcessColumns(); err != nil {
+		return nil, err
 	}
-	if len(t.extraPKColumns) > 0 {
-		return nil, fmt.Errorf("%s table definition has %d extra PK keys: %v", t.Name, len(t.extraPKColumns), funk.Keys(t.extraPKColumns))
-	}
-	t.Columns = columns
 
 	return t, t.Check()
 }

--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -77,7 +77,7 @@ type (
 )
 
 var (
-	expectedColumns = []ColumnDefinition{
+	expectedColumns = ColumnDefinitions{
 		{
 			Name:     "int_col",
 			Type:     schema.TypeInt,
@@ -142,14 +142,20 @@ var (
 	}
 	expectedTestTable = TableDefinition{
 		Name:                "test_struct",
-		Columns:             expectedColumns,
+		Columns:             expectedColumns.sorted(),
 		nameTransformer:     DefaultNameTransformer,
 		typeTransformer:     DefaultTypeTransformer,
 		resolverTransformer: DefaultResolverTransformer,
 	}
 	expectedTestTableEmbeddedStruct = TableDefinition{
-		Name:                "test_struct",
-		Columns:             append(expectedColumns, ColumnDefinition{Name: "embedded_string", Type: schema.TypeString, Resolver: `schema.PathResolver("EmbeddedString")`}),
+		Name: "test_struct",
+		Columns: append(expectedColumns,
+			ColumnDefinition{
+				Name:     "embedded_string",
+				Type:     schema.TypeString,
+				Resolver: `schema.PathResolver("EmbeddedString")`,
+			},
+		).sorted(),
 		nameTransformer:     DefaultNameTransformer,
 		typeTransformer:     DefaultTypeTransformer,
 		resolverTransformer: DefaultResolverTransformer,
@@ -166,7 +172,7 @@ var (
 				Resolver: `schema.PathResolver("NonEmbedded.EmbeddedString")`,
 				Options:  schema.ColumnCreationOptions{PrimaryKey: true},
 			},
-		},
+		}.sorted(),
 		nameTransformer:     DefaultNameTransformer,
 		typeTransformer:     DefaultTypeTransformer,
 		resolverTransformer: DefaultResolverTransformer,
@@ -333,7 +339,7 @@ func TestTableFromGoStruct(t *testing.T) {
 					{Name: "account_id", Type: schema.TypeString, Resolver: `schema.PathResolver("AccountID")`},
 					{Name: "postgre_sql", Type: schema.TypeString, Resolver: `schema.PathResolver("PostgreSQL")`},
 					{Name: "ids", Type: schema.TypeString, Resolver: `schema.PathResolver("IDs")`},
-				},
+				}.sorted(),
 				nameTransformer: DefaultNameTransformer},
 		},
 		{


### PR DESCRIPTION
#### Summary

This change will sort columns in the following way:
1. The columns with `_cq` prefix will be moved to the top & sorted
2. The PK columns will be moved to the top & left in the order they were specified initially
3. All other columns will be moved to the bottom & sorted

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
