### PR TITLE
fix: Glob table filtering

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -95,7 +95,7 @@ func (tt Tables) FilterDfs(tables, skipTables []string) (Tables, error) {
 	filteredTables := make(Tables, 0, len(tt))
 	for _, t := range tt {
 		filteredTable := t.Copy(nil)
-		filteredTable = filteredTable.filterDfs(tables, skipTables)
+		filteredTable = filteredTable.filterDfs(false, tables, skipTables)
 		if filteredTable != nil {
 			filteredTables = append(filteredTables, filteredTable)
 		}
@@ -189,8 +189,8 @@ func (tt Tables) ValidateColumnNames() error {
 }
 
 // this will filter the tree in-place
-func (t *Table) filterDfs(tables, skipTables []string) *Table {
-	var matched bool
+func (t *Table) filterDfs(parentMatched bool, tables []string, skipTables []string) *Table {
+	matched := parentMatched
 	for _, includeTable := range tables {
 		if glob.Glob(includeTable, t.Name) {
 			matched = true
@@ -204,7 +204,7 @@ func (t *Table) filterDfs(tables, skipTables []string) *Table {
 	}
 	filteredRelations := make([]*Table, 0, len(t.Relations))
 	for _, r := range t.Relations {
-		filteredChild := r.filterDfs(tables, skipTables)
+		filteredChild := r.filterDfs(matched, tables, skipTables)
 		if filteredChild != nil {
 			matched = true
 			filteredRelations = append(filteredRelations, r)

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -63,7 +63,7 @@ func TestTablesFilterDFS(t *testing.T) {
 					},
 				},
 			},
-			configurationTables:     []string{"sub_sub_table"},
+			configurationTables:     []string{"main_table"},
 			configurationSkipTables: []string{},
 			want:                    []string{"main_table", "sub_table", "sub_sub_table"},
 		},

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -184,8 +184,11 @@ func TestTablesFilterDFS(t *testing.T) {
 			err:                     "tables include a pattern main_table1 with no matches",
 		},
 		{
-			name:                    "should return child tables unless skipped if parent table is specified",
-			tables:                  []*Table{{Name: "main_table", Relations: []*Table{{Name: "sub_table_1", Parent: &Table{Name: "main_table"}}, {Name: "sub_table_2", Parent: &Table{Name: "main_table"}}}}},
+			name:                    "skip child table but return sibilings",
+			tables:                  []*Table{
+				{Name: "main_table", Relations: []*Table{
+					{Name: "sub_table_1", Parent: &Table{Name: "main_table"}},
+					{Name: "sub_table_2", Parent: &Table{Name: "main_table"}}}}},
 			configurationTables:     []string{"main_table"},
 			configurationSkipTables: []string{"sub_table_2"},
 			want:                    []string{"main_table", "sub_table_1"},

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -184,8 +184,8 @@ func TestTablesFilterDFS(t *testing.T) {
 			err:                     "tables include a pattern main_table1 with no matches",
 		},
 		{
-			name:                    "skip child table but return siblings",
-			tables:                  []*Table{
+			name: "skip child table but return siblings",
+			tables: []*Table{
 				{Name: "main_table", Relations: []*Table{
 					{Name: "sub_table_1", Parent: &Table{Name: "main_table"}},
 					{Name: "sub_table_2", Parent: &Table{Name: "main_table"}}}}},

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -183,6 +183,13 @@ func TestTablesFilterDFS(t *testing.T) {
 			want:                    []string{},
 			err:                     "tables include a pattern main_table1 with no matches",
 		},
+		{
+			name:                    "should return child tables unless skipped if parent table is specified",
+			tables:                  []*Table{{Name: "main_table", Relations: []*Table{{Name: "sub_table_1", Parent: &Table{Name: "main_table"}}, {Name: "sub_table_2", Parent: &Table{Name: "main_table"}}}}},
+			configurationTables:     []string{"main_table"},
+			configurationSkipTables: []string{"sub_table_2"},
+			want:                    []string{"main_table", "sub_table_1"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -184,7 +184,7 @@ func TestTablesFilterDFS(t *testing.T) {
 			err:                     "tables include a pattern main_table1 with no matches",
 		},
 		{
-			name:                    "skip child table but return sibilings",
+			name:                    "skip child table but return siblings",
 			tables:                  []*Table{
 				{Name: "main_table", Relations: []*Table{
 					{Name: "sub_table_1", Parent: &Table{Name: "main_table"}},


### PR DESCRIPTION
If parent is selected all child selected as well unless explicitly skipped.

