### PR TITLE
feat: Add handling for json.Number in faker

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -67,6 +68,9 @@ func (f faker) getFakedValue(a interface{}) (reflect.Value, error) {
 			return v, nil
 		}
 	case reflect.String:
+		if t == reflect.TypeOf(json.Number("")) {
+			return reflect.ValueOf("123456789"), nil
+		}
 		return reflect.ValueOf("test string"), nil
 	case reflect.Slice:
 		switch t.String() {

--- a/faker/faker_test.go
+++ b/faker/faker_test.go
@@ -1,6 +1,7 @@
 package faker
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ type testFakerStruct struct {
 	C *string
 	D time.Time
 	E interface{}
+	F json.Number
 }
 
 func TestFaker(t *testing.T) {
@@ -25,7 +27,8 @@ func TestFaker(t *testing.T) {
 	assert.NotEmpty(t, a.B)
 	assert.NotEmpty(t, a.C)
 	assert.NotEmpty(t, a.D)
-	assert.Empty(t, a.E) // empty interfaces are not faked
+	assert.Empty(t, a.E)                           // empty interfaces are not faked
+	assert.Equal(t, json.Number("123456789"), a.F) // json numbers should be numbers
 }
 
 type customType string


### PR DESCRIPTION
When faking data, it is useful if `json.Number` is faked with a number, otherwise json marshalling fails later with `"test string" is not a number`. 