### PR TITLE
fix(errors): Remove usage of `codes.Internal`

### DIFF
--- a/internal/servers/source.go
+++ b/internal/servers/source.go
@@ -114,7 +114,7 @@ func (s *SourceServer) Sync2(req *pb.Sync2_Request, stream pb.Source_Sync2Server
 		destResource := resource.ToDestinationResource()
 		b, err := json.Marshal(destResource)
 		if err != nil {
-			return status.Errorf(codes.Internal, "failed to marshal resource: %v", err)
+			return status.Errorf(codes.InvalidArgument, "failed to marshal resource: %v", err)
 		}
 
 		msg := &pb.Sync2_Response{
@@ -128,7 +128,7 @@ func (s *SourceServer) Sync2(req *pb.Sync2_Request, stream pb.Source_Sync2Server
 			continue
 		}
 		if err := stream.Send(msg); err != nil {
-			return status.Errorf(codes.Internal, "failed to send resource: %v", err)
+			return fmt.Errorf("failed to send resource: %v", err)
 		}
 	}
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Related to https://github.com/cloudquery/plugin-sdk/issues/462 and also https://github.com/cloudquery/plugin-sdk/pull/477.
Two reasons for this change:
1. We shouldn't be using `codes.Internal` as it's generated internally by gRPC so we won't be able to distinguish between gRPC protocol errors and application level errors, see https://github.com/grpc/grpc-go/blob/eeb9afa1f6b6388152955eeca8926e36ca94c768/codes/codes.go#L166.
2. We don't really do anything with the code at the moment, it's only printed in a confusing way (see https://github.com/cloudquery/plugin-sdk/pull/477)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
