### PR TITLE
fix(destinations): Propagate write errors

### DIFF
--- a/internal/servers/destinations.go
+++ b/internal/servers/destinations.go
@@ -104,6 +104,8 @@ func (s *DestinationServer) Write2(msg pb.Destination_Write2Server) error {
 		if err := json.Unmarshal(r.Resource, &resource); err != nil {
 			close(resources)
 			if err := eg.Wait(); err != nil {
+				// log the unmarshal error so we don't lose that information, but return the write error as that's the first one that occurred
+				s.Logger.Error().Err(err).Msg("failed to unmarshal resource")
 				return fmt.Errorf("plugin write failed: %w", err)
 			}
 			return status.Errorf(codes.InvalidArgument, "failed to unmarshal resource: %v", err)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/cloudquery/issues/5152 and https://github.com/cloudquery/plugin-sdk/pull/460

The error returned from the error group `Wait()` function is the [error reported by the Go routine](https://github.com/cloudquery/plugin-sdk/blob/ab7ca972e0b187a7dfb66132a03f07479cd29bb7/internal/servers/destinations.go#L84), not the error of the `Wait()` function

> This is only a patch. I think we should separate application level errors (e.g. write) from protocol/communication level errors. I'll open a separate issue for that.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
