### PR TITLE
chore(ci): Upgrade golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.50.1
           args: --verbose


### PR DESCRIPTION
I think this should fix the `interface{}/any` check