### PR TITLE
feat: Add batch size bytes as additional option

### DIFF
--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -23,6 +23,22 @@ func TestPluginManagedClient(t *testing.T) {
 		destination.PluginTestSuiteTests{})
 }
 
+func TestPluginManagedClientWithSmallBatchSize(t *testing.T) {
+	p := destination.NewPlugin("test", "development", NewClient, destination.WithManagedWriter(),
+		destination.WithDefaultBatchSize(1),
+		destination.WithDefaultBatchSizeBytes(1))
+	destination.PluginTestSuiteRunner(t, p, nil,
+		destination.PluginTestSuiteTests{})
+}
+
+func TestPluginManagedClientWithLargeBatchSize(t *testing.T) {
+	p := destination.NewPlugin("test", "development", NewClient, destination.WithManagedWriter(),
+		destination.WithDefaultBatchSize(100000000),
+		destination.WithDefaultBatchSizeBytes(100000000))
+	destination.PluginTestSuiteRunner(t, p, nil,
+		destination.PluginTestSuiteTests{})
+}
+
 func TestPluginOnNewError(t *testing.T) {
 	ctx := context.Background()
 	p := destination.NewPlugin("test", "development", NewClientErrOnNew)

--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -40,11 +40,13 @@ func (p *Plugin) worker(ctx context.Context, metrics *Metrics, table *schema.Tab
 			if len(resources) > 0 {
 				p.flush(ctx, metrics, table, resources)
 				resources = make([][]any, 0)
+				sizeBytes = 0
 			}
 		case done := <-flush:
 			if len(resources) > 0 {
 				p.flush(ctx, metrics, table, resources)
 				resources = make([][]any, 0)
+				sizeBytes = 0
 			}
 			done <- true
 		}

--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -17,7 +17,11 @@ const (
 	managed
 )
 
-const defaultBatchTimeoutSeconds = 20
+const (
+	defaultBatchTimeoutSeconds = 20
+	defaultBatchSize           = 10000
+	defaultBatchSizeBytes      = 5 * 1024 * 1024 // 5 MiB
+)
 
 type NewClientFunc func(context.Context, zerolog.Logger, specs.Destination) (Client, error)
 
@@ -86,8 +90,9 @@ type Plugin struct {
 	workers     map[string]*worker
 	workersLock *sync.Mutex
 
-	batchTimeout     time.Duration
-	defaultBatchSize int
+	batchTimeout          time.Duration
+	defaultBatchSize      int
+	defaultBatchSizeBytes int
 }
 
 func WithManagedWriter() Option {
@@ -108,18 +113,25 @@ func WithDefaultBatchSize(defaultBatchSize int) Option {
 	}
 }
 
+func WithDefaultBatchSizeBytes(defaultBatchSizeBytes int) Option {
+	return func(p *Plugin) {
+		p.defaultBatchSizeBytes = defaultBatchSizeBytes
+	}
+}
+
 // NewPlugin creates a new destination plugin
 func NewPlugin(name string, version string, newClientFunc NewClientFunc, opts ...Option) *Plugin {
 	p := &Plugin{
-		name:             name,
-		version:          version,
-		newClient:        newClientFunc,
-		metrics:          make(map[string]*Metrics),
-		metricsLock:      &sync.RWMutex{},
-		workers:          make(map[string]*worker),
-		workersLock:      &sync.Mutex{},
-		batchTimeout:     time.Duration(defaultBatchTimeoutSeconds) * time.Second,
-		defaultBatchSize: 10000,
+		name:                  name,
+		version:               version,
+		newClient:             newClientFunc,
+		metrics:               make(map[string]*Metrics),
+		metricsLock:           &sync.RWMutex{},
+		workers:               make(map[string]*worker),
+		workersLock:           &sync.Mutex{},
+		batchTimeout:          time.Duration(defaultBatchTimeoutSeconds) * time.Second,
+		defaultBatchSize:      defaultBatchSize,
+		defaultBatchSizeBytes: defaultBatchSizeBytes,
 	}
 	if newClientFunc == nil {
 		// we do this check because we only call this during runtime later on so it can fail
@@ -163,7 +175,7 @@ func (p *Plugin) Init(ctx context.Context, logger zerolog.Logger, spec specs.Des
 	var err error
 	p.logger = logger
 	p.spec = spec
-	p.spec.SetDefaults(p.defaultBatchSize)
+	p.spec.SetDefaults(p.defaultBatchSize, p.defaultBatchSizeBytes)
 	p.client, err = p.newClient(ctx, logger, spec)
 	if err != nil {
 		return err

--- a/specs/destination.go
+++ b/specs/destination.go
@@ -12,13 +12,14 @@ import (
 type WriteMode int
 
 type Destination struct {
-	Name      string    `json:"name,omitempty"`
-	Version   string    `json:"version,omitempty"`
-	Path      string    `json:"path,omitempty"`
-	Registry  Registry  `json:"registry,omitempty"`
-	WriteMode WriteMode `json:"write_mode,omitempty"`
-	BatchSize int       `json:"batch_size,omitempty"`
-	Spec      any       `json:"spec,omitempty"`
+	Name           string    `json:"name,omitempty"`
+	Version        string    `json:"version,omitempty"`
+	Path           string    `json:"path,omitempty"`
+	Registry       Registry  `json:"registry,omitempty"`
+	WriteMode      WriteMode `json:"write_mode,omitempty"`
+	BatchSize      int       `json:"batch_size,omitempty"`
+	BatchSizeBytes int       `json:"batch_size_bytes,omitempty"`
+	Spec           any       `json:"spec,omitempty"`
 }
 
 const (
@@ -31,12 +32,15 @@ var (
 	writeModeStrings = []string{"overwrite-delete-stale", "overwrite", "append"}
 )
 
-func (d *Destination) SetDefaults(defaultBatchSize int) {
+func (d *Destination) SetDefaults(defaultBatchSize, defaultBatchSizeBytes int) {
 	if d.Registry.String() == "" {
 		d.Registry = RegistryGithub
 	}
 	if d.BatchSize == 0 {
 		d.BatchSize = defaultBatchSize
+	}
+	if d.BatchSizeBytes == 0 {
+		d.BatchSizeBytes = defaultBatchSizeBytes
 	}
 }
 

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -144,10 +144,11 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryGrpc,
-			Path:      "localhost:9999",
-			BatchSize: 10000,
+			Name:           "test",
+			Registry:       RegistryGrpc,
+			Path:           "localhost:9999",
+			BatchSize:      10000,
+			BatchSizeBytes: 10000000,
 		},
 	},
 	{
@@ -160,10 +161,11 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryLocal,
-			Path:      "/home/user/some_executable",
-			BatchSize: 10000,
+			Name:           "test",
+			Registry:       RegistryLocal,
+			Path:           "/home/user/some_executable",
+			BatchSize:      10000,
+			BatchSizeBytes: 10000000,
 		},
 	},
 	{
@@ -176,11 +178,12 @@ spec:
 `,
 		"",
 		&Destination{
-			Name:      "test",
-			Registry:  RegistryGithub,
-			Path:      "cloudquery/test",
-			Version:   "v1.1.0",
-			BatchSize: 10000,
+			Name:           "test",
+			Registry:       RegistryGithub,
+			Path:           "cloudquery/test",
+			Version:        "v1.1.0",
+			BatchSize:      10000,
+			BatchSizeBytes: 10000000,
 		},
 	},
 }
@@ -195,7 +198,7 @@ func TestDestinationUnmarshalSpecValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			destination := spec.Spec.(*Destination)
-			destination.SetDefaults(10000)
+			destination.SetDefaults(10000, 10000000)
 			err = destination.Validate()
 			if err != nil {
 				if err.Error() != tc.err {

--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -84,8 +84,8 @@ func (r *SpecReader) loadSpecsFromFile(path string) error {
 			if r.Destinations[destination.Name] != nil {
 				return fmt.Errorf("duplicate destination name %s", destination.Name)
 			}
-			// We set the default value to 0 so it can be overridden later by plugins' defaults
-			destination.SetDefaults(0)
+			// We set the default value to 0, so it can be overridden later by plugins' defaults
+			destination.SetDefaults(0, 0)
 			if err := destination.Validate(); err != nil {
 				return fmt.Errorf("failed to validate destination %s: %w", destination.Name, err)
 			}


### PR DESCRIPTION
This adds `batchSizeBytes` as an additional option to limit batches not only by number of records, but also by number of bytes.