### PR TITLE
fix: Allow both 'yml' and 'yaml' extensions

### DIFF
--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -82,7 +82,8 @@ func (r *SpecReader) loadSpecsFromDir(path string) error {
 		return fmt.Errorf("failed to read directory %s: %w", path, err)
 	}
 	for _, file := range files {
-		if !file.IsDir() && !strings.HasPrefix(file.Name(), ".") && strings.HasSuffix(file.Name(), ".yml") {
+		if !file.IsDir() && !strings.HasPrefix(file.Name(), ".") &&
+			(strings.HasSuffix(file.Name(), ".yml") || strings.HasSuffix(file.Name(), ".yaml")) {
 			if err := r.loadSpecsFromFile(filepath.Join(path, file.Name())); err != nil {
 				return err
 			}

--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -31,6 +31,15 @@ var specLoaderTestCases = []specLoaderTestCase{
 		destinations: 2,
 	},
 	{
+		name: "success_yaml_extension",
+		path: []string{getPath("gcp.yml"), getPath("dir_yaml")},
+		err: func() string {
+			return ""
+		},
+		sources:      2,
+		destinations: 2,
+	},
+	{
 		name: "duplicate_source",
 		path: []string{getPath("gcp.yml"), getPath("gcp.yml")},
 		err: func() string {

--- a/specs/testdata/dir_yaml/aws.yaml
+++ b/specs/testdata/dir_yaml/aws.yaml
@@ -1,0 +1,8 @@
+kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v1.0.0
+  table_concurrency: 10
+  registry: local
+  destinations: [postgresql]

--- a/specs/testdata/dir_yaml/postgresql.yaml
+++ b/specs/testdata/dir_yaml/postgresql.yaml
@@ -1,0 +1,7 @@
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v1.0.0
+  registry: grpc
+  write_mode: overwrite


### PR DESCRIPTION
#### Summary

Fixes: https://github.com/cloudquery/cloudquery/issues/5502

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
