### PR TITLE
feat(destinations): Add BatchSize method to ManagedWriter interface

### DIFF
--- a/internal/memdb/memdb.go
+++ b/internal/memdb/memdb.go
@@ -165,6 +165,10 @@ func (c *client) WriteTableBatch(ctx context.Context, table *schema.Table, resou
 	return nil
 }
 
+func (*client) BatchSize() int {
+	return 100
+}
+
 func (*client) Metrics() destination.Metrics {
 	return destination.Metrics{}
 }

--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -23,6 +23,7 @@ type NewClientFunc func(context.Context, zerolog.Logger, specs.Destination) (Cli
 
 type ManagedWriter interface {
 	WriteTableBatch(ctx context.Context, table *schema.Table, data [][]any) error
+	BatchSize() int
 }
 
 type UnimplementedManagedWriter struct{}
@@ -36,6 +37,10 @@ type UnimplementedUnmanagedWriter struct{}
 
 func (*UnimplementedManagedWriter) WriteTableBatch(context.Context, *schema.Table, [][]any) error {
 	panic("WriteTableBatch not implemented")
+}
+
+func (*UnimplementedManagedWriter) BatchSize() int {
+	panic("BatchSize not implemented")
 }
 
 func (*UnimplementedUnmanagedWriter) Write(context.Context, schema.Tables, <-chan *ClientResource) error {

--- a/specs/destination.go
+++ b/specs/destination.go
@@ -17,7 +17,6 @@ type Destination struct {
 	Path      string    `json:"path,omitempty"`
 	Registry  Registry  `json:"registry,omitempty"`
 	WriteMode WriteMode `json:"write_mode,omitempty"`
-	BatchSize int       `json:"batch_size,omitempty"`
 	Spec      any       `json:"spec,omitempty"`
 }
 
@@ -27,8 +26,6 @@ const (
 	WriteModeAppend
 )
 
-const defaultBatchSize = 10000
-
 var (
 	writeModeStrings = []string{"overwrite-delete-stale", "overwrite", "append"}
 )
@@ -36,9 +33,6 @@ var (
 func (d *Destination) SetDefaults() {
 	if d.Registry.String() == "" {
 		d.Registry = RegistryGithub
-	}
-	if d.BatchSize == 0 {
-		d.BatchSize = defaultBatchSize
 	}
 }
 
@@ -74,9 +68,6 @@ func (d *Destination) Validate() error {
 		if !strings.HasPrefix(d.Version, "v") {
 			return fmt.Errorf("version must start with v")
 		}
-	}
-	if d.BatchSize < 0 {
-		return fmt.Errorf("batch_size must be greater than 0")
 	}
 	return nil
 }

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -144,10 +144,9 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryGrpc,
-			Path:      "localhost:9999",
-			BatchSize: defaultBatchSize,
+			Name:     "test",
+			Registry: RegistryGrpc,
+			Path:     "localhost:9999",
 		},
 	},
 	{
@@ -160,10 +159,9 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryLocal,
-			Path:      "/home/user/some_executable",
-			BatchSize: 10000,
+			Name:     "test",
+			Registry: RegistryLocal,
+			Path:     "/home/user/some_executable",
 		},
 	},
 	{
@@ -176,11 +174,10 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryGithub,
-			Path:      "cloudquery/test",
-			Version:   "v1.1.0",
-			BatchSize: 10000,
+			Name:     "test",
+			Registry: RegistryGithub,
+			Path:     "cloudquery/test",
+			Version:  "v1.1.0",
 		},
 	},
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Batch size should be configured at the plugin level spec (see https://www.cloudquery.io/docs/plugins/destinations/bigquery/overview#bigquery-spec).
This PR adds a `BatchSize` interface method to be called by the managed writer.

This can't be done via a plugin option, as we read the plugin spec after the plugin is created (options are passed on creation)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
