### PR TITLE
fix: Incremental tables should not delete stale

### DIFF
--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/schema"
-	"github.com/cloudquery/plugin-sdk/specs"
 )
 
 type worker struct {
@@ -135,11 +134,5 @@ func (p *Plugin) writeManagedTableBatch(ctx context.Context, tables schema.Table
 		}
 	}
 	p.workersLock.Unlock()
-
-	if p.spec.WriteMode == specs.WriteModeOverwriteDeleteStale {
-		if err := p.DeleteStale(ctx, tables, sourceName, syncTime); err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -254,7 +254,13 @@ func (p *Plugin) Write(ctx context.Context, tables schema.Tables, sourceName str
 		panic("unknown client type")
 	}
 	if p.spec.WriteMode == specs.WriteModeOverwriteDeleteStale {
-		if err := p.DeleteStale(ctx, tables, sourceName, syncTime); err != nil {
+		include := func(t *schema.Table) bool { return true }
+		exclude := func(t *schema.Table) bool { return t.IsIncremental }
+		nonIncrementalTables, err := tables.FilterDfsFunc(include, exclude)
+		if err != nil {
+			return err
+		}
+		if err := p.DeleteStale(ctx, nonIncrementalTables, sourceName, syncTime); err != nil {
 			return err
 		}
 	}

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -117,18 +117,95 @@ func (s *PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Contex
 		return fmt.Errorf("after overwrite expected second resource diff: %s", diff)
 	}
 
-	if !s.tests.SkipDeleteStale {
-		if err := p.DeleteStale(ctx, tables, sourceName, secondSyncTime); err != nil {
-			return fmt.Errorf("failed to delete stale data second time: %w", err)
-		}
+	return nil
+}
+
+func (s *PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination) error {
+	spec.WriteMode = specs.WriteModeOverwriteDeleteStale
+	if err := p.Init(ctx, logger, spec); err != nil {
+		return fmt.Errorf("failed to init plugin: %w", err)
+	}
+	tableName := "cq_test_write_overwrite_delete_stale"
+	table := testdata.TestTable(tableName)
+	incTable := testdata.TestTable(tableName + "_incremental")
+	incTable.IsIncremental = true
+	syncTime := time.Now().UTC().Round(1 * time.Second)
+	tables := []*schema.Table{
+		table,
+		incTable,
+	}
+	if err := p.Migrate(ctx, tables); err != nil {
+		return fmt.Errorf("failed to migrate tables: %w", err)
+	}
+
+	sourceName := "testOverwriteSource" + uuid.NewString()
+
+	resources := createTestResources(table, sourceName, syncTime, 2)
+	incResources := createTestResources(incTable, sourceName, syncTime, 2)
+	if err := p.writeAll(ctx, tables, sourceName, syncTime, append(resources, incResources...)); err != nil {
+		return fmt.Errorf("failed to write all: %w", err)
+	}
+	sortResources(table, resources)
+
+	resourcesRead, err := p.readAll(ctx, table, sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to read all: %w", err)
+	}
+	sortCQTypes(table, resourcesRead)
+
+	if len(resourcesRead) != 2 {
+		return fmt.Errorf("expected 2 resources, got %d", len(resourcesRead))
+	}
+
+	if diff := resources[0].Data.Diff(resourcesRead[0]); diff != "" {
+		return fmt.Errorf("expected first resource diff: %s", diff)
+	}
+
+	if diff := resources[1].Data.Diff(resourcesRead[1]); diff != "" {
+		return fmt.Errorf("expected second resource diff: %s", diff)
+	}
+
+	// read from incremental table
+	resourcesRead, err = p.readAll(ctx, incTable, sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to read all: %w", err)
+	}
+	if len(resourcesRead) != 2 {
+		return fmt.Errorf("expected 2 resources in incremental table, got %d", len(resourcesRead))
+	}
+
+	secondSyncTime := syncTime.Add(time.Second).UTC()
+
+	// copy first resource but update the sync time
+	updatedResource := schema.DestinationResource{
+		TableName: table.Name,
+		Data:      make(schema.CQTypes, len(resources[0].Data)),
+	}
+	copy(updatedResource.Data, resources[0].Data)
+	_ = updatedResource.Data[1].Set(secondSyncTime)
+
+	// write second time
+	if err := p.writeOne(ctx, tables, sourceName, secondSyncTime, updatedResource); err != nil {
+		return fmt.Errorf("failed to write one second time: %w", err)
+	}
+
+	resourcesRead, err = p.readAll(ctx, table, sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to read all second time: %w", err)
+	}
+	sortCQTypes(table, resourcesRead)
+	if len(resourcesRead) != 1 {
+		return fmt.Errorf("after overwrite expected 1 resource, got %d", len(resourcesRead))
+	}
+
+	if diff := resources[0].Data.Diff(resourcesRead[0]); diff != "" {
+		return fmt.Errorf("after overwrite expected first resource diff: %s", diff)
 	}
 
 	resourcesRead, err = p.readAll(ctx, tables[0], sourceName)
 	if err != nil {
 		return fmt.Errorf("failed to read all second time: %w", err)
 	}
-	sortCQTypes(table, resourcesRead)
-
 	if len(resourcesRead) != 1 {
 		return fmt.Errorf("expected 1 resource after delete stale, got %d", len(resourcesRead))
 	}
@@ -136,6 +213,16 @@ func (s *PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Contex
 	// we expect the only resource returned to match the updated resource we wrote
 	if diff := updatedResource.Data.Diff(resourcesRead[0]); diff != "" {
 		return fmt.Errorf("after delete stale expected resource diff: %s", diff)
+	}
+
+	// we expect the incremental table to still have 2 resources, because delete-stale should
+	// not apply there
+	resourcesRead, err = p.readAll(ctx, tables[1], sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to read all from incremental table: %w", err)
+	}
+	if len(resourcesRead) != 2 {
+		return fmt.Errorf("expected 2 resources in incremental table after delete-stale, got %d", len(resourcesRead))
 	}
 
 	return nil
@@ -322,6 +409,17 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 			return
 		}
 		if err := suite.destinationPluginTestWriteOverwrite(ctx, p, logger, destSpec); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("TestWriteOverwriteDeleteStale", func(t *testing.T) {
+		t.Helper()
+		if suite.tests.SkipOverwrite || suite.tests.SkipDeleteStale {
+			t.Skip("skipping TestWriteOverwriteDeleteStale")
+			return
+		}
+		if err := suite.destinationPluginTestWriteOverwriteDeleteStale(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
When `overwrite-delete-stale` write mode is used, the delete stale should exclude incremental tables. We still want `delete-stale` behavior for non-incremental tables, but incremental tables have the expectation that previously synced rows should remain there. 

This also fixes a small bug where we were deleting stale entries twice for managed tables.