### PR TITLE
feat: Add WithResolverTransformer

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -25,7 +25,7 @@ type TypeTransformer func(reflect.StructField) (schema.ValueType, error)
 
 type ResolverTransformer func(field reflect.StructField, path string) schema.ColumnResolver
 
-func DefaultResolverTransformer(field reflect.StructField, path string) schema.ColumnResolver {
+func DefaultResolverTransformer(_ reflect.StructField, path string) schema.ColumnResolver {
 	return schema.PathResolver(path)
 }
 

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -91,7 +91,7 @@ func WithTypeTransformer(transformer TypeTransformer) StructTransformerOption {
 func WithResolverTransformer(transformer ResolverTransformer) StructTransformerOption {
 	return func(t *structTransformer) {
 		t.resolverTransformer = transformer
-  }
+	}
 }
 
 // WithIgnoreInTestsTransformer overrides how column ignoreInTests will be determined.


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

For some plugins it's useful to configure a resolver based on the field's type:
https://github.com/cloudquery/cloudquery/blob/876cc163d6dff277bb09a5147162a8646fcd98de/plugins/source/gcp/codegen/main.go#L263

I don't use the default one from `codegen` package like others as it returns `(string, error)` and we want to return a `schema.ColumnResolver` instead

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
