### PR TITLE
fix: Initialise clients only once

### DIFF
--- a/plugins/source.go
+++ b/plugins/source.go
@@ -26,7 +26,7 @@ type SourcePlugin struct {
 	// Tables is all tables supported by this source plugin
 	tables schema.Tables
 	// status sync metrics
-	metrics SourceMetrics
+	metrics *SourceMetrics
 	// Logger to call, this logger is passed to the serve.Serve Client, if not defined Serve will create one instead.
 	logger zerolog.Logger
 	// resourceSem is a semaphore that limits the number of concurrent resources being fetched
@@ -88,7 +88,7 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 		version:            version,
 		tables:             tables,
 		newExecutionClient: newExecutionClient,
-		metrics:            SourceMetrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
+		metrics:            &SourceMetrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
 		caser:              caser.New(),
 	}
 	addInternalColumns(p.tables)
@@ -146,7 +146,7 @@ func (p *SourcePlugin) Version() string {
 	return p.version
 }
 
-func (p *SourcePlugin) Metrics() SourceMetrics {
+func (p *SourcePlugin) Metrics() *SourceMetrics {
 	return p.metrics
 }
 

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -96,7 +96,6 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 	if err := p.validate(); err != nil {
 		panic(err)
 	}
-	// p.metrics.initWithTables(p.tables)
 	p.maxDepth = maxDepth(p.tables)
 	if p.maxDepth > maxAllowedDepth {
 		panic(fmt.Errorf("max depth of tables is %d, max allowed is %d", p.maxDepth, maxAllowedDepth))
@@ -120,11 +119,10 @@ func (p *SourcePlugin) TablesForSpec(spec specs.Source) (schema.Tables, error) {
 	if err := spec.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
-	// tables, err := p.listAndValidateTables(spec.Tables, spec.SkipTables)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	tables := p.tables
+	tables, err := p.listAndValidateTables(spec.Tables, spec.SkipTables)
+	if err != nil {
+		return nil, err
+	}
 	// listAndValidateTables returns a flattened list - we only want to return
 	// the top-level tables from this function.
 	var topLevelTables schema.Tables

--- a/plugins/source.go
+++ b/plugins/source.go
@@ -96,7 +96,7 @@ func NewSourcePlugin(name string, version string, tables []*schema.Table, newExe
 	if err := p.validate(); err != nil {
 		panic(err)
 	}
-	p.metrics.initWithTables(p.tables)
+	// p.metrics.initWithTables(p.tables)
 	p.maxDepth = maxDepth(p.tables)
 	if p.maxDepth > maxAllowedDepth {
 		panic(fmt.Errorf("max depth of tables is %d, max allowed is %d", p.maxDepth, maxAllowedDepth))
@@ -120,10 +120,11 @@ func (p *SourcePlugin) TablesForSpec(spec specs.Source) (schema.Tables, error) {
 	if err := spec.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
-	tables, err := p.listAndValidateTables(spec.Tables, spec.SkipTables)
-	if err != nil {
-		return nil, err
-	}
+	// tables, err := p.listAndValidateTables(spec.Tables, spec.SkipTables)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	tables := p.tables
 	// listAndValidateTables returns a flattened list - we only want to return
 	// the top-level tables from this function.
 	var topLevelTables schema.Tables

--- a/plugins/source_metrics.go
+++ b/plugins/source_metrics.go
@@ -54,7 +54,7 @@ func (s *SourceMetrics) Equal(other *SourceMetrics) bool {
 }
 
 func (s *SourceMetrics) initWithTables(tables schema.Tables) {
-	s.TableClient = make(map[string]map[string]*TableClientMetrics)
+	s.TableClient = make(map[string]map[string]*TableClientMetrics, len(tables))
 	for _, table := range tables {
 		s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
 		s.initWithTables(table.Relations)
@@ -62,12 +62,12 @@ func (s *SourceMetrics) initWithTables(tables schema.Tables) {
 }
 
 func (s *SourceMetrics) initWithClients(table *schema.Table, clients []schema.ClientMeta) {
-	s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
+	s.TableClient[table.Name] = make(map[string]*TableClientMetrics, len(clients))
 	for _, client := range clients {
 		s.TableClient[table.Name][client.ID()] = &TableClientMetrics{}
-		for _, relation := range table.Relations {
-			s.initWithClients(relation, clients)
-		}
+	}
+	for _, relation := range table.Relations {
+		s.initWithClients(relation, clients)
 	}
 }
 

--- a/plugins/source_metrics.go
+++ b/plugins/source_metrics.go
@@ -53,14 +53,6 @@ func (s *SourceMetrics) Equal(other *SourceMetrics) bool {
 	return true
 }
 
-func (s *SourceMetrics) initWithTables(tables schema.Tables) {
-	s.TableClient = make(map[string]map[string]*TableClientMetrics, len(tables))
-	for _, table := range tables {
-		s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
-		s.initWithTables(table.Relations)
-	}
-}
-
 func (s *SourceMetrics) initWithClients(table *schema.Table, clients []schema.ClientMeta) {
 	s.TableClient[table.Name] = make(map[string]*TableClientMetrics, len(clients))
 	for _, client := range clients {

--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
@@ -94,12 +93,6 @@ func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables sc
 	}
 
 	tableMetrics := p.metrics.TableClient[table.Name][clientName]
-	if tableMetrics == nil {
-		fmt.Println(table.Name + " " + clientName)
-		fmt.Println(table.Name + " " + clientName)
-		fmt.Println(p.metrics.TableClient[table.Name])
-		os.Exit(3)
-	}
 	res := make(chan interface{})
 	go func() {
 		defer func() {
@@ -197,10 +190,6 @@ func (p *SourcePlugin) resolveResource(ctx context.Context, table *schema.Table,
 	objectStartTime := time.Now()
 	clientID := client.ID()
 	tableMetrics := p.metrics.TableClient[table.Name][clientID]
-	if tableMetrics == nil {
-		fmt.Println("table metrics is nil" + table.Name + " " + clientID)
-		os.Exit(1)
-	}
 	logger := p.logger.With().Str("table", table.Name).Str("client", clientID).Logger()
 	defer func() {
 		if err := recover(); err != nil {

--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -39,8 +39,8 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 
 	// we have this because plugins can return sometimes clients in a random way which will cause
 	// differences between this run and the next one.
-	preInitialisedClients := make([][]schema.ClientMeta, 0)
-	for _, table := range tables {
+	preInitialisedClients := make([][]schema.ClientMeta, len(tables))
+	for i, table := range tables {
 		if table.Parent != nil {
 			// skip descendent tables here - they are handled in initWithClients
 			continue
@@ -49,7 +49,7 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 		if table.Multiplex != nil {
 			clients = table.Multiplex(client)
 		}
-		preInitialisedClients = append(preInitialisedClients, clients)
+		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.
 		p.metrics.initWithClients(table, clients)
@@ -97,6 +97,7 @@ func (p *SourcePlugin) resolveTableDfs(ctx context.Context, allIncludedTables sc
 	if tableMetrics == nil {
 		fmt.Println(table.Name + " " + clientName)
 		fmt.Println(table.Name + " " + clientName)
+		fmt.Println(p.metrics.TableClient[table.Name])
 		os.Exit(3)
 	}
 	res := make(chan interface{})

--- a/plugins/source_scheduler_dfs.go
+++ b/plugins/source_scheduler_dfs.go
@@ -54,7 +54,6 @@ func (p *SourcePlugin) syncDfs(ctx context.Context, spec specs.Source, client sc
 		p.metrics.initWithClients(table, clients)
 	}
 
-
 	var wg sync.WaitGroup
 	for i, table := range tables {
 		if table.Parent != nil {

--- a/plugins/source_test.go
+++ b/plugins/source_test.go
@@ -314,7 +314,7 @@ func testSyncTable(t *testing.T, tc syncTestCase) {
 	}
 
 	stats := plugin.Metrics()
-	if !tc.stats.Equal(&stats) {
+	if !tc.stats.Equal(stats) {
 		t.Fatalf("unexpected stats: %v", cmp.Diff(tc.stats, stats))
 	}
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
This fix a panic that was caused if plugins misbehave and return difference results for difference runs with the same config.