### PR TITLE
fix: Revert "fix(codegen)!: Column type for slices (#447)"

### DIFF
--- a/codegen/table_test.go
+++ b/codegen/table_test.go
@@ -31,12 +31,8 @@ type (
 			IntCol    int    `json:"int_col,omitempty"`
 			StringCol string `json:"string_col,omitempty"`
 		}
-		IntArrayCol        []int  `json:"int_array_col,omitempty"`
-		IntPointerArrayCol []*int `json:"int_pointer_array_col,omitempty"`
-
-		StringArrayCol        []string  `json:"string_array_col,omitempty"`
-		StringPointerArrayCol []*string `json:"string_pointer_array_col,omitempty"`
-
+		IntArrayCol    []int      `json:"int_array_col,omitempty"`
+		StringArrayCol []string   `json:"string_array_col,omitempty"`
 		TimeCol        time.Time  `json:"time_col,omitempty"`
 		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
 		JSONTag        *string    `json:"json_tag"`
@@ -119,19 +115,9 @@ var (
 			Resolver: `schema.PathResolver("IntArrayCol")`,
 		},
 		{
-			Name:     "int_pointer_array_col",
-			Type:     schema.TypeIntArray,
-			Resolver: `schema.PathResolver("IntPointerArrayCol")`,
-		},
-		{
 			Name:     "string_array_col",
 			Type:     schema.TypeStringArray,
 			Resolver: `schema.PathResolver("StringArrayCol")`,
-		},
-		{
-			Name:     "string_pointer_array_col",
-			Type:     schema.TypeStringArray,
-			Resolver: `schema.PathResolver("StringPointerArrayCol")`,
 		},
 		{
 			Name:     "time_col",

--- a/codegen/transformers.go
+++ b/codegen/transformers.go
@@ -54,10 +54,11 @@ func defaultGoTypeToSchemaType(v reflect.Type) (schema.ValueType, error) {
 		}
 		return schema.TypeJSON, nil
 	case reflect.Slice:
-		switch elemValueType, _ := defaultGoTypeToSchemaType(v.Elem()); elemValueType {
-		case schema.TypeString:
+		switch v.Elem().Kind() {
+		case reflect.String:
 			return schema.TypeStringArray, nil
-		case schema.TypeInt:
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			return schema.TypeIntArray, nil
 		default:
 			return schema.TypeJSON, nil


### PR DESCRIPTION
This reverts commit 7474c90415119082bdb1cdb145bd16d1ef51a3b2.

#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Reverts https://github.com/cloudquery/plugin-sdk/pull/447 so we can ship that breaking change separately 

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
