### PR TITLE
fix(sync): Extract error message from gRPC error

### DIFF
--- a/clients/errors.go
+++ b/clients/errors.go
@@ -20,3 +20,8 @@ func IsUnimplemented(err error) bool {
 	err = errors.Unwrap(err)
 	return IsUnimplemented(err)
 }
+
+func extractErrorMessage(err error) string {
+	st := status.Convert(err)
+	return st.Message()
+}

--- a/clients/source.go
+++ b/clients/source.go
@@ -277,7 +277,7 @@ func (c *SourceClient) Sync(ctx context.Context, spec specs.Source, res chan<- [
 		Spec: b,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to call Sync: %w", err)
+		return fmt.Errorf("failed to call Sync: %s", extractErrorMessage(err))
 	}
 	for {
 		r, err := stream.Recv()
@@ -285,7 +285,7 @@ func (c *SourceClient) Sync(ctx context.Context, spec specs.Source, res chan<- [
 			if err == io.EOF {
 				return nil
 			}
-			return fmt.Errorf("failed to fetch resources from stream: %w", err)
+			return errors.New(extractErrorMessage(err))
 		}
 		select {
 		case <-ctx.Done():
@@ -307,7 +307,7 @@ func (c *SourceClient) Sync2(ctx context.Context, spec specs.Source, res chan<- 
 		Spec: b,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to call Sync: %w", err)
+		return fmt.Errorf("failed to call Sync: %s", extractErrorMessage(err))
 	}
 	for {
 		r, err := stream.Recv()
@@ -315,7 +315,7 @@ func (c *SourceClient) Sync2(ctx context.Context, spec specs.Source, res chan<- 
 			if err == io.EOF {
 				return nil
 			}
-			return fmt.Errorf("failed to fetch resources from stream: %w", err)
+			return errors.New(extractErrorMessage(err))
 		}
 		select {
 		case <-ctx.Done():

--- a/serve/source_test.go
+++ b/serve/source_test.go
@@ -230,7 +230,7 @@ func TestSourceSuccess(t *testing.T) {
 	}
 }
 
-const testSourceFailExpectedErr = "failed to fetch resources from stream: rpc error: code = Unknown desc = failed to sync resources: failed to create execution client for source plugin testSourcePlugin: error in newTestExecutionClientErr"
+const testSourceFailExpectedErr = "failed to sync resources: failed to create execution client for source plugin testSourcePlugin: error in newTestExecutionClientErr"
 
 func TestSourceFail(t *testing.T) {
 	plugin := plugins.NewSourcePlugin(


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/cloudquery/issues/4707.
Errors returned from a gRPC call have both a status and a message. We don't really use the status, but when we wrap the error it always gets printed, see:
https://github.com/grpc/grpc-go/blob/eeb9afa1f6b6388152955eeca8926e36ca94c768/internal/status/status.go#L140

We can easily extract just the message and print only that.
Before:
```
Error: failed to sync source aws: failed to fetch resources from stream: rpc error: code = Unknown desc = failed to sync resources: failed to create execution client for source plugin aws: no enabled accounts instantiated
```
After:
```
Error: failed to sync source aws: failed to sync resources: failed to create execution client for source plugin aws: no enabled accounts instantiated
```

We should do this for all gRPC calls, but I'll do that in follow up PRs so I can test it

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
