### PR TITLE
fix: Send resource validation errors to Sentry

### DIFF
--- a/plugins/source/scheduler_dfs.go
+++ b/plugins/source/scheduler_dfs.go
@@ -161,6 +161,10 @@ func (p *Plugin) resolveResourcesDfs(ctx context.Context, table *schema.Table, c
 				if err := resolvedResource.Validate(); err != nil {
 					tableMetrics := p.metrics.TableClient[table.Name][client.ID()]
 					p.logger.Error().Err(err).Str("table", table.Name).Str("client", client.ID()).Msg("resource resolver finished with validation error")
+					sentry.WithScope(func(scope *sentry.Scope) {
+						scope.SetTag("table", table.Name)
+						sentry.CurrentHub().CaptureMessage(err.Error())
+					})
 					atomic.AddUint64(&tableMetrics.Errors, 1)
 					return
 				}

--- a/plugins/source/scheduler_dfs.go
+++ b/plugins/source/scheduler_dfs.go
@@ -162,14 +162,13 @@ func (p *Plugin) resolveResourcesDfs(ctx context.Context, table *schema.Table, c
 				if err := resolvedResource.Validate(); err != nil {
 					tableMetrics := p.metrics.TableClient[table.Name][client.ID()]
 					p.logger.Error().Err(err).Str("table", table.Name).Str("client", client.ID()).Msg("resource resolver finished with validation error")
-					if _, found := sentValidationErrors.Load(table.Name); !found {
+					if _, found := sentValidationErrors.LoadOrStore(table.Name, struct{}{}); !found {
 						// send resource validation errors to Sentry only once per table,
 						// to avoid sending too many duplicate messages
 						sentry.WithScope(func(scope *sentry.Scope) {
 							scope.SetTag("table", table.Name)
 							sentry.CurrentHub().CaptureMessage(err.Error())
 						})
-						sentValidationErrors.Store(table.Name, struct{}{})
 					}
 					atomic.AddUint64(&tableMetrics.Errors, 1)
 					return


### PR DESCRIPTION
Resource validation errors, like a row missing a PK value, are non-recoverable and need to be fixed by the plugin author. As such, we should know about them when they happen, even though they do not cause a panic in the code.