### PR TITLE
fix: Codegen: Add Recursive Embedded Struct Unwrapping

### DIFF
--- a/codegen/options.go
+++ b/codegen/options.go
@@ -46,6 +46,15 @@ func WithUnwrapAllEmbeddedStructs() TableOption {
 	}
 }
 
+// WithUnwrapAllEmbeddedStructFieldsRecursively instructs codegen to unwrap all embedded fields recursively
+// Use with caution.
+func WithUnwrapAllEmbeddedStructFieldsRecursively() TableOption {
+	return func(t *TableDefinition) {
+		t.unwrapAllEmbeddedStructFieldsRecursively = true
+		t.unwrapAllEmbeddedStructFields = true
+	}
+}
+
 // WithLogger allows passing custom logger
 func WithLogger(logger zerolog.Logger) TableOption {
 	return func(t *TableDefinition) {

--- a/codegen/table.go
+++ b/codegen/table.go
@@ -37,7 +37,8 @@ type (
 		skipFields           []string
 		structFieldsToUnwrap []string
 
-		unwrapAllEmbeddedStructFields bool
+		unwrapAllEmbeddedStructFields            bool
+		unwrapAllEmbeddedStructFieldsRecursively bool
 
 		logger zerolog.Logger
 	}

--- a/codegen/unwrap.go
+++ b/codegen/unwrap.go
@@ -48,6 +48,13 @@ func (t *TableDefinition) unwrapField(field reflect.StructField) error {
 		parent = &field
 	}
 	for _, f := range unwrappedFields {
+		if isFieldStruct(f.Type) && f.Anonymous && t.unwrapAllEmbeddedStructFieldsRecursively {
+			if err := t.unwrapField(f); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if err := t.addColumnFromField(f, parent); err != nil {
 			return fmt.Errorf("failed to add column from field %s: %w", f.Name, err)
 		}


### PR DESCRIPTION
Depended on by https://github.com/cloudquery/cloudquery/pull/5901

Required, because for IncidentLogEntries, the primary-key (`id`) is twice-embedded:

https://github.com/PagerDuty/go-pagerduty/blob/b6aa0d76f875e1de499b2a246c82882f022a0f8a/log_entry.go#L43
https://github.com/PagerDuty/go-pagerduty/blob/b6aa0d76f875e1de499b2a246c82882f022a0f8a/log_entry.go#L30
https://github.com/PagerDuty/go-pagerduty/blob/b6aa0d76f875e1de499b2a246c82882f022a0f8a/client.go#L49
