### PR TITLE
feat(transformers): Add WithPrimaryKeys option

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -20,6 +20,7 @@ type structTransformer struct {
 	ignoreInTestsTransformer      IgnoreInTestsTransformer
 	unwrapAllEmbeddedStructFields bool
 	structFieldsToUnwrap          []string
+	pkFields                      []string
 }
 
 type NameTransformer func(reflect.StructField) (string, error)
@@ -104,6 +105,13 @@ func WithIgnoreInTestsTransformer(transformer IgnoreInTestsTransformer) StructTr
 	}
 }
 
+// WithPrimaryKeys allows to specify what struct fields should be used as primary keys
+func WithPrimaryKeys(fields ...string) StructTransformerOption {
+	return func(t *structTransformer) {
+		t.pkFields = fields
+	}
+}
+
 func TransformWithStruct(st any, opts ...StructTransformerOption) schema.Transform {
 	t := &structTransformer{
 		nameTransformer:          DefaultNameTransformer,
@@ -142,6 +150,7 @@ func TransformWithStruct(st any, opts ...StructTransformerOption) schema.Transfo
 				}
 			}
 		}
+
 		return nil
 	}
 }
@@ -249,14 +258,20 @@ func (t *structTransformer) addColumnFromField(field reflect.StructField, parent
 		resolver = DefaultResolverTransformer(field, path)
 	}
 
-	t.table.Columns = append(t.table.Columns,
-		schema.Column{
-			Name:          name,
-			Type:          columnType,
-			Resolver:      resolver,
-			IgnoreInTests: t.ignoreInTestsTransformer(field),
-		},
-	)
+	column := schema.Column{
+		Name:          name,
+		Type:          columnType,
+		Resolver:      resolver,
+		IgnoreInTests: t.ignoreInTestsTransformer(field),
+	}
+
+	for _, pk := range t.pkFields {
+		if pk == field.Name {
+			column.CreationOptions.PrimaryKey = true
+		}
+	}
+
+	t.table.Columns = append(t.table.Columns, column)
 
 	return nil
 }

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -52,6 +52,12 @@ type (
 	testSliceStruct []struct {
 		IntCol int
 	}
+
+	testPKStruct struct {
+		Parent  string `json:"parent"`
+		Name    string `json:"name"`
+		Version int    `json:"version"`
+	}
 )
 
 var (
@@ -163,6 +169,26 @@ var (
 			},
 		},
 	}
+
+	expectedTableWithPKs = schema.Table{
+		Name: "test_pk_struct",
+		Columns: schema.ColumnList{
+			{
+				Name:            "parent",
+				Type:            schema.TypeString,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
+			{
+				Name:            "name",
+				Type:            schema.TypeString,
+				CreationOptions: schema.ColumnCreationOptions{PrimaryKey: true},
+			},
+			{
+				Name: "version",
+				Type: schema.TypeInt,
+			},
+		},
+	}
 )
 
 func TestTableFromGoStruct(t *testing.T) {
@@ -210,6 +236,16 @@ func TestTableFromGoStruct(t *testing.T) {
 				testStruct: testSliceStruct{},
 			},
 			want: expectedTestSliceStruct,
+		},
+		{
+			name: "Should configure primary keys when options are set",
+			args: args{
+				testStruct: testPKStruct{},
+				options: []StructTransformerOption{
+					WithPrimaryKeys("Parent", "Name"),
+				},
+			},
+			want: expectedTableWithPKs,
 		},
 	}
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Adds `WithPrimaryKeys` so we don't need to define extra columns just for the sake of primary keys.
The issue with extra columns is that you need to manually configure the column name resolver and type. It's easy to miss those especially when plugins have custom logic for resolvers and types, for example:
https://github.com/cloudquery/cloudquery/blob/cb9b4f85ccb82f850e6ded6c19a39d06c4f2c94a/plugins/source/gcp/client/transformers.go#L17
https://github.com/cloudquery/cloudquery/blob/cb9b4f85ccb82f850e6ded6c19a39d06c4f2c94a/plugins/source/gcp/client/transformers.go#L39
https://github.com/cloudquery/cloudquery/blob/cb9b4f85ccb82f850e6ded6c19a39d06c4f2c94a/plugins/source/gcp/client/transformers.go#L54

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
