### PR TITLE
fix: Reduce default concurrency

### DIFF
--- a/specs/source.go
+++ b/specs/source.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultConcurrency = 1000000
+	defaultConcurrency = 500000
 )
 
 // Source is the spec for a source plugin


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


When plugins have many tables, like the new Azure plugin we quickly run into memory issues with the current default.
This works on my machine ™️ with the new Azure plugin

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
