### PR TITLE
fix(destinations): Set done even if no resources to flush

### DIFF
--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -75,8 +75,8 @@ func (p *Plugin) worker(ctx context.Context, metrics *Metrics, table *schema.Tab
 					atomic.AddUint64(&metrics.Writes, uint64(len(resources)))
 				}
 				resources = make([][]any, 0)
-				done <- true
 			}
+			done <- true
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/cloudquery/issues/6070. This fixes a deadlock in the managed writer when we wait for the flush to finish indefinitely.
The cause is that the resources can already be flushed by another case in the switch, so there might not be resources to flush when we hit the flush case.
The fix is to always pass `done` to the channel 

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
