### PR TITLE
fix: PK Addition Order

### DIFF
--- a/plugins/source/plugin.go
+++ b/plugins/source/plugin.go
@@ -112,11 +112,11 @@ func NewPlugin(name string, version string, tables []*schema.Table, newExecution
 		metrics:            &Metrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
 		caser:              caser.New(),
 	}
-	addInternalColumns(p.tables)
 	setParents(p.tables, nil)
 	if err := transformTables(p.tables); err != nil {
 		panic(err)
 	}
+	addInternalColumns(p.tables)
 	if err := p.validate(); err != nil {
 		panic(err)
 	}

--- a/plugins/source/plugin_test.go
+++ b/plugins/source/plugin_test.go
@@ -326,7 +326,7 @@ var testTable struct {
 	Quaternary   string
 }
 
-func TestNewPlugin(t *testing.T) {
+func TestNewPluginPrimaryKeys(t *testing.T) {
 	testTransforms := []struct {
 		transformerOptions []transformers.StructTransformerOption
 		resultKeys         []string


### PR DESCRIPTION
#### Summary

This will only add the default PKs once the `Transformers` have run and added any and all PKs


<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
