### PR TITLE
feat(transformers): Add support for `net.IP`

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -280,8 +280,7 @@ func DefaultTypeTransformer(v reflect.StructField) (schema.ValueType, error) {
 
 func defaultGoTypeToSchemaType(v reflect.Type) (schema.ValueType, error) {
 	// Non primitive types
-	switch v {
-	case reflect.TypeOf(net.IP{}):
+	if v == reflect.TypeOf(net.IP{}) {
 		return schema.TypeInet, nil
 	}
 

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -281,7 +281,7 @@ func DefaultTypeTransformer(v reflect.StructField) (schema.ValueType, error) {
 func defaultGoTypeToSchemaType(v reflect.Type) (schema.ValueType, error) {
 	// Non primitive types
 	switch v {
-	case reflect.TypeOf(net.IP{}), reflect.TypeOf(&net.IP{}):
+	case reflect.TypeOf(net.IP{}):
 		return schema.TypeInet, nil
 	}
 

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -2,6 +2,7 @@ package transformers
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -278,6 +279,12 @@ func DefaultTypeTransformer(v reflect.StructField) (schema.ValueType, error) {
 }
 
 func defaultGoTypeToSchemaType(v reflect.Type) (schema.ValueType, error) {
+	// Non primitive types
+	switch v {
+	case reflect.TypeOf(net.IP{}), reflect.TypeOf(&net.IP{}):
+		return schema.TypeInet, nil
+	}
+
 	k := v.Kind()
 	switch k {
 	case reflect.Pointer:

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -1,6 +1,7 @@
 package transformers
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -30,6 +31,9 @@ type (
 
 		StringArrayCol        []string  `json:"string_array_col,omitempty"`
 		StringPointerArrayCol []*string `json:"string_pointer_array_col,omitempty"`
+
+		InetCol        net.IP  `json:"inet_col,omitempty"`
+		InetPointerCol *net.IP `json:"inet_pointer_col,omitempty"`
 
 		ByteArrayCol []byte `json:"byte_array_col,omitempty"`
 
@@ -95,6 +99,14 @@ var (
 		{
 			Name: "string_pointer_array_col",
 			Type: schema.TypeStringArray,
+		},
+		{
+			Name: "inet_col",
+			Type: schema.TypeInet,
+		},
+		{
+			Name: "inet_pointer_col",
+			Type: schema.TypeInet,
 		},
 		{
 			Name: "byte_array_col",


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


A follow up to https://github.com/cloudquery/cloudquery/pull/6588 where `net.IP` was resolved to `TypeByteArray` by the SDK and we had to manually configure it https://github.com/cloudquery/cloudquery/pull/6588/commits/0ccf23be4b556ad5d6f252cecc9e13df18fa251c

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
