### PR TITLE
fix(codegen): Preserve PK column order with `codegen.WithPKColumns` option

### DIFF
--- a/codegen/column.go
+++ b/codegen/column.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/cloudquery/plugin-sdk/schema"
+	"golang.org/x/exp/slices"
 )
 
 type (
@@ -77,5 +78,53 @@ func (t *TableDefinition) addColumnFromField(field reflect.StructField, parent *
 			Resolver: resolver,
 		},
 	)
+	return nil
+}
+
+func (t *TableDefinition) pkOrder() error {
+	if len(t.pkColumns) == 0 {
+		// no need for extra work
+		return nil
+	}
+
+	// check for dups
+	pkColumns := slices.Clone(t.pkColumns)
+	slices.Sort(pkColumns)
+	pkColumns = slices.Compact(pkColumns)
+	if len(pkColumns) != len(t.pkColumns) {
+		return fmt.Errorf("%s table definition has %d duplicate PK columns", t.Name, len(t.pkColumns)-len(pkColumns))
+	}
+
+	// Add PK columns first in the order they were specified
+	columns := slices.Clone(t.Columns)
+	t.Columns = make(ColumnDefinitions, 0, len(t.Columns)) // reset
+	for _, name := range t.pkColumns {
+		idx := slices.IndexFunc(columns,
+			func(def ColumnDefinition) bool {
+				return def.Name == name
+			},
+		)
+		if idx < 0 {
+			return fmt.Errorf("%s table definition missing %q column required for PK", t.Name, name)
+		}
+
+		col := columns[idx]
+		col.Options.PrimaryKey = true
+		t.Columns = append(t.Columns, col)
+		columns = slices.Delete(columns, idx, idx+1)
+	}
+
+	// If we got here, all t.pkColumns have been processed and there are no duplicates
+	// Now we need to take all remaining PKs
+	var rest ColumnDefinitions
+	for _, col := range columns {
+		if col.Options.PrimaryKey {
+			t.Columns = append(t.Columns, col)
+		} else {
+			rest = append(rest, col)
+		}
+	}
+
+	t.Columns = append(t.Columns, rest...)
 	return nil
 }

--- a/codegen/options.go
+++ b/codegen/options.go
@@ -23,12 +23,7 @@ func WithExtraColumns(columns ColumnDefinitions) TableOption {
 // WithPKColumns allows to specify what columns should be considered PKs without need for WithExtraColumns + WithSkipFields
 func WithPKColumns(columnNames ...string) TableOption {
 	return func(t *TableDefinition) {
-		if t.extraPKColumns == nil {
-			t.extraPKColumns = make(map[string]struct{}, len(columnNames))
-		}
-		for _, name := range columnNames {
-			t.extraPKColumns[name] = struct{}{}
-		}
+		t.pkColumns = append(t.pkColumns, columnNames...)
 	}
 }
 


### PR DESCRIPTION
#### Summary

If we have a struct
```go
type A struct {
	A int
	B int
}
```
and use `codegen.WithPKColumns("b", "a")`, the resulting PK should be `(b, a)`.
However, prior to this fix it'd be `(a, b)`.

Additionally, if we have a struct
```go
type A struct {
	A int
	B int
	C int
}
```
and use the following options together:
* `codegen.WithPKColumns("c", "a")`
* `codegen.SkipFields([]string{"B"}`
* `codegen.WithExtraColumns(ColumnDefinitions{{Name:"b", …, Options: PK}})`
the resulting PK should be `(c, a, b)`.
However, prior to this fix it'd be `(a, b, c)`.
---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
