### PR TITLE
fix: Don't log start-and-finish of relational tables

### DIFF
--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -72,7 +72,11 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resolvedResources chan<- *schema.Resource, depth int) {
 	clientName := client.ID()
 	logger := p.logger.With().Str("table", table.Name).Str("client", clientName).Logger()
-	logger.Info().Msg("table resolver started")
+
+	if parent == nil { // Log only for root tables, otherwise we spam too much.
+		logger.Info().Msg("table resolver started")
+	}
+
 	tableMetrics := p.metrics.TableClient[table.Name][clientName]
 	res := make(chan interface{})
 	go func() {
@@ -100,7 +104,9 @@ func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables sc
 	}
 
 	// we don't need any waitgroups here because we are waiting for the channel to close
-	logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Msg("fetch table finished")
+	if parent == nil { // Log only for root tables, otherwise we spam too much.
+		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Msg("fetch table finished")
+	}
 }
 
 func (p *SourcePlugin) resolveResourcesDfs(ctx context.Context, allIncludedTables schema.Tables, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resources interface{}, resolvedResources chan<- *schema.Resource, depth int) {


### PR DESCRIPTION
Related to: https://github.com/cloudquery/cloudquery/issues/5273

Logging every start and finish of relational tables fetches, means that the number of logs depends on the number of [parent] resources.

for example, logs for fetching `aws_rds_*` (where there are many `aws_rds_engine_versions` resources, with `aws_rds_cluster_parameters` relations).

All the relational-fetch logs are identical:
```
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF fetch table finished client=615713231484:eu-north-1 errors=0 module=aws-src resources=5576 table=aws_rds_cluster_parameters
2022-12-03T09:00:19Z INF table resolver started client=615713231484:eu-north-1 module=aws-src table=aws_rds_cluster_parameters
```

This PR reduces the logs from 11700 lines (1.5MB) to 1300 lines (144 KB).

#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
