### PR TITLE
fix(types-timestamptz): Handle `MarshalText` and `String` for pointer receivers

### DIFF
--- a/schema/timestamptz.go
+++ b/schema/timestamptz.go
@@ -106,7 +106,11 @@ func (dst *Timestamptz) Set(src any) error {
 		*dst = Timestamptz{InfinityModifier: value, Status: Present}
 	default:
 		if originalSrc, ok := underlyingTimeType(src); ok {
-			return dst.Set(originalSrc)
+			err := dst.Set(originalSrc)
+			// We want to fall through to the TextMarshaler/Stringer interface if there was an error on the underlying type
+			if err == nil {
+				return nil
+			}
 		}
 		if value, ok := value.(encoding.TextMarshaler); ok {
 			s, err := value.MarshalText()

--- a/schema/timestamptz_test.go
+++ b/schema/timestamptz_test.go
@@ -9,6 +9,13 @@ type Timestamp struct {
 	time.Time
 }
 
+type TimestampPointer struct {
+}
+
+func (*TimestampPointer) String() string {
+	return "2150-10-15 07:25:09.75007611 +0000 UTC"
+}
+
 func TestTimestamptzSet(t *testing.T) {
 	type _time time.Time
 
@@ -36,6 +43,7 @@ func TestTimestamptzSet(t *testing.T) {
 		{source: timeInstance.String(), result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
 		{source: Timestamp{timeInstance}, result: Timestamptz{Time: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Status: Present}},
 		{source: "", result: Timestamptz{Status: Null}},
+		{source: &TimestampPointer{}, result: Timestamptz{Time: time.Date(2150, 10, 15, 7, 25, 9, 750076110, time.UTC), Status: Present}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

We need to also try calling `MarshalText` and `String` when those methods are declared on a pointer receiver

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
