### PR TITLE
fix: Improve formatting of newlines in markdown files

### DIFF
--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-README.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-README.md
@@ -1,5 +1,7 @@
 # Source Plugin: test
+
 ## Tables
+
 - [test_table](test_table.md)
   - [relation_table](relation_table.md)
     - [relation_relation_table](relation_relation_table.md)

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table.md
@@ -5,10 +5,11 @@ Description for relational table's relation
 The primary key for this table is **_cq_id**.
 
 ## Relations
+
 This table depends on [relation_table](relation_table.md).
 
-
 ## Columns
+
 | Name          | Type          |
 | ------------- | ------------- |
 |_cq_source_name|String|

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_table.md
@@ -5,12 +5,14 @@ Description for relational table
 The primary key for this table is **_cq_id**.
 
 ## Relations
+
 This table depends on [test_table](test_table.md).
 
 The following tables depend on relation_table:
   - [relation_relation_table](relation_relation_table.md)
 
 ## Columns
+
 | Name          | Type          |
 | ------------- | ------------- |
 |_cq_source_name|String|

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-test_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-test_table.md
@@ -11,6 +11,7 @@ The following tables depend on test_table:
   - [relation_table2](relation_table2.md)
 
 ## Columns
+
 | Name          | Type          |
 | ------------- | ------------- |
 |_cq_source_name|String|

--- a/plugins/source/docs.go
+++ b/plugins/source/docs.go
@@ -1,11 +1,13 @@
 package source
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -15,6 +17,9 @@ import (
 
 //go:embed templates/*.go.tpl
 var templatesFS embed.FS
+
+var reMatchNewlines = regexp.MustCompile(`\n{3,}`)
+var reMatchHeaders = regexp.MustCompile(`(#{1,6}.+)\n+`)
 
 // GeneratePluginDocs creates table documentation for the source plugin based on its list of tables
 func (p *Plugin) GeneratePluginDocs(dir, format string) error {
@@ -91,15 +96,17 @@ func (p *Plugin) renderTablesAsMarkdown(dir string) error {
 		return fmt.Errorf("failed to parse template for README.md: %v", err)
 	}
 
+	var b bytes.Buffer
+	if err := t.Execute(&b, p); err != nil {
+		return fmt.Errorf("failed to execute template: %v", err)
+	}
+	content := formatMarkdown(b.String())
 	outputPath := filepath.Join(dir, "README.md")
 	f, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %v: %v", outputPath, err)
 	}
-	defer f.Close()
-	if err := t.Execute(f, p); err != nil {
-		return fmt.Errorf("failed to execute template: %v", err)
-	}
+	f.WriteString(content)
 	return nil
 }
 
@@ -125,15 +132,23 @@ func renderTable(table *schema.Table, dir string) error {
 	}
 
 	outputPath := filepath.Join(dir, fmt.Sprintf("%s.md", table.Name))
+
+	var b bytes.Buffer
+	if err := t.Execute(&b, table); err != nil {
+		return fmt.Errorf("failed to execute template: %v", err)
+	}
+	content := formatMarkdown(b.String())
 	f, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %v: %v", outputPath, err)
 	}
-	defer f.Close()
-	if err := t.Execute(f, table); err != nil {
-		return fmt.Errorf("failed to execute template: %v", err)
-	}
-	return nil
+	f.WriteString(content)
+	return f.Close()
+}
+
+func formatMarkdown(s string) string {
+	s = reMatchNewlines.ReplaceAllString(s, "\n\n")
+	return reMatchHeaders.ReplaceAllString(s, `$1`+"\n\n")
 }
 
 func formatType(v schema.ValueType) string {


### PR DESCRIPTION
This neatens the newlines rendered for table docs, so we can no longer get multiple newlines in a row, like here: https://github.com/cloudquery/cloudquery/pull/5547/files#diff-7a51ae50d93ba1ae94ee3a2e3ff898ae0224a0a1cc32cafe0c667ff46cf080e6R1-R8

Closes https://github.com/cloudquery/plugin-sdk/issues/454