### PR TITLE
fix(destinations): Set correct status code for context errors

### DIFF
--- a/internal/servers/destinations.go
+++ b/internal/servers/destinations.go
@@ -115,11 +115,7 @@ func (s *DestinationServer) Write2(msg pb.Destination_Write2Server) error {
 			if err := eg.Wait(); err != nil {
 				s.Logger.Error().Err(err).Msg("failed to wait")
 			}
-			st := status.FromContextError(ctx.Err())
-			if st == nil {
-				return nil
-			}
-			return st.Err()
+			return status.FromContextError(ctx.Err()).Err()
 		}
 	}
 }

--- a/internal/servers/destinations.go
+++ b/internal/servers/destinations.go
@@ -115,7 +115,11 @@ func (s *DestinationServer) Write2(msg pb.Destination_Write2Server) error {
 			if err := eg.Wait(); err != nil {
 				s.Logger.Error().Err(err).Msg("failed to wait")
 			}
-			return ctx.Err()
+			st := status.FromContextError(ctx.Err())
+			if st == nil {
+				return nil
+			}
+			return st.Err()
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


This ensures relevant status code (`codes.DeadlineExceeded` or `codes.Canceled`) is set for the gRPC error.
Without this fix the status will always be `codes.Unknown`.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
