### PR TITLE
fix(sentry): Use HTTPSyncTransport, remove flush

### DIFF
--- a/serve/destination.go
+++ b/serve/destination.go
@@ -49,11 +49,9 @@ func Destination(plugin *plugins.DestinationPlugin, opts ...DestinationOption) {
 	}
 	if err := newCmdDestinationRoot(s).Execute(); err != nil {
 		sentry.CaptureMessage(err.Error())
-		sentry.Flush(flushTimeout)
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	sentry.Flush(flushTimeout)
 }
 
 // nolint:dupl
@@ -122,6 +120,7 @@ func newCmdDestinationServe(destination *destinationServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: false,
 					Release:          version,
+					Transport:        sentry.NewHTTPSyncTransport(),
 					ServerName:       "oss", // set to "oss" on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {

--- a/serve/source.go
+++ b/serve/source.go
@@ -51,11 +51,9 @@ func Source(plugin *plugins.SourcePlugin, opts ...SourceOption) {
 	}
 	if err := newCmdSourceRoot(s).Execute(); err != nil {
 		sentry.CaptureMessage(err.Error())
-		sentry.Flush(flushTimeout)
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	sentry.Flush(flushTimeout)
 }
 
 // nolint:dupl
@@ -129,6 +127,7 @@ func newCmdSourceServe(source *sourceServe) *cobra.Command {
 					Debug:            false,
 					AttachStacktrace: false,
 					Release:          version,
+					Transport:        sentry.NewHTTPSyncTransport(),
 					ServerName:       "oss", // set to "oss" on purpose to avoid sending any identifying information
 					// https://docs.sentry.io/platforms/go/configuration/options/#removing-default-integrations
 					Integrations: func(integrations []sentry.Integration) []sentry.Integration {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

This PR switches Sentry to work in synchronous mode (like we have in the [CLI](https://github.com/cloudquery/cloudquery/blob/a98e20d3c13b4f9a4ef3a08cf00daa48648935fe/cli/cmd/sentry.go#L10)).

We can't rely on `sentry.Flush` begin called in a consistent way, especially on Windows since it doesn't support sending an interrupt signal and kills the process immediately:
https://github.com/cloudquery/plugin-sdk/blob/464f75f0b586def0c85a501dccc9e6235eebff0e/clients/source_terminate_windows.go#L6

This might have a performance tradeoff, but since we use it for errors/panics only I think that should be ok.
Another solution @disq suggested would be to call `sentry.Flush` after the `sync` for example in source plugins. 

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
