### PR TITLE
fix(destination): Pass proper spec to client constructor

### DIFF
--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -176,7 +176,7 @@ func (p *Plugin) Init(ctx context.Context, logger zerolog.Logger, spec specs.Des
 	p.logger = logger
 	p.spec = spec
 	p.spec.SetDefaults(p.defaultBatchSize, p.defaultBatchSizeBytes)
-	p.client, err = p.newClient(ctx, logger, spec)
+	p.client, err = p.newClient(ctx, logger, p.spec)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We need to pass the correct spec to the client constructor.
Currently, we set defaults on `p.spec`, but pass `spec` that can be not initialized properly.