### PR TITLE
feat(destinations): Allow plugins to set default batch size

### DIFF
--- a/specs/destination.go
+++ b/specs/destination.go
@@ -27,13 +27,11 @@ const (
 	WriteModeAppend
 )
 
-const defaultBatchSize = 10000
-
 var (
 	writeModeStrings = []string{"overwrite-delete-stale", "overwrite", "append"}
 )
 
-func (d *Destination) SetDefaults() {
+func (d *Destination) SetDefaults(defaultBatchSize int) {
 	if d.Registry.String() == "" {
 		d.Registry = RegistryGithub
 	}

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -147,7 +147,7 @@ spec:
 			Name:      "test",
 			Registry:  RegistryGrpc,
 			Path:      "localhost:9999",
-			BatchSize: defaultBatchSize,
+			BatchSize: 10000,
 		},
 	},
 	{
@@ -195,7 +195,7 @@ func TestDestinationUnmarshalSpecValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			destination := spec.Spec.(*Destination)
-			destination.SetDefaults()
+			destination.SetDefaults(10000)
 			err = destination.Validate()
 			if err != nil {
 				if err.Error() != tc.err {

--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -84,7 +84,8 @@ func (r *SpecReader) loadSpecsFromFile(path string) error {
 			if r.Destinations[destination.Name] != nil {
 				return fmt.Errorf("duplicate destination name %s", destination.Name)
 			}
-			destination.SetDefaults()
+			// We set the default value to 0 so it can be overridden later by plugins' defaults
+			destination.SetDefaults(0)
 			if err := destination.Validate(); err != nil {
 				return fmt.Errorf("failed to validate destination %s: %w", destination.Name, err)
 			}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Replaces https://github.com/cloudquery/plugin-sdk/pull/539. Keeps batch size on the top level spec, but allows plugins to override it

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
