### PR TITLE
feat(spec): Add source, destination String methods

### DIFF
--- a/specs/destination.go
+++ b/specs/destination.go
@@ -71,3 +71,11 @@ func (d *Destination) Validate() error {
 	}
 	return nil
 }
+
+func (d Destination) String() string {
+	pathParts := strings.Split(d.Path, "/")
+	if d.Name == pathParts[1] {
+		return fmt.Sprintf("%s (%s)", d.Name, d.Version)
+	}
+	return fmt.Sprintf("%s (%s@%s)", d.Name, pathParts[1], d.Version)
+}

--- a/specs/destination.go
+++ b/specs/destination.go
@@ -73,7 +73,13 @@ func (d *Destination) Validate() error {
 }
 
 func (d Destination) String() string {
+	if d.Registry != RegistryGithub {
+		return fmt.Sprintf("%s (%s@%s)", d.Name, d.Registry, d.Path)
+	}
 	pathParts := strings.Split(d.Path, "/")
+	if len(pathParts) != 2 {
+		return fmt.Sprintf("%s (%s@%s)", d.Name, d.Path, d.Version)
+	}
 	if d.Name == pathParts[1] {
 		return fmt.Sprintf("%s (%s)", d.Name, d.Version)
 	}

--- a/specs/destination.go
+++ b/specs/destination.go
@@ -72,7 +72,7 @@ func (d *Destination) Validate() error {
 	return nil
 }
 
-func (d Destination) String() string {
+func (d Destination) VersionString() string {
 	if d.Registry != RegistryGithub {
 		return fmt.Sprintf("%s (%s@%s)", d.Name, d.Registry, d.Path)
 	}

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -200,9 +200,10 @@ func TestDestinationUnmarshalSpecValidate(t *testing.T) {
 
 func TestDestination_String(t *testing.T) {
 	type fields struct {
-		Name    string
-		Version string
-		Path    string
+		Name     string
+		Version  string
+		Path     string
+		Registry Registry
 	}
 	tests := []struct {
 		name   string
@@ -212,18 +213,40 @@ func TestDestination_String(t *testing.T) {
 		{
 			name: "should use short version without name part in path when those are the same",
 			fields: fields{
-				Name:    "aws",
-				Version: "v10.0.0",
-				Path:    "cloudquery/aws",
+				Name:     "aws",
+				Version:  "v10.0.0",
+				Path:     "cloudquery/aws",
+				Registry: RegistryGithub,
 			},
 			want: "aws (v10.0.0)",
 		},
 		{
 			name: "should use long version with path when name doesn't match path",
 			fields: fields{
-				Name:    "my-aws-spec",
-				Version: "v10.0.0",
-				Path:    "cloudquery/aws",
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "cloudquery/aws",
+				Registry: RegistryGithub,
+			},
+			want: "my-aws-spec (aws@v10.0.0)",
+		},
+		{
+			name: "should handle non GitHub registry",
+			fields: fields{
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "localhost:7777",
+				Registry: RegistryGrpc,
+			},
+			want: "my-aws-spec (grpc@localhost:7777)",
+		},
+		{
+			name: "should handle malformed path",
+			fields: fields{
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "aws",
+				Registry: RegistryGithub,
 			},
 			want: "my-aws-spec (aws@v10.0.0)",
 		},
@@ -231,9 +254,10 @@ func TestDestination_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := Destination{
-				Name:    tt.fields.Name,
-				Version: tt.fields.Version,
-				Path:    tt.fields.Path,
+				Name:     tt.fields.Name,
+				Version:  tt.fields.Version,
+				Path:     tt.fields.Path,
+				Registry: tt.fields.Registry,
 			}
 			if got := d.String(); got != tt.want {
 				t.Errorf("Destination.String() = %v, want %v", got, tt.want)

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -197,3 +197,47 @@ func TestDestinationUnmarshalSpecValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestDestination_String(t *testing.T) {
+	type fields struct {
+		Name    string
+		Version string
+		Path    string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "should use short version without name part in path when those are the same",
+			fields: fields{
+				Name:    "aws",
+				Version: "v10.0.0",
+				Path:    "cloudquery/aws",
+			},
+			want: "aws (v10.0.0)",
+		},
+		{
+			name: "should use long version with path when name doesn't match path",
+			fields: fields{
+				Name:    "my-aws-spec",
+				Version: "v10.0.0",
+				Path:    "cloudquery/aws",
+			},
+			want: "my-aws-spec (aws@v10.0.0)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Destination{
+				Name:    tt.fields.Name,
+				Version: tt.fields.Version,
+				Path:    tt.fields.Path,
+			}
+			if got := d.String(); got != tt.want {
+				t.Errorf("Destination.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/specs/destination_test.go
+++ b/specs/destination_test.go
@@ -198,7 +198,7 @@ func TestDestinationUnmarshalSpecValidate(t *testing.T) {
 	}
 }
 
-func TestDestination_String(t *testing.T) {
+func TestDestination_VersionString(t *testing.T) {
 	type fields struct {
 		Name     string
 		Version  string
@@ -259,7 +259,7 @@ func TestDestination_String(t *testing.T) {
 				Path:     tt.fields.Path,
 				Registry: tt.fields.Registry,
 			}
-			if got := d.String(); got != tt.want {
+			if got := d.VersionString(); got != tt.want {
 				t.Errorf("Destination.String() = %v, want %v", got, tt.want)
 			}
 		})

--- a/specs/source.go
+++ b/specs/source.go
@@ -129,7 +129,7 @@ func (s *Source) Validate() error {
 	return nil
 }
 
-func (s Source) String() string {
+func (s Source) VersionString() string {
 	if s.Registry != RegistryGithub {
 		return fmt.Sprintf("%s (%s@%s)", s.Name, s.Registry, s.Path)
 	}

--- a/specs/source.go
+++ b/specs/source.go
@@ -130,7 +130,13 @@ func (s *Source) Validate() error {
 }
 
 func (s Source) String() string {
+	if s.Registry != RegistryGithub {
+		return fmt.Sprintf("%s (%s@%s)", s.Name, s.Registry, s.Path)
+	}
 	pathParts := strings.Split(s.Path, "/")
+	if len(pathParts) != 2 {
+		return fmt.Sprintf("%s (%s@%s)", s.Name, s.Path, s.Version)
+	}
 	if s.Name == pathParts[1] {
 		return fmt.Sprintf("%s (%s)", s.Name, s.Version)
 	}

--- a/specs/source.go
+++ b/specs/source.go
@@ -128,3 +128,11 @@ func (s *Source) Validate() error {
 	}
 	return nil
 }
+
+func (s Source) String() string {
+	pathParts := strings.Split(s.Path, "/")
+	if s.Name == pathParts[1] {
+		return fmt.Sprintf("%s (%s)", s.Name, s.Version)
+	}
+	return fmt.Sprintf("%s (%s@%s)", s.Name, pathParts[1], s.Version)
+}

--- a/specs/source_test.go
+++ b/specs/source_test.go
@@ -192,9 +192,10 @@ func TestSourceUnmarshalSpecValidate(t *testing.T) {
 
 func TestSpec_String(t *testing.T) {
 	type fields struct {
-		Name    string
-		Version string
-		Path    string
+		Name     string
+		Version  string
+		Path     string
+		Registry Registry
 	}
 	tests := []struct {
 		name   string
@@ -204,18 +205,40 @@ func TestSpec_String(t *testing.T) {
 		{
 			name: "should use short version without name part in path when those are the same",
 			fields: fields{
-				Name:    "aws",
-				Version: "v10.0.0",
-				Path:    "cloudquery/aws",
+				Name:     "aws",
+				Version:  "v10.0.0",
+				Path:     "cloudquery/aws",
+				Registry: RegistryGithub,
 			},
 			want: "aws (v10.0.0)",
 		},
 		{
 			name: "should use long version with path when name doesn't match path",
 			fields: fields{
-				Name:    "my-aws-spec",
-				Version: "v10.0.0",
-				Path:    "cloudquery/aws",
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "cloudquery/aws",
+				Registry: RegistryGithub,
+			},
+			want: "my-aws-spec (aws@v10.0.0)",
+		},
+		{
+			name: "should handle non GitHub registry",
+			fields: fields{
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "localhost:7777",
+				Registry: RegistryGrpc,
+			},
+			want: "my-aws-spec (grpc@localhost:7777)",
+		},
+		{
+			name: "should handle malformed path",
+			fields: fields{
+				Name:     "my-aws-spec",
+				Version:  "v10.0.0",
+				Path:     "aws",
+				Registry: RegistryGithub,
 			},
 			want: "my-aws-spec (aws@v10.0.0)",
 		},
@@ -223,9 +246,10 @@ func TestSpec_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Source{
-				Name:    tt.fields.Name,
-				Version: tt.fields.Version,
-				Path:    tt.fields.Path,
+				Name:     tt.fields.Name,
+				Version:  tt.fields.Version,
+				Path:     tt.fields.Path,
+				Registry: tt.fields.Registry,
 			}
 			if got := s.String(); got != tt.want {
 				t.Errorf("Source.String() = %v, want %v", got, tt.want)

--- a/specs/source_test.go
+++ b/specs/source_test.go
@@ -189,3 +189,47 @@ func TestSourceUnmarshalSpecValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestSpec_String(t *testing.T) {
+	type fields struct {
+		Name    string
+		Version string
+		Path    string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "should use short version without name part in path when those are the same",
+			fields: fields{
+				Name:    "aws",
+				Version: "v10.0.0",
+				Path:    "cloudquery/aws",
+			},
+			want: "aws (v10.0.0)",
+		},
+		{
+			name: "should use long version with path when name doesn't match path",
+			fields: fields{
+				Name:    "my-aws-spec",
+				Version: "v10.0.0",
+				Path:    "cloudquery/aws",
+			},
+			want: "my-aws-spec (aws@v10.0.0)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Source{
+				Name:    tt.fields.Name,
+				Version: tt.fields.Version,
+				Path:    tt.fields.Path,
+			}
+			if got := s.String(); got != tt.want {
+				t.Errorf("Source.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/specs/source_test.go
+++ b/specs/source_test.go
@@ -190,7 +190,7 @@ func TestSourceUnmarshalSpecValidate(t *testing.T) {
 	}
 }
 
-func TestSpec_String(t *testing.T) {
+func TestSpec_VersionString(t *testing.T) {
 	type fields struct {
 		Name     string
 		Version  string
@@ -251,7 +251,7 @@ func TestSpec_String(t *testing.T) {
 				Path:     tt.fields.Path,
 				Registry: tt.fields.Registry,
 			}
-			if got := s.String(); got != tt.want {
+			if got := s.VersionString(); got != tt.want {
 				t.Errorf("Source.String() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


A user recently ran into some issues since they thought they used a newer version of a plugin, but actually used an old one.
This PR adds `String()` methods to specs so we can use them in logs/errors.

CLI PR https://github.com/cloudquery/cloudquery/pull/6842

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
