### PR TITLE
feat: Add TableSet type

### DIFF
--- a/plugins/source_metrics.go
+++ b/plugins/source_metrics.go
@@ -53,21 +53,16 @@ func (s *SourceMetrics) Equal(other *SourceMetrics) bool {
 	return true
 }
 
-func (s *SourceMetrics) initWithTables(tables schema.Tables) {
-	s.TableClient = make(map[string]map[string]*TableClientMetrics)
-	for _, table := range tables {
-		s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
-		s.initWithTables(table.Relations)
-	}
-}
-
-func (s *SourceMetrics) initWithClients(table *schema.Table, clients []schema.ClientMeta) {
+func (s *SourceMetrics) initWithClients(table *schema.Table, selectedTables *schema.TableSet, clients []schema.ClientMeta) {
 	s.TableClient[table.Name] = make(map[string]*TableClientMetrics)
+	if !selectedTables.Contains(table.Name) {
+		return
+	}
 	for _, client := range clients {
 		s.TableClient[table.Name][client.ID()] = &TableClientMetrics{}
-		for _, relation := range table.Relations {
-			s.initWithClients(relation, clients)
-		}
+	}
+	for _, relation := range table.Relations {
+		s.initWithClients(relation, selectedTables, clients)
 	}
 }
 

--- a/plugins/source_validate.go
+++ b/plugins/source_validate.go
@@ -28,9 +28,8 @@ func (p *SourcePlugin) validate() error {
 }
 
 // listAndValidateTables returns all the tables matched by the `tables` and `skip_tables` config settings.
-// It will return ALL tables, including descendent tables. Callers should take care to only use the top-level
-// tables if that is what they need.
-func (p *SourcePlugin) listAndValidateTables(tables, skipTables []string) (schema.Tables, error) {
+// It returns a set of tables (both top-level and descendent) that should be included.
+func (p *SourcePlugin) listAndValidateTables(tables, skipTables []string) (*schema.TableSet, error) {
 	if len(tables) == 0 {
 		return nil, fmt.Errorf("list of tables is empty")
 	}
@@ -95,6 +94,5 @@ func (p *SourcePlugin) listAndValidateTables(tables, skipTables []string) (schem
 			return nil, fmt.Errorf("table %s is a descendant table and cannot be included without %s", t.Name, strings.Join(missingParents, ", "))
 		}
 	}
-
-	return remainingTables, nil
+	return schema.NewTableSet(remainingTables), nil
 }

--- a/plugins/source_validate_test.go
+++ b/plugins/source_validate_test.go
@@ -199,9 +199,14 @@ func TestSourcePlugin_listAndValidateAllResources(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
-			gotNames := make([]string, len(gotTables))
-			for i := range gotTables {
-				gotNames[i] = gotTables[i].Name
+			gotNames := make([]string, 0, gotTables.Size())
+			if gotTables.Size() != len(tt.want) {
+				t.Errorf("SourcePlugin.listAndValidateTables() returned %d tables, want %d", gotTables.Size(), len(tt.want))
+			}
+			for _, table := range tt.plugin.tables.FlattenTables() {
+				if gotTables.Contains(table.Name) {
+					gotNames = append(gotNames, table.Name)
+				}
 			}
 			if diff := cmp.Diff(gotNames, tt.want); diff != "" {
 				t.Errorf("SourcePlugin.listAndValidateTables() diff (+got, -want): %v", diff)

--- a/schema/table.go
+++ b/schema/table.go
@@ -66,13 +66,13 @@ var (
 )
 
 type TableSet struct {
-	tables map[string]bool
+	tables map[string]struct{}
 }
 
 func NewTableSet(tables Tables) *TableSet {
-	m := make(map[string]bool, len(tables))
+	m := make(map[string]struct{}, len(tables))
 	for _, t := range tables {
-		m[t.Name] = true
+		m[t.Name] = struct{}{}
 	}
 	return &TableSet{tables: m}
 }

--- a/schema/table.go
+++ b/schema/table.go
@@ -65,6 +65,33 @@ var (
 	reValidColumnName = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
 )
 
+type TableSet struct {
+	tables map[string]bool
+}
+
+func NewTableSet(tables Tables) *TableSet {
+	m := make(map[string]bool, len(tables))
+	for _, t := range tables {
+		m[t.Name] = true
+	}
+	return &TableSet{tables: m}
+}
+
+func (s *TableSet) Add(other *TableSet) {
+	for name, table := range other.tables {
+		s.tables[name] = table
+	}
+}
+
+func (s TableSet) Size() int {
+	return len(s.tables)
+}
+
+func (s TableSet) Contains(name string) bool {
+	_, ok := s.tables[name]
+	return ok
+}
+
 func (tt Tables) FlattenTables() Tables {
 	tables := make(Tables, 0, len(tt))
 	for _, t := range tt {

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -7,25 +7,8 @@ var testTable = &Table{
 	Columns: []Column{},
 	Relations: []*Table{
 		{
-			Name:    "test_sub",
+			Name:    "test2",
 			Columns: []Column{},
-		},
-	},
-}
-
-var testTable2 = &Table{
-	Name:    "test2",
-	Columns: []Column{},
-	Relations: []*Table{
-		{
-			Name:    "test2_sub",
-			Columns: []Column{},
-			Relations: []*Table{
-				{
-					Name:    "test2_sub_sub",
-					Columns: []Column{},
-				},
-			},
 		},
 	},
 }

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -7,8 +7,25 @@ var testTable = &Table{
 	Columns: []Column{},
 	Relations: []*Table{
 		{
-			Name:    "test2",
+			Name:    "test_sub",
 			Columns: []Column{},
+		},
+	},
+}
+
+var testTable2 = &Table{
+	Name:    "test2",
+	Columns: []Column{},
+	Relations: []*Table{
+		{
+			Name:    "test2_sub",
+			Columns: []Column{},
+			Relations: []*Table{
+				{
+					Name:    "test2_sub_sub",
+					Columns: []Column{},
+				},
+			},
 		},
 	},
 }


### PR DESCRIPTION
This implements the set idea from https://github.com/cloudquery/plugin-sdk/issues/470

It doesn't change any behavior, and doesn't fix the bug in `TableForSpec`. It's just for readability: `listAndValidateTables` now returns a set type which only supports a very limited set of operations. This set type is passed to `syncDfs` rather than a flattened list. `syncDfs` and its related functions must reference `p.tables` to traverse the tables, but can now check `selectedTables.Contains(table.Name)` to see whether a given table should be included or skipped. I think this makes the code quite a bit simpler (e.g. no more checks for whether a table is top-level or not) and less error-prone.