### PR TITLE
fix(destinations): Log correct size of batch

### DIFF
--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -55,13 +55,14 @@ func (p *Plugin) worker(ctx context.Context, metrics *Metrics, table *schema.Tab
 
 func (p *Plugin) flush(ctx context.Context, metrics *Metrics, table *schema.Table, resources [][]any) {
 	start := time.Now()
+	batchSize := len(resources)
 	if err := p.client.WriteTableBatch(ctx, table, resources); err != nil {
-		p.logger.Err(err).Str("table", table.Name).Int("len", p.spec.BatchSize).Dur("duration", time.Since(start)).Msg("failed to write batch")
+		p.logger.Err(err).Str("table", table.Name).Int("len", batchSize).Dur("duration", time.Since(start)).Msg("failed to write batch")
 		// we don't return an error as we need to continue until channel is closed otherwise there will be a deadlock
-		atomic.AddUint64(&metrics.Errors, uint64(p.spec.BatchSize))
+		atomic.AddUint64(&metrics.Errors, uint64(batchSize))
 	} else {
-		p.logger.Info().Str("table", table.Name).Int("len", p.spec.BatchSize).Dur("duration", time.Since(start)).Msg("batch written successfully")
-		atomic.AddUint64(&metrics.Writes, uint64(p.spec.BatchSize))
+		p.logger.Info().Str("table", table.Name).Int("len", batchSize).Dur("duration", time.Since(start)).Msg("batch written successfully")
+		atomic.AddUint64(&metrics.Writes, uint64(batchSize))
 	}
 }
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

If we exceed `BatchSizeBytes` the batch size is lower than the one in the spec

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
