### PR TITLE
fix: Sentry errors not sent

### DIFF
--- a/schema/bool.go
+++ b/schema/bool.go
@@ -88,7 +88,7 @@ func (dst *Bool) Set(src any) error {
 		if originalSrc, ok := underlyingBoolType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Bool", value)
+		return &ValidationError{Type: TypeBool, msg: fmt.Sprintf("value %v is not bool", value)}
 	}
 
 	return nil

--- a/schema/bool.go
+++ b/schema/bool.go
@@ -2,7 +2,6 @@
 package schema
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -88,7 +87,7 @@ func (dst *Bool) Set(src any) error {
 		if originalSrc, ok := underlyingBoolType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeBool, msg: fmt.Sprintf("value %v is not bool", value)}
+		return &ValidationError{Type: TypeBool, Msg: noConversion, Value: src}
 	}
 
 	return nil

--- a/schema/bytea.go
+++ b/schema/bytea.go
@@ -4,7 +4,6 @@ package schema
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 )
 
 type ByteaTransformer interface {
@@ -73,7 +72,7 @@ func (dst *Bytea) Set(src any) error {
 			b := make([]byte, hex.DecodedLen(len(value)))
 			_, err := hex.Decode(b, []byte(value))
 			if err != nil {
-				return fmt.Errorf("cannot decode hex string to bytea: %w", err)
+				return &ValidationError{Type: TypeByteArray, msg: "hex decode failed", err: err}
 			}
 			*dst = Bytea{Status: Present, Bytes: b}
 		} else {
@@ -83,7 +82,7 @@ func (dst *Bytea) Set(src any) error {
 		if originalSrc, ok := underlyingBytesType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Bytea", value)
+		return &ValidationError{Type: TypeByteArray, msg: "value is not byte array"}
 	}
 
 	return nil

--- a/schema/bytea.go
+++ b/schema/bytea.go
@@ -72,7 +72,7 @@ func (dst *Bytea) Set(src any) error {
 			b := make([]byte, hex.DecodedLen(len(value)))
 			_, err := hex.Decode(b, []byte(value))
 			if err != nil {
-				return &ValidationError{Type: TypeByteArray, Msg: "hex decode failed", Err: err, Value: err}
+				return &ValidationError{Type: TypeByteArray, Msg: "hex decode failed", Err: err, Value: value}
 			}
 			*dst = Bytea{Status: Present, Bytes: b}
 		} else {

--- a/schema/bytea.go
+++ b/schema/bytea.go
@@ -72,7 +72,7 @@ func (dst *Bytea) Set(src any) error {
 			b := make([]byte, hex.DecodedLen(len(value)))
 			_, err := hex.Decode(b, []byte(value))
 			if err != nil {
-				return &ValidationError{Type: TypeByteArray, msg: "hex decode failed", err: err}
+				return &ValidationError{Type: TypeByteArray, Msg: "hex decode failed", Err: err, Value: err}
 			}
 			*dst = Bytea{Status: Present, Bytes: b}
 		} else {
@@ -82,7 +82,7 @@ func (dst *Bytea) Set(src any) error {
 		if originalSrc, ok := underlyingBytesType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeByteArray, msg: "value is not byte array"}
+		return &ValidationError{Type: TypeByteArray, Msg: noConversion, Value: src}
 	}
 
 	return nil

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -1,0 +1,21 @@
+package schema
+
+import "fmt"
+
+type ValidationError struct {
+	err   error
+	msg   string
+	Type  ValueType
+	Value any
+}
+
+func (e *ValidationError) Error() string {
+	if e.err == nil {
+		return fmt.Sprintf("cannot convert `%s`: %s", e.Type, e.msg)
+	}
+	return fmt.Sprintf("cannot convert `%s`: %s (%s)", e.Type, e.msg, e.err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.err
+}

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -2,20 +2,38 @@ package schema
 
 import "fmt"
 
+const (
+	noConversion                = "no conversion available"
+	cannotDecodeString          = "cannot decode from string"
+	cannotFindDimensions        = "cannot find dimensions"
+	notInterface                = "not an interface"
+	expectedElements            = "expected %d elements, but got %d instead"
+	expectedElementsInDimension = "expected %d elements in dimension %d, but got %d instead"
+	cannotSetIndex              = "cannot set index %d"
+)
+
 type ValidationError struct {
-	err   error
-	msg   string
+	Err   error
+	Msg   string
 	Type  ValueType
 	Value any
 }
 
 func (e *ValidationError) Error() string {
-	if e.err == nil {
-		return fmt.Sprintf("cannot convert `%s`: %s", e.Type, e.msg)
+	if e.Err == nil {
+		return fmt.Sprintf("cannot set `%s` with value `%v`: %s", e.Type, e.Value, e.Msg)
 	}
-	return fmt.Sprintf("cannot convert `%s`: %s (%s)", e.Type, e.msg, e.err)
+	return fmt.Sprintf("cannot set `%s` with value `%v`: %s (%s)", e.Type, e.Value, e.Msg, e.Err)
+}
+
+// this prints the error without the value
+func (e *ValidationError) MaskedError() string {
+	if e.Err == nil {
+		return fmt.Sprintf("cannot set `%s`: %s", e.Type, e.Msg)
+	}
+	return fmt.Sprintf("cannot set `%s`: %s (%s)", e.Type, e.Msg, e.Err)
 }
 
 func (e *ValidationError) Unwrap() error {
-	return e.err
+	return e.Err
 }

--- a/schema/float8.go
+++ b/schema/float8.go
@@ -2,7 +2,6 @@
 package schema
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 )
@@ -87,28 +86,28 @@ func (dst *Float8) Set(src any) error {
 		if int64(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return fmt.Errorf("%v cannot be exactly represented as float64", value)
+			return &ValidationError{Type: TypeFloat, msg: "int64 value cannot be exactly represented as float64"}
 		}
 	case uint64:
 		f64 := float64(value)
 		if uint64(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return fmt.Errorf("%v cannot be exactly represented as float64", value)
+			return &ValidationError{Type: TypeFloat, msg: "uint64 value cannot be exactly represented as float64"}
 		}
 	case int:
 		f64 := float64(value)
 		if int(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return fmt.Errorf("%v cannot be exactly represented as float64", value)
+			return &ValidationError{Type: TypeFloat, msg: "int value cannot be exactly represented as float64"}
 		}
 	case uint:
 		f64 := float64(value)
 		if uint(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return fmt.Errorf("%v cannot be exactly represented as float64", value)
+			return &ValidationError{Type: TypeFloat, msg: "uint value cannot be exactly represented as float64"}
 		}
 	case string:
 		num, err := strconv.ParseFloat(value, 64)
@@ -198,7 +197,7 @@ func (dst *Float8) Set(src any) error {
 		if originalSrc, ok := underlyingNumberType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Float8", value)
+		return &ValidationError{Type: TypeFloat, msg: "value is not a number", Value: src}
 	}
 
 	return nil

--- a/schema/float8.go
+++ b/schema/float8.go
@@ -86,28 +86,28 @@ func (dst *Float8) Set(src any) error {
 		if int64(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return &ValidationError{Type: TypeFloat, msg: "int64 value cannot be exactly represented as float64"}
+			return &ValidationError{Type: TypeFloat, Msg: "int64 value cannot be exactly represented as float64", Value: value}
 		}
 	case uint64:
 		f64 := float64(value)
 		if uint64(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return &ValidationError{Type: TypeFloat, msg: "uint64 value cannot be exactly represented as float64"}
+			return &ValidationError{Type: TypeFloat, Msg: "uint64 value cannot be exactly represented as float64", Value: value}
 		}
 	case int:
 		f64 := float64(value)
 		if int(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return &ValidationError{Type: TypeFloat, msg: "int value cannot be exactly represented as float64"}
+			return &ValidationError{Type: TypeFloat, Msg: "int value cannot be exactly represented as float64", Value: value}
 		}
 	case uint:
 		f64 := float64(value)
 		if uint(f64) == value {
 			*dst = Float8{Float: f64, Status: Present}
 		} else {
-			return &ValidationError{Type: TypeFloat, msg: "uint value cannot be exactly represented as float64"}
+			return &ValidationError{Type: TypeFloat, Msg: "uint value cannot be exactly represented as float64", Value: value}
 		}
 	case string:
 		num, err := strconv.ParseFloat(value, 64)
@@ -197,7 +197,7 @@ func (dst *Float8) Set(src any) error {
 		if originalSrc, ok := underlyingNumberType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeFloat, msg: "value is not a number", Value: src}
+		return &ValidationError{Type: TypeFloat, Msg: noConversion, Value: src}
 	}
 
 	return nil

--- a/schema/inet.go
+++ b/schema/inet.go
@@ -84,7 +84,7 @@ func (dst *Inet) Set(src any) error {
 		if err != nil {
 			ip := net.ParseIP(value)
 			if ip == nil {
-				return fmt.Errorf("unable to parse inet address: %s", value)
+				return &ValidationError{Type: TypeInet, msg: "cannot parse string as IP"}
 			}
 
 			if ipv4 := maybeGetIPv4(value, ip); ipv4 != nil {
@@ -125,7 +125,7 @@ func (dst *Inet) Set(src any) error {
 		if tv, ok := src.(encoding.TextMarshaler); ok {
 			text, err := tv.MarshalText()
 			if err != nil {
-				return fmt.Errorf("cannot marshal %v: %w", value, err)
+				return &ValidationError{Type: TypeInet, msg: "cannot marshal text", err: err}
 			}
 			return dst.Set(string(text))
 		}
@@ -135,7 +135,7 @@ func (dst *Inet) Set(src any) error {
 		if originalSrc, ok := underlyingPtrType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Inet", value)
+		return &ValidationError{Type: TypeInet, msg: "no available conversion for value"}
 	}
 
 	return nil

--- a/schema/inet.go
+++ b/schema/inet.go
@@ -84,7 +84,7 @@ func (dst *Inet) Set(src any) error {
 		if err != nil {
 			ip := net.ParseIP(value)
 			if ip == nil {
-				return &ValidationError{Type: TypeInet, msg: "cannot parse string as IP"}
+				return &ValidationError{Type: TypeInet, Msg: "cannot parse string as IP", Value: value}
 			}
 
 			if ipv4 := maybeGetIPv4(value, ip); ipv4 != nil {
@@ -125,7 +125,7 @@ func (dst *Inet) Set(src any) error {
 		if tv, ok := src.(encoding.TextMarshaler); ok {
 			text, err := tv.MarshalText()
 			if err != nil {
-				return &ValidationError{Type: TypeInet, msg: "cannot marshal text", err: err}
+				return &ValidationError{Type: TypeInet, Msg: "cannot marshal text", Err: err, Value: src}
 			}
 			return dst.Set(string(text))
 		}
@@ -135,7 +135,7 @@ func (dst *Inet) Set(src any) error {
 		if originalSrc, ok := underlyingPtrType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeInet, msg: "no available conversion for value"}
+		return &ValidationError{Type: TypeInet, Msg: noConversion, Value: src}
 	}
 
 	return nil

--- a/schema/inet_array.go
+++ b/schema/inet_array.go
@@ -60,7 +60,7 @@ func (dst *InetArray) Equal(src CQType) bool {
 func (dst *InetArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return fmt.Errorf("cannot decode %v into InetArray", value)
+		return &ValidationError{Type: TypeInetArray, msg: "cannot decode from string"}
 	}
 	// remove the curly braces
 	value = value[1 : len(value)-1]
@@ -205,7 +205,7 @@ func (dst *InetArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return fmt.Errorf("cannot find dimensions of %v for InetArray", src)
+			return &ValidationError{Type: TypeInetArray, msg: "cannot find dimensions"}
 		}
 		if elementsLength == 0 {
 			*dst = InetArray{Status: Present}
@@ -215,7 +215,7 @@ func (dst *InetArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return fmt.Errorf("cannot convert %v to InetArray", src)
+			return &ValidationError{Type: TypeInetArray, msg: "underlying value is not a slice"}
 		}
 
 		*dst = InetArray{
@@ -246,7 +246,7 @@ func (dst *InetArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return fmt.Errorf("cannot convert %v to InetArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+			return &ValidationError{Type: TypeInetArray, msg: fmt.Sprintf("expected %d elements, but got %d instead", len(dst.Elements), elementCount)}
 		}
 	}
 
@@ -264,7 +264,7 @@ func (dst *InetArray) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, fmt.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+			return 0, &ValidationError{Type: TypeInetArray, msg: "multidimensional arrays must have array expressions with matching dimensions"}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -277,10 +277,10 @@ func (dst *InetArray) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, fmt.Errorf("cannot convert all values to InetArray")
+		return 0, &ValidationError{Type: TypeInetArray, msg: "value is not an interface"}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, fmt.Errorf("%v in InetArray", err)
+		return 0, &ValidationError{Type: TypeInetArray, msg: fmt.Sprintf("failed to set value at index %d", index), err: err}
 	}
 	index++
 

--- a/schema/int8.go
+++ b/schema/int8.go
@@ -2,7 +2,6 @@
 package schema
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 )
@@ -77,14 +76,14 @@ func (dst *Int8) Set(src any) error {
 		*dst = Int8{Int: value, Status: Present}
 	case uint64:
 		if value > math.MaxInt64 {
-			return fmt.Errorf("%d is greater than maximum value for Int8", value)
+			return &ValidationError{Type: TypeInt, msg: "uint64 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case int:
 		*dst = Int8{Int: int64(value), Status: Present}
 	case uint:
 		if uint64(value) > math.MaxInt64 {
-			return fmt.Errorf("%d is greater than maximum value for Int8", value)
+			return &ValidationError{Type: TypeInt, msg: "uint bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case string:
@@ -95,12 +94,12 @@ func (dst *Int8) Set(src any) error {
 		*dst = Int8{Int: num, Status: Present}
 	case float32:
 		if value > math.MaxInt64 {
-			return fmt.Errorf("%f is greater than maximum value for Int8", value)
+			return &ValidationError{Type: TypeInt, msg: "float32 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case float64:
 		if value > math.MaxInt64 {
-			return fmt.Errorf("%f is greater than maximum value for Int8", value)
+			return &ValidationError{Type: TypeInt, msg: "float64 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case *int8:
@@ -185,7 +184,7 @@ func (dst *Int8) Set(src any) error {
 		if originalSrc, ok := underlyingNumberType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Int8", value)
+		return &ValidationError{Type: TypeInt, msg: "value is not a number", Value: value}
 	}
 
 	return nil

--- a/schema/int8.go
+++ b/schema/int8.go
@@ -76,14 +76,14 @@ func (dst *Int8) Set(src any) error {
 		*dst = Int8{Int: value, Status: Present}
 	case uint64:
 		if value > math.MaxInt64 {
-			return &ValidationError{Type: TypeInt, msg: "uint64 bigger than MaxInt64", Value: value}
+			return &ValidationError{Type: TypeInt, Msg: "uint64 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case int:
 		*dst = Int8{Int: int64(value), Status: Present}
 	case uint:
 		if uint64(value) > math.MaxInt64 {
-			return &ValidationError{Type: TypeInt, msg: "uint bigger than MaxInt64", Value: value}
+			return &ValidationError{Type: TypeInt, Msg: "uint bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case string:
@@ -94,12 +94,12 @@ func (dst *Int8) Set(src any) error {
 		*dst = Int8{Int: num, Status: Present}
 	case float32:
 		if value > math.MaxInt64 {
-			return &ValidationError{Type: TypeInt, msg: "float32 bigger than MaxInt64", Value: value}
+			return &ValidationError{Type: TypeInt, Msg: "float32 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case float64:
 		if value > math.MaxInt64 {
-			return &ValidationError{Type: TypeInt, msg: "float64 bigger than MaxInt64", Value: value}
+			return &ValidationError{Type: TypeInt, Msg: "float64 bigger than MaxInt64", Value: value}
 		}
 		*dst = Int8{Int: int64(value), Status: Present}
 	case *int8:
@@ -184,7 +184,7 @@ func (dst *Int8) Set(src any) error {
 		if originalSrc, ok := underlyingNumberType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeInt, msg: "value is not a number", Value: value}
+		return &ValidationError{Type: TypeInt, Msg: noConversion, Value: value}
 	}
 
 	return nil

--- a/schema/int8_array.go
+++ b/schema/int8_array.go
@@ -56,7 +56,7 @@ func (dst *Int8Array) Equal(src CQType) bool {
 func (dst *Int8Array) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return &ValidationError{Type: TypeIntArray, msg: "cannot decode from string", Value: value}
+		return &ValidationError{Type: TypeIntArray, Msg: cannotDecodeString, Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -451,7 +451,7 @@ func (dst *Int8Array) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return &ValidationError{Type: TypeIntArray, msg: "cannot find dimensions", Value: src}
+			return &ValidationError{Type: TypeIntArray, Msg: cannotFindDimensions, Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = Int8Array{Status: Present}
@@ -461,7 +461,7 @@ func (dst *Int8Array) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return &ValidationError{Type: TypeIntArray, msg: "value is not a slice", Value: src}
+			return &ValidationError{Type: TypeIntArray, Msg: noConversion, Value: src}
 		}
 
 		*dst = Int8Array{
@@ -492,7 +492,7 @@ func (dst *Int8Array) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
+			return &ValidationError{Type: TypeIntArray, Msg: fmt.Sprintf(expectedElements, len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -510,7 +510,7 @@ func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value.Interface()}
+			return 0, &ValidationError{Type: TypeIntArray, Msg: fmt.Sprintf(expectedElementsInDimension, dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -523,10 +523,10 @@ func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, &ValidationError{Type: TypeIntArray, msg: "cannot interface value", Value: value.Interface()}
+		return 0, &ValidationError{Type: TypeIntArray, Msg: notInterface, Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value.Interface(), err: err}
+		return 0, &ValidationError{Type: TypeIntArray, Msg: fmt.Sprintf(cannotSetIndex, index), Value: value.Interface(), Err: err}
 	}
 	index++
 

--- a/schema/int8_array.go
+++ b/schema/int8_array.go
@@ -56,7 +56,7 @@ func (dst *Int8Array) Equal(src CQType) bool {
 func (dst *Int8Array) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return fmt.Errorf("cannot decode %v into Int8Array", value)
+		return &ValidationError{Type: TypeIntArray, msg: "cannot decode from string", Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -451,7 +451,7 @@ func (dst *Int8Array) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return fmt.Errorf("cannot find dimensions of %v for Int8Array", src)
+			return &ValidationError{Type: TypeIntArray, msg: "cannot find dimensions", Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = Int8Array{Status: Present}
@@ -461,7 +461,7 @@ func (dst *Int8Array) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return fmt.Errorf("cannot convert %v to Int8Array", src)
+			return &ValidationError{Type: TypeIntArray, msg: "value is not a slice", Value: src}
 		}
 
 		*dst = Int8Array{
@@ -492,7 +492,7 @@ func (dst *Int8Array) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return fmt.Errorf("cannot convert %v to Int8Array, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+			return &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -510,7 +510,7 @@ func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, fmt.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+			return 0, &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value.Interface()}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -523,10 +523,10 @@ func (dst *Int8Array) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, fmt.Errorf("cannot convert all values to Int8Array")
+		return 0, &ValidationError{Type: TypeIntArray, msg: "cannot interface value", Value: value.Interface()}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, fmt.Errorf("%v in Int8Array", err)
+		return 0, &ValidationError{Type: TypeIntArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value.Interface(), err: err}
 	}
 	index++
 

--- a/schema/json.go
+++ b/schema/json.go
@@ -86,7 +86,7 @@ func (dst *JSON) Set(src any) error {
 			return nil
 		}
 		if !json.Valid([]byte(value)) {
-			return &ValidationError{Type: TypeJSON, msg: "invalid json string", Value: value}
+			return &ValidationError{Type: TypeJSON, Msg: "invalid json string", Value: value}
 		}
 		*dst = JSON{Bytes: []byte(value), Status: Present}
 	case *string:
@@ -98,7 +98,7 @@ func (dst *JSON) Set(src any) error {
 				return nil
 			}
 			if !json.Valid([]byte(*value)) {
-				return &ValidationError{Type: TypeJSON, msg: "invalid json string pointer", Value: value}
+				return &ValidationError{Type: TypeJSON, Msg: "invalid json string pointer", Value: value}
 			}
 			*dst = JSON{Bytes: []byte(*value), Status: Present}
 		}
@@ -112,7 +112,7 @@ func (dst *JSON) Set(src any) error {
 			}
 
 			if !json.Valid(value) {
-				return &ValidationError{Type: TypeJSON, msg: "invalid json byte array", Value: value}
+				return &ValidationError{Type: TypeJSON, Msg: "invalid json byte array", Value: value}
 			}
 			*dst = JSON{Bytes: value, Status: Present}
 		}
@@ -121,7 +121,7 @@ func (dst *JSON) Set(src any) error {
 	// struct itself would be encoded instead of Bytes. This is clearly a footgun
 	// so detect and return an error. See https://github.com/jackc/pgx/issues/350.
 	case JSON:
-		return &ValidationError{Type: TypeJSON, msg: "use pointer to JSON instead of value", Value: value}
+		return &ValidationError{Type: TypeJSON, Msg: "use pointer to JSON instead of value", Value: value}
 
 	default:
 		buf, err := json.Marshal(value)

--- a/schema/json.go
+++ b/schema/json.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"reflect"
 )
 
@@ -87,7 +86,7 @@ func (dst *JSON) Set(src any) error {
 			return nil
 		}
 		if !json.Valid([]byte(value)) {
-			return errors.New("invalid JSON string value")
+			return &ValidationError{Type: TypeJSON, msg: "invalid json string", Value: value}
 		}
 		*dst = JSON{Bytes: []byte(value), Status: Present}
 	case *string:
@@ -99,7 +98,7 @@ func (dst *JSON) Set(src any) error {
 				return nil
 			}
 			if !json.Valid([]byte(*value)) {
-				return errors.New("invalid JSON string pointer value")
+				return &ValidationError{Type: TypeJSON, msg: "invalid json string pointer", Value: value}
 			}
 			*dst = JSON{Bytes: []byte(*value), Status: Present}
 		}
@@ -113,7 +112,7 @@ func (dst *JSON) Set(src any) error {
 			}
 
 			if !json.Valid(value) {
-				return errors.New("invalid JSON byte array value")
+				return &ValidationError{Type: TypeJSON, msg: "invalid json byte array", Value: value}
 			}
 			*dst = JSON{Bytes: value, Status: Present}
 		}
@@ -122,7 +121,7 @@ func (dst *JSON) Set(src any) error {
 	// struct itself would be encoded instead of Bytes. This is clearly a footgun
 	// so detect and return an error. See https://github.com/jackc/pgx/issues/350.
 	case JSON:
-		return errors.New("use pointer to JSON instead of value")
+		return &ValidationError{Type: TypeJSON, msg: "use pointer to JSON instead of value", Value: value}
 
 	default:
 		buf, err := json.Marshal(value)

--- a/schema/macaddr.go
+++ b/schema/macaddr.go
@@ -85,7 +85,7 @@ func (dst *Macaddr) Set(src any) error {
 		if originalSrc, ok := underlyingPtrType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeMacAddr, msg: "type mismatch", Value: value}
+		return &ValidationError{Type: TypeMacAddr, Msg: noConversion, Value: value}
 	}
 
 	return nil

--- a/schema/macaddr.go
+++ b/schema/macaddr.go
@@ -2,7 +2,6 @@
 package schema
 
 import (
-	"fmt"
 	"net"
 )
 
@@ -86,7 +85,7 @@ func (dst *Macaddr) Set(src any) error {
 		if originalSrc, ok := underlyingPtrType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Macaddr", value)
+		return &ValidationError{Type: TypeMacAddr, msg: "type mismatch", Value: value}
 	}
 
 	return nil

--- a/schema/macaddr_array.go
+++ b/schema/macaddr_array.go
@@ -61,7 +61,7 @@ func (dst *MacaddrArray) Equal(src CQType) bool {
 func (dst *MacaddrArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return &ValidationError{Type: TypeMacAddrArray, msg: "cannot decode from string", Value: value}
+		return &ValidationError{Type: TypeMacAddrArray, Msg: cannotDecodeString, Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -180,7 +180,7 @@ func (dst *MacaddrArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return &ValidationError{Type: TypeMacAddrArray, msg: "cannot find dimensions of source", Value: src}
+			return &ValidationError{Type: TypeMacAddrArray, Msg: cannotFindDimensions, Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = MacaddrArray{Status: Present}
@@ -190,7 +190,7 @@ func (dst *MacaddrArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return &ValidationError{Type: TypeMacAddrArray, msg: "value is not a slice", Value: src}
+			return &ValidationError{Type: TypeMacAddrArray, Msg: noConversion, Value: src}
 		}
 
 		*dst = MacaddrArray{
@@ -221,7 +221,7 @@ func (dst *MacaddrArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
+			return &ValidationError{Type: TypeMacAddrArray, Msg: fmt.Sprintf(expectedElements, len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -239,7 +239,7 @@ func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int)
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value.Interface()}
+			return 0, &ValidationError{Type: TypeMacAddrArray, Msg: fmt.Sprintf(expectedElementsInDimension, dst.Dimensions[dimension].Length, dimension, valueLen), Value: value.Interface()}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -252,10 +252,10 @@ func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int)
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, &ValidationError{Type: TypeMacAddrArray, msg: "cannot interface value", Value: value.Interface()}
+		return 0, &ValidationError{Type: TypeMacAddrArray, Msg: notInterface, Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("cannot set element at %d", index), Value: value.Interface(), err: err}
+		return 0, &ValidationError{Type: TypeMacAddrArray, Msg: fmt.Sprintf(cannotSetIndex, index), Value: value.Interface(), Err: err}
 	}
 	index++
 

--- a/schema/macaddr_array.go
+++ b/schema/macaddr_array.go
@@ -61,7 +61,7 @@ func (dst *MacaddrArray) Equal(src CQType) bool {
 func (dst *MacaddrArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return fmt.Errorf("cannot decode %v into MacaddrArray", value)
+		return &ValidationError{Type: TypeMacAddrArray, msg: "cannot decode from string", Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -180,7 +180,7 @@ func (dst *MacaddrArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return fmt.Errorf("cannot find dimensions of %v for MacaddrArray", src)
+			return &ValidationError{Type: TypeMacAddrArray, msg: "cannot find dimensions of source", Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = MacaddrArray{Status: Present}
@@ -190,7 +190,7 @@ func (dst *MacaddrArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return fmt.Errorf("cannot convert %v to MacaddrArray", src)
+			return &ValidationError{Type: TypeMacAddrArray, msg: "value is not a slice", Value: src}
 		}
 
 		*dst = MacaddrArray{
@@ -221,7 +221,7 @@ func (dst *MacaddrArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return fmt.Errorf("cannot convert %v to MacaddrArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+			return &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -239,7 +239,7 @@ func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int)
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, fmt.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+			return 0, &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value.Interface()}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -252,10 +252,10 @@ func (dst *MacaddrArray) setRecursive(value reflect.Value, index, dimension int)
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, fmt.Errorf("cannot convert all values to MacaddrArray")
+		return 0, &ValidationError{Type: TypeMacAddrArray, msg: "cannot interface value", Value: value.Interface()}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, fmt.Errorf("%v in MacaddrArray", err)
+		return 0, &ValidationError{Type: TypeMacAddrArray, msg: fmt.Sprintf("cannot set element at %d", index), Value: value.Interface(), err: err}
 	}
 	index++
 

--- a/schema/text.go
+++ b/schema/text.go
@@ -94,7 +94,7 @@ func (dst *Text) Set(src any) error {
 			} else {
 				v, err := value.Value()
 				if err != nil {
-					return fmt.Errorf("driver.Valuer Value() method failed: %w", err)
+					return &ValidationError{Type: TypeString, msg: "driver.Valuer Value() method failed", err: err}
 				}
 
 				// Handles also v == nil case.
@@ -108,7 +108,7 @@ func (dst *Text) Set(src any) error {
 		if originalSrc, ok := underlyingStringType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to Text", value)
+		return &ValidationError{Type: TypeString, msg: "not a string", Value: src}
 	}
 
 	return nil

--- a/schema/text.go
+++ b/schema/text.go
@@ -94,7 +94,7 @@ func (dst *Text) Set(src any) error {
 			} else {
 				v, err := value.Value()
 				if err != nil {
-					return &ValidationError{Type: TypeString, Msg: "driver.Valuer Value() method failed", Err: err}
+					return &ValidationError{Type: TypeString, Msg: "driver.Valuer Value() method failed", Err: err, Value: src}
 				}
 
 				// Handles also v == nil case.

--- a/schema/text.go
+++ b/schema/text.go
@@ -94,7 +94,7 @@ func (dst *Text) Set(src any) error {
 			} else {
 				v, err := value.Value()
 				if err != nil {
-					return &ValidationError{Type: TypeString, msg: "driver.Valuer Value() method failed", err: err}
+					return &ValidationError{Type: TypeString, Msg: "driver.Valuer Value() method failed", Err: err}
 				}
 
 				// Handles also v == nil case.
@@ -108,7 +108,7 @@ func (dst *Text) Set(src any) error {
 		if originalSrc, ok := underlyingStringType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeString, msg: "not a string", Value: src}
+		return &ValidationError{Type: TypeString, Msg: noConversion, Value: src}
 	}
 
 	return nil

--- a/schema/text_array.go
+++ b/schema/text_array.go
@@ -60,7 +60,7 @@ func (dst *TextArray) Equal(src CQType) bool {
 func (dst *TextArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return &ValidationError{Type: TypeStringArray, msg: "cannot decode from string", Value: value}
+		return &ValidationError{Type: TypeStringArray, Msg: cannotDecodeString, Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -177,7 +177,7 @@ func (dst *TextArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return &ValidationError{Type: TypeStringArray, msg: "cannot find dimensions of source", Value: src}
+			return &ValidationError{Type: TypeStringArray, Msg: cannotFindDimensions, Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = TextArray{Status: Present}
@@ -187,7 +187,7 @@ func (dst *TextArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return &ValidationError{Type: TypeStringArray, msg: "value not a slice", Value: src}
+			return &ValidationError{Type: TypeStringArray, Msg: noConversion, Value: src}
 		}
 
 		*dst = TextArray{
@@ -219,7 +219,7 @@ func (dst *TextArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
+			return &ValidationError{Type: TypeStringArray, Msg: fmt.Sprintf(expectedElements, len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -237,7 +237,7 @@ func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
+			return 0, &ValidationError{Type: TypeStringArray, Msg: fmt.Sprintf(expectedElementsInDimension, dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -250,10 +250,10 @@ func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, &ValidationError{Type: TypeStringArray, msg: "not an interface", Value: value}
+		return 0, &ValidationError{Type: TypeStringArray, Msg: notInterface, Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value, err: err}
+		return 0, &ValidationError{Type: TypeStringArray, Msg: fmt.Sprintf(cannotSetIndex, index), Value: value, Err: err}
 	}
 	index++
 

--- a/schema/text_array.go
+++ b/schema/text_array.go
@@ -60,7 +60,7 @@ func (dst *TextArray) Equal(src CQType) bool {
 func (dst *TextArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return fmt.Errorf("cannot decode %v into Int8Array", value)
+		return &ValidationError{Type: TypeStringArray, msg: "cannot decode from string", Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -177,7 +177,7 @@ func (dst *TextArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return fmt.Errorf("cannot find dimensions of %v for TextArray", src)
+			return &ValidationError{Type: TypeStringArray, msg: "cannot find dimensions of source", Value: src}
 		}
 		if elementsLength == 0 {
 			*dst = TextArray{Status: Present}
@@ -187,7 +187,7 @@ func (dst *TextArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return fmt.Errorf("cannot convert %v to TextArray", src)
+			return &ValidationError{Type: TypeStringArray, msg: "value not a slice", Value: src}
 		}
 
 		*dst = TextArray{
@@ -219,7 +219,7 @@ func (dst *TextArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return fmt.Errorf("cannot convert %v to TextArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+			return &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: src}
 		}
 	}
 
@@ -237,7 +237,7 @@ func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, fmt.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+			return 0, &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -250,10 +250,10 @@ func (dst *TextArray) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, fmt.Errorf("cannot convert all values to TextArray")
+		return 0, &ValidationError{Type: TypeStringArray, msg: "not an interface", Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, fmt.Errorf("%v in TextArray", err)
+		return 0, &ValidationError{Type: TypeStringArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value, err: err}
 	}
 	index++
 

--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -119,7 +119,7 @@ func (dst *Timestamptz) Set(src any) error {
 			s := value.String()
 			return dst.Set(s)
 		}
-		return &ValidationError{Type: TypeTimestamp, msg: "no conversion available", Value: value}
+		return &ValidationError{Type: TypeTimestamp, Msg: noConversion, Value: value}
 	}
 
 	return nil
@@ -170,7 +170,7 @@ func (dst *Timestamptz) DecodeText(src []byte) error {
 			*dst = Timestamptz{Time: normalizePotentialUTC(tim), Status: Present}
 			return nil
 		}
-		return &ValidationError{Type: TypeTimestamp, msg: "cannot parse timestamp", Value: sbuf, err: err}
+		return &ValidationError{Type: TypeTimestamp, Msg: "cannot parse timestamp", Value: sbuf, Err: err}
 	}
 
 	return nil

--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -119,7 +119,7 @@ func (dst *Timestamptz) Set(src any) error {
 			s := value.String()
 			return dst.Set(s)
 		}
-		return fmt.Errorf("cannot convert %v of type %T to Timestamptz", value, value)
+		return &ValidationError{Type: TypeTimestamp, msg: "no conversion available", Value: value}
 	}
 
 	return nil
@@ -170,8 +170,7 @@ func (dst *Timestamptz) DecodeText(src []byte) error {
 			*dst = Timestamptz{Time: normalizePotentialUTC(tim), Status: Present}
 			return nil
 		}
-		return fmt.Errorf("cannot parse %s as Timestamptz", sbuf)
-
+		return &ValidationError{Type: TypeTimestamp, msg: "cannot parse timestamp", Value: sbuf, err: err}
 	}
 
 	return nil

--- a/schema/uuid.go
+++ b/schema/uuid.go
@@ -67,7 +67,7 @@ func (dst *UUID) Set(src any) error {
 	case []byte:
 		if value != nil {
 			if len(value) != 16 {
-				return fmt.Errorf("[]byte must be 16 bytes to convert to UUID: %d", len(value))
+				return &ValidationError{Type: TypeUUID, msg: "[]byte must be 16 bytes to convert to UUID", Value: value}
 			}
 			*dst = UUID{Status: Present}
 			copy(dst.Bytes[:], value)
@@ -90,7 +90,7 @@ func (dst *UUID) Set(src any) error {
 		if originalSrc, ok := underlyingUUIDType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return fmt.Errorf("cannot convert %v to UUID", value)
+		return &ValidationError{Type: TypeUUID, msg: "no conversion available", Value: value}
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func parseUUID(src string) (dst [16]byte, err error) {
 		// dashes already stripped, assume valid
 	default:
 		// assume invalid.
-		return dst, fmt.Errorf("cannot parse UUID %v", src)
+		return dst, &ValidationError{Type: TypeUUID, msg: fmt.Sprintf("invalid %d UUID length", len(src)), Value: src}
 	}
 
 	buf, err := hex.DecodeString(src)

--- a/schema/uuid.go
+++ b/schema/uuid.go
@@ -67,7 +67,7 @@ func (dst *UUID) Set(src any) error {
 	case []byte:
 		if value != nil {
 			if len(value) != 16 {
-				return &ValidationError{Type: TypeUUID, msg: "[]byte must be 16 bytes to convert to UUID", Value: value}
+				return &ValidationError{Type: TypeUUID, Msg: "[]byte must be 16 bytes to convert to UUID", Value: value}
 			}
 			*dst = UUID{Status: Present}
 			copy(dst.Bytes[:], value)
@@ -90,7 +90,7 @@ func (dst *UUID) Set(src any) error {
 		if originalSrc, ok := underlyingUUIDType(src); ok {
 			return dst.Set(originalSrc)
 		}
-		return &ValidationError{Type: TypeUUID, msg: "no conversion available", Value: value}
+		return &ValidationError{Type: TypeUUID, Msg: noConversion, Value: value}
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func parseUUID(src string) (dst [16]byte, err error) {
 		// dashes already stripped, assume valid
 	default:
 		// assume invalid.
-		return dst, &ValidationError{Type: TypeUUID, msg: fmt.Sprintf("invalid %d UUID length", len(src)), Value: src}
+		return dst, &ValidationError{Type: TypeUUID, Msg: fmt.Sprintf("invalid %d UUID length", len(src)), Value: src}
 	}
 
 	buf, err := hex.DecodeString(src)

--- a/schema/uuid_array.go
+++ b/schema/uuid_array.go
@@ -60,7 +60,7 @@ func (dst *UUIDArray) Equal(src CQType) bool {
 func (dst *UUIDArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return fmt.Errorf("cannot decode %v into InetArray", value)
+		return &ValidationError{Type: TypeUUIDArray, msg: "cannot decode from string", Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -222,7 +222,7 @@ func (dst *UUIDArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return fmt.Errorf("cannot find dimensions of %v for UUIDArray", src)
+			return &ValidationError{Type: TypeUUIDArray, msg: "cannot find dimensions", Value: value}
 		}
 		if elementsLength == 0 {
 			*dst = UUIDArray{Status: Present}
@@ -232,7 +232,7 @@ func (dst *UUIDArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return fmt.Errorf("cannot convert %v to UUIDArray", src)
+			return &ValidationError{Type: TypeUUIDArray, msg: "not a slice", Value: value}
 		}
 
 		*dst = UUIDArray{
@@ -263,7 +263,7 @@ func (dst *UUIDArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return fmt.Errorf("cannot convert %v to UUIDArray, expected %d dst.Elements, but got %d instead", src, len(dst.Elements), elementCount)
+			return &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: value}
 		}
 	}
 
@@ -281,7 +281,7 @@ func (dst *UUIDArray) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, fmt.Errorf("multidimensional arrays must have array expressions with matching dimensions")
+			return 0, &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -294,10 +294,10 @@ func (dst *UUIDArray) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, fmt.Errorf("cannot convert all values to UUIDArray")
+		return 0, &ValidationError{Type: TypeUUIDArray, msg: "cannot create interface from value", Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, fmt.Errorf("%v in UUIDArray", err)
+		return 0, &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value, err: err}
 	}
 	index++
 

--- a/schema/uuid_array.go
+++ b/schema/uuid_array.go
@@ -60,7 +60,7 @@ func (dst *UUIDArray) Equal(src CQType) bool {
 func (dst *UUIDArray) fromString(value string) error {
 	// this is basically back from string encoding
 	if !strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}") {
-		return &ValidationError{Type: TypeUUIDArray, msg: "cannot decode from string", Value: value}
+		return &ValidationError{Type: TypeUUIDArray, Msg: cannotDecodeString, Value: value}
 	}
 
 	value = value[1 : len(value)-1]
@@ -222,7 +222,7 @@ func (dst *UUIDArray) Set(src any) error {
 
 		dimensions, elementsLength, ok := findDimensionsFromValue(reflectedValue, nil, 0)
 		if !ok {
-			return &ValidationError{Type: TypeUUIDArray, msg: "cannot find dimensions", Value: value}
+			return &ValidationError{Type: TypeUUIDArray, Msg: cannotFindDimensions, Value: value}
 		}
 		if elementsLength == 0 {
 			*dst = UUIDArray{Status: Present}
@@ -232,7 +232,7 @@ func (dst *UUIDArray) Set(src any) error {
 			if originalSrc, ok := underlyingSliceType(src); ok {
 				return dst.Set(originalSrc)
 			}
-			return &ValidationError{Type: TypeUUIDArray, msg: "not a slice", Value: value}
+			return &ValidationError{Type: TypeUUIDArray, Msg: noConversion, Value: value}
 		}
 
 		*dst = UUIDArray{
@@ -263,7 +263,7 @@ func (dst *UUIDArray) Set(src any) error {
 			}
 		}
 		if elementCount != len(dst.Elements) {
-			return &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("expected %d dst.Elements, but got %d instead", len(dst.Elements), elementCount), Value: value}
+			return &ValidationError{Type: TypeUUIDArray, Msg: fmt.Sprintf(expectedElements, len(dst.Elements), elementCount), Value: value}
 		}
 	}
 
@@ -281,7 +281,7 @@ func (dst *UUIDArray) setRecursive(value reflect.Value, index, dimension int) (i
 
 		valueLen := value.Len()
 		if int32(valueLen) != dst.Dimensions[dimension].Length {
-			return 0, &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("expected %d elements in dimension %d, but got %d instead", dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
+			return 0, &ValidationError{Type: TypeUUIDArray, Msg: fmt.Sprintf(expectedElementsInDimension, dst.Dimensions[dimension].Length, dimension, valueLen), Value: value}
 		}
 		for i := 0; i < valueLen; i++ {
 			var err error
@@ -294,10 +294,10 @@ func (dst *UUIDArray) setRecursive(value reflect.Value, index, dimension int) (i
 		return index, nil
 	}
 	if !value.CanInterface() {
-		return 0, &ValidationError{Type: TypeUUIDArray, msg: "cannot create interface from value", Value: value}
+		return 0, &ValidationError{Type: TypeUUIDArray, Msg: notInterface, Value: value}
 	}
 	if err := dst.Elements[index].Set(value.Interface()); err != nil {
-		return 0, &ValidationError{Type: TypeUUIDArray, msg: fmt.Sprintf("cannot set element %d", index), Value: value, err: err}
+		return 0, &ValidationError{Type: TypeUUIDArray, Msg: fmt.Sprintf(cannotSetIndex, index), Value: value, Err: err}
 	}
 	index++
 


### PR DESCRIPTION
Apparently we weren't really sending anything to sentry (apart from one place in table resolver panics).

Now this should send sentry errors on all panics that we catch + all validation errors.