### PR TITLE
fix(destination-testing): Make destination tests opt-in rather than opt-out

### DIFF
--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -37,7 +37,7 @@ type PluginTestSuiteTests struct {
 	// existing object after the file has been closed.
 	TestSecondAppend bool
 
-	// destinationPluginTestMigrateAppend adds a test for the migrate function where a column is added,
+	// TestMigrateAppend adds a test for the migrate function where a column is added,
 	// data is appended, then the column is removed and more data appended, checking that the migrations handle
 	// this correctly.
 	TestMigrateAppend bool
@@ -202,7 +202,7 @@ func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, 
 	return nil
 }
 
-func (*PluginTestSuite) DestinationPluginTestMigrateAppend(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination) error {
+func (*PluginTestSuite) destinationPluginTestMigrateAppend(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination) error {
 	spec.WriteMode = specs.WriteModeAppend
 	spec.BatchSize = 1
 	if err := p.Init(ctx, logger, spec); err != nil {
@@ -343,7 +343,7 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 			t.Skip("skipping TestMigrateAppend")
 			return
 		}
-		if err := suite.DestinationPluginTestMigrateAppend(ctx, p, logger, destSpec); err != nil {
+		if err := suite.destinationPluginTestMigrateAppend(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
I'd like to propose changing the destination tests to opt-in, rather than opt-out, so that we can add new tests without immediately needing to update all destination plugins to either make the test pass or skip the test. Instead, we can then gradually add the test case to plugins where it makes sense, and ignore it in other plugins.

Within each destination, this also makes it more explicit what tests will be run. E.g. this is what it would look like for BigQuery:

```
destination.PluginTestSuiteTests{
	TestOverwrite:     false,
	TestDeleteStale:   true,
	TestAppend:        true,
	TestSecondAppend:  true,
	TestMigrateAppend: true,
})
```

This is a breaking change for the SDK interface, but since it doesn't affect the gPRC interface this won't be a major bump.