### PR TITLE
fix(clients): Update `log line too long` message

### DIFF
--- a/clients/destination/v0/destination.go
+++ b/clients/destination/v0/destination.go
@@ -153,16 +153,16 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 				break
 			}
 			if errors.Is(err, logging.ErrLogLineToLong) {
-				c.logger.Err(err).Str("line", string(line)).Msg("skipping too long log line")
+				c.logger.Info().Str("line", string(line)).Msg("truncated destination plugin log line")
 				continue
 			}
 			if err != nil {
-				c.logger.Err(err).Msg("failed to read log line from plugin")
+				c.logger.Err(err).Msg("failed to read log line from destination plugin")
 				break
 			}
 			var structuredLogLine map[string]any
 			if err := json.Unmarshal(line, &structuredLogLine); err != nil {
-				c.logger.Err(err).Str("line", string(line)).Msg("failed to unmarshal log line from plugin")
+				c.logger.Err(err).Str("line", string(line)).Msg("failed to unmarshal log line from destination plugin")
 			} else {
 				logging.JSONToLog(c.logger, structuredLogLine)
 			}

--- a/clients/source/v0/source.go
+++ b/clients/source/v0/source.go
@@ -150,16 +150,16 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 				break
 			}
 			if errors.Is(err, logging.ErrLogLineToLong) {
-				c.logger.Err(err).Str("line", string(line)).Msg("skipping too long log line")
+				c.logger.Info().Str("line", string(line)).Msg("truncated source plugin log line")
 				continue
 			}
 			if err != nil {
-				c.logger.Err(err).Msg("failed to read log line from plugin")
+				c.logger.Err(err).Msg("failed to read log line from source plugin")
 				break
 			}
 			var structuredLogLine map[string]any
 			if err := json.Unmarshal(line, &structuredLogLine); err != nil {
-				c.logger.Err(err).Str("line", string(line)).Msg("failed to unmarshal log line from plugin")
+				c.logger.Err(err).Str("line", string(line)).Msg("failed to unmarshal log line from source plugin")
 			} else {
 				logging.JSONToLog(c.logger, structuredLogLine)
 			}

--- a/internal/logging/log_reader.go
+++ b/internal/logging/log_reader.go
@@ -9,7 +9,10 @@ import (
 // logReaderPrefixLen is used when returning a partial line as context in NextLine
 const logReaderPrefixLen = 1000
 
-var ErrLogLineToLong = errors.New("log line too long, discarding")
+var (
+	ErrLogLineToLong = errors.New("log line too long, discarding")
+	ellipsis         = []byte("...")
+)
 
 // logReader is a custom implementation similar to bufio.Scanner, but provides a way to handle lines
 // (or tokens) that exceed the buffer size.
@@ -52,5 +55,5 @@ func (r *LogReader) NextLine() ([]byte, error) {
 			return nil, err
 		}
 	}
-	return prefix, ErrLogLineToLong
+	return append(prefix, ellipsis...), ErrLogLineToLong
 }

--- a/internal/logging/log_reader_test.go
+++ b/internal/logging/log_reader_test.go
@@ -45,7 +45,7 @@ func Test_LogReader(t *testing.T) {
 			name: "very long line",
 			text: longStr(10000000),
 			wantLines: []string{
-				longStr(logReaderPrefixLen),
+				longStr(logReaderPrefixLen) + "...",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/cloudquery/issues/5665, by making this log message look less like an error.
I could go with `Warn` too and maybe update the level of the other errors here (but won't do it unless someone finds those confusing).

The current message can cause users to think that there is data loss or something wrong with the sync

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
