### PR TITLE
feat: Add unwrap option to transformations

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -10,10 +10,12 @@ import (
 )
 
 type structTransformer struct {
-	table           *schema.Table
-	skipFields      []string
-	nameTransformer NameTransformer
-	typeTransformer TypeTransformer
+	table                         *schema.Table
+	skipFields                    []string
+	nameTransformer               NameTransformer
+	typeTransformer               TypeTransformer
+	unwrapAllEmbeddedStructFields bool
+	structFieldsToUnwrap          []string
 }
 
 type NameTransformer func(reflect.StructField) (string, error)
@@ -21,6 +23,31 @@ type NameTransformer func(reflect.StructField) (string, error)
 type TypeTransformer func(reflect.StructField) (schema.ValueType, error)
 
 type StructTransformerOption func(*structTransformer)
+
+func isFieldStruct(reflectType reflect.Type) bool {
+	switch reflectType.Kind() {
+	case reflect.Struct:
+		return true
+	case reflect.Ptr:
+		return reflectType.Elem().Kind() == reflect.Struct
+	default:
+		return false
+	}
+}
+
+// WithUnwrapAllEmbeddedStructs instructs codegen to unwrap all embedded fields (1 level deep only)
+func WithUnwrapAllEmbeddedStructs() StructTransformerOption {
+	return func(t *structTransformer) {
+		t.unwrapAllEmbeddedStructFields = true
+	}
+}
+
+// WithUnwrapStructFields allows to unwrap specific struct fields (1 level deep only)
+func WithUnwrapStructFields(fields ...string) StructTransformerOption {
+	return func(t *structTransformer) {
+		t.structFieldsToUnwrap = fields
+	}
+}
 
 // WithSkipFields allows to specify what struct fields should be skipped.
 func WithSkipFields(fields ...string) StructTransformerOption {
@@ -34,14 +61,6 @@ func WithSkipFields(fields ...string) StructTransformerOption {
 func WithNameTransformer(transformer NameTransformer) StructTransformerOption {
 	return func(t *structTransformer) {
 		t.nameTransformer = transformer
-	}
-}
-
-// WithTypeTransformer sets a function that can override the schema type for specific fields. Return `schema.TypeInvalid` to fall back to default behavior.
-// DefaultTypeTransformer is used as the default.
-func WithTypeTransformer(transformer TypeTransformer) StructTransformerOption {
-	return func(t *structTransformer) {
-		t.typeTransformer = transformer
 	}
 }
 
@@ -70,11 +89,66 @@ func TransformWithStruct(st any, opts ...StructTransformerOption) schema.Transfo
 		for i := 0; i < e.NumField(); i++ {
 			field := eType.Field(i)
 
-			if err := t.addColumnFromField(field, nil); err != nil {
-				return fmt.Errorf("failed to add column for field %s: %w", field.Name, err)
+			switch {
+			case t.shouldUnwrapField(field):
+				if err := t.unwrapField(field); err != nil {
+					return err
+				}
+			default:
+				if err := t.addColumnFromField(field, nil); err != nil {
+					return fmt.Errorf("failed to add column for field %s: %w", field.Name, err)
+				}
 			}
 		}
 		return nil
+	}
+}
+
+func (t *structTransformer) getUnwrappedFields(field reflect.StructField) []reflect.StructField {
+	reflectType := field.Type
+	if reflectType.Kind() == reflect.Ptr {
+		reflectType = reflectType.Elem()
+	}
+
+	fields := make([]reflect.StructField, 0)
+	for i := 0; i < reflectType.NumField(); i++ {
+		sf := reflectType.Field(i)
+		if t.ignoreField(sf) {
+			continue
+		}
+
+		fields = append(fields, sf)
+	}
+	return fields
+}
+
+func (t *structTransformer) unwrapField(field reflect.StructField) error {
+	unwrappedFields := t.getUnwrappedFields(field)
+	var parent *reflect.StructField
+	// For non embedded structs we need to add the parent field name to the path
+	if !field.Anonymous {
+		parent = &field
+	}
+	for _, f := range unwrappedFields {
+		if err := t.addColumnFromField(f, parent); err != nil {
+			return fmt.Errorf("failed to add column from field %s: %w", f.Name, err)
+		}
+	}
+	return nil
+}
+
+func (t *structTransformer) shouldUnwrapField(field reflect.StructField) bool {
+	switch {
+	case !isFieldStruct(field.Type):
+		return false
+	case slices.Contains(t.structFieldsToUnwrap, field.Name):
+		return true
+	case !field.Anonymous:
+		return false
+	case t.unwrapAllEmbeddedStructFields:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -1,0 +1,233 @@
+package transformers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloudquery/plugin-sdk/schema"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type (
+	embeddedStruct struct {
+		EmbeddedString string
+	}
+
+	testStruct struct {
+		// IntCol this is an example documentation comment
+		IntCol    int     `json:"int_col,omitempty"`
+		Int64Col  int64   `json:"int64_col,omitempty"`
+		StringCol string  `json:"string_col,omitempty"`
+		FloatCol  float64 `json:"float_col,omitempty"`
+		BoolCol   bool    `json:"bool_col,omitempty"`
+		JSONCol   struct {
+			IntCol    int    `json:"int_col,omitempty"`
+			StringCol string `json:"string_col,omitempty"`
+		}
+		IntArrayCol        []int  `json:"int_array_col,omitempty"`
+		IntPointerArrayCol []*int `json:"int_pointer_array_col,omitempty"`
+
+		StringArrayCol        []string  `json:"string_array_col,omitempty"`
+		StringPointerArrayCol []*string `json:"string_pointer_array_col,omitempty"`
+
+		TimeCol        time.Time  `json:"time_col,omitempty"`
+		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
+		JSONTag        *string    `json:"json_tag"`
+		SkipJSONTag    *string    `json:"-"`
+		NoJSONTag      *string
+		*embeddedStruct
+	}
+	testStructWithEmbeddedStruct struct {
+		*testStruct
+		*embeddedStruct
+	}
+	testStructWithNonEmbeddedStruct struct {
+		TestStruct  *testStruct
+		NonEmbedded *embeddedStruct
+	}
+
+	testSliceStruct []struct {
+		IntCol int
+	}
+)
+
+var (
+	expectedColumns = []schema.Column{
+		{
+			Name: "int_col",
+			Type: schema.TypeInt,
+		},
+		{
+			Name: "int64_col",
+			Type: schema.TypeInt,
+		},
+		{
+			Name: "string_col",
+			Type: schema.TypeString,
+		},
+		{
+			Name: "float_col",
+			Type: schema.TypeFloat,
+		},
+		{
+			Name: "bool_col",
+			Type: schema.TypeBool,
+		},
+		{
+			Name: "json_col",
+			Type: schema.TypeJSON,
+		},
+		{
+			Name: "int_array_col",
+			Type: schema.TypeIntArray,
+		},
+		{
+			Name: "int_pointer_array_col",
+			Type: schema.TypeIntArray,
+		},
+		{
+			Name: "string_array_col",
+			Type: schema.TypeStringArray,
+		},
+		{
+			Name: "string_pointer_array_col",
+			Type: schema.TypeStringArray,
+		},
+		{
+			Name: "time_col",
+			Type: schema.TypeTimestamp,
+		},
+		{
+			Name: "time_pointer_col",
+			Type: schema.TypeTimestamp,
+		},
+		{
+			Name: "json_tag",
+			Type: schema.TypeString,
+		},
+		{
+			Name: "no_json_tag",
+			Type: schema.TypeString,
+		},
+	}
+	expectedTestTable = schema.Table{
+		Name:    "test_struct",
+		Columns: expectedColumns,
+	}
+	expectedTestTableEmbeddedStruct = schema.Table{
+		Name: "test_struct",
+		Columns: append(
+			expectedColumns, schema.Column{
+				Name: "embedded_string",
+				Type: schema.TypeString,
+			}),
+	}
+	expectedTestTableNonEmbeddedStruct = schema.Table{
+		Name: "test_struct",
+		Columns: schema.ColumnList{
+			// Should not be unwrapped
+			schema.Column{Name: "test_struct", Type: schema.TypeJSON},
+			// Should be unwrapped
+			schema.Column{
+				Name: "non_embedded_embedded_string",
+				Type: schema.TypeString,
+			},
+		},
+	}
+	expectedTestTableStructForCustomResolvers = schema.Table{
+		Name: "test_struct",
+		Columns: schema.ColumnList{
+			{
+				Name: "time_col",
+				Type: schema.TypeTimestamp,
+			},
+			{
+				Name: "custom",
+				Type: schema.TypeTimestamp,
+			},
+		},
+	}
+	expectedTestSliceStruct = schema.Table{
+		Name: "test_struct",
+		Columns: schema.ColumnList{
+			{
+				Name: "int_col",
+				Type: schema.TypeInt,
+			},
+		},
+	}
+)
+
+func TestTableFromGoStruct(t *testing.T) {
+	type args struct {
+		testStruct any
+		options    []StructTransformerOption
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    schema.Table
+		wantErr bool
+	}{
+		{
+			name: "should generate table from struct with default options",
+			args: args{
+				testStruct: testStruct{},
+			},
+			want: expectedTestTable,
+		},
+		{
+			name: "should unwrap all embedded structs when option is set",
+			args: args{
+				testStruct: testStructWithEmbeddedStruct{},
+				options: []StructTransformerOption{
+					WithUnwrapAllEmbeddedStructs(),
+				},
+			},
+			want: expectedTestTableEmbeddedStruct,
+		},
+		{
+			name: "should unwrap specific structs when option is set",
+			args: args{
+				testStruct: testStructWithNonEmbeddedStruct{},
+				options: []StructTransformerOption{
+					WithUnwrapStructFields("NonEmbedded"),
+				},
+			},
+			want: expectedTestTableNonEmbeddedStruct,
+		},
+		{
+			name: "should generate table from slice struct",
+			args: args{
+				testStruct: testSliceStruct{},
+			},
+			want: expectedTestSliceStruct,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := schema.Table{
+				Name:    "test",
+				Columns: schema.ColumnList{},
+			}
+			transformer := TransformWithStruct(tt.args.testStruct, tt.args.options...)
+			if err := transformer(&table); err != nil {
+				t.Fatal(err)
+			}
+			// table, err := NewTableFromStruct("test_struct", tt.args.testStruct, tt.args.options...)
+			// if (err != nil) != tt.wantErr {
+			// 	t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			// }
+			// if tt.wantErr {
+			// 	return
+			// }
+			if diff := cmp.Diff(table.Columns, tt.want.Columns,
+				cmpopts.IgnoreFields(schema.Column{}, "Resolver")); diff != "" {
+				t.Fatalf("table does not match expected. diff (-got, +want): %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up on transformation. Adding unwrap option as needed in some cases where we create our own wrapper struct.

This also moves the tests from codegen.