### PR TITLE
fix: Simplify client naming conventions

### DIFF
--- a/clients/destination/v0/destination.go
+++ b/clients/destination/v0/destination.go
@@ -44,26 +44,26 @@ type Client struct {
 
 type ClientOption func(*Client)
 
-func WithDestinationLogger(logger zerolog.Logger) func(*Client) {
+func WithLogger(logger zerolog.Logger) func(*Client) {
 	return func(c *Client) {
 		c.logger = logger
 	}
 }
 
-func WithDestinationDirectory(directory string) func(*Client) {
+func WithDirectory(directory string) func(*Client) {
 	return func(c *Client) {
 		c.directory = directory
 	}
 }
 
-func WithDestinationGrpcConn(userConn *grpc.ClientConn) func(*Client) {
+func WithGrpcConn(userConn *grpc.ClientConn) func(*Client) {
 	return func(c *Client) {
 		// we use a different variable here because we don't want to close a connection that wasn't created by us.
 		c.userConn = userConn
 	}
 }
 
-func WithDestinationNoSentry() func(*Client) {
+func WithNoSentry() func(*Client) {
 	return func(c *Client) {
 		c.noSentry = true
 	}

--- a/clients/destination/v0/destination_test.go
+++ b/clients/destination/v0/destination_test.go
@@ -38,7 +38,7 @@ func TestDestinationClient(t *testing.T) {
 	for _, tc := range newDestinationClientTestCases {
 		t.Run(tc.Path+"_"+tc.Version, func(t *testing.T) {
 			dirName := t.TempDir()
-			c, err := NewClient(ctx, tc.Registry, tc.Path, tc.Version, WithDestinationLogger(l), WithDestinationDirectory(dirName))
+			c, err := NewClient(ctx, tc.Registry, tc.Path, tc.Version, WithLogger(l), WithDirectory(dirName))
 			if err != nil {
 				if strings.HasPrefix(err.Error(), "destination plugin protocol version") {
 					// this also means success as in this tests we just want to make sure we were able to download and spawn the plugin
@@ -69,7 +69,7 @@ func TestDestinationClientWriteReturnsCorrectError(t *testing.T) {
 	ctx := context.Background()
 	l := zerolog.New(zerolog.NewTestWriter(t)).Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(zerolog.DebugLevel)
 	dirName := t.TempDir()
-	c, err := NewClient(ctx, specs.RegistryGithub, "cloudquery/sqlite", "v1.0.11", WithDestinationLogger(l), WithDestinationDirectory(dirName))
+	c, err := NewClient(ctx, specs.RegistryGithub, "cloudquery/sqlite", "v1.0.11", WithLogger(l), WithDirectory(dirName))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/clients/source/v0/source.go
+++ b/clients/source/v0/source.go
@@ -47,26 +47,26 @@ type FetchResultMessage struct {
 
 type ClientOption func(*Client)
 
-func WithSourceLogger(logger zerolog.Logger) func(*Client) {
+func WithLogger(logger zerolog.Logger) func(*Client) {
 	return func(c *Client) {
 		c.logger = logger
 	}
 }
 
-func WithSourceDirectory(directory string) func(*Client) {
+func WithDirectory(directory string) func(*Client) {
 	return func(c *Client) {
 		c.directory = directory
 	}
 }
 
-func WithSourceGRPCConnection(userConn *grpc.ClientConn) func(*Client) {
+func WithGRPCConnection(userConn *grpc.ClientConn) func(*Client) {
 	return func(c *Client) {
 		// we use a different variable here because we don't want to close a connection that wasn't created by us.
 		c.userConn = userConn
 	}
 }
 
-func WithSourceNoSentry() func(*Client) {
+func WithNoSentry() func(*Client) {
 	return func(c *Client) {
 		c.noSentry = true
 	}

--- a/clients/source/v0/source_test.go
+++ b/clients/source/v0/source_test.go
@@ -33,7 +33,7 @@ func TestSourceClient(t *testing.T) {
 	for _, tc := range newSourceClientTestCases {
 		t.Run(tc.Path+"_"+tc.Version, func(t *testing.T) {
 			dirName := t.TempDir()
-			c, err := NewClient(ctx, tc.Registry, tc.Path, tc.Version, WithSourceLogger(l), WithSourceDirectory(dirName))
+			c, err := NewClient(ctx, tc.Registry, tc.Path, tc.Version, WithLogger(l), WithDirectory(dirName))
 			if err != nil {
 				if strings.HasPrefix(err.Error(), "source plugin protocol version") {
 					// this also means success as in this tests we just want to make sure we were able to download and spawn the plugin

--- a/clients/source/v1/source.go
+++ b/clients/source/v1/source.go
@@ -44,26 +44,26 @@ type FetchResultMessage struct {
 
 type ClientOption func(*Client)
 
-func WithSourceLogger(logger zerolog.Logger) func(*Client) {
+func WithLogger(logger zerolog.Logger) func(*Client) {
 	return func(c *Client) {
 		c.logger = logger
 	}
 }
 
-func WithSourceDirectory(directory string) func(*Client) {
+func WithDirectory(directory string) func(*Client) {
 	return func(c *Client) {
 		c.directory = directory
 	}
 }
 
-func WithSourceGRPCConnection(userConn *grpc.ClientConn) func(*Client) {
+func WithGRPCConnection(userConn *grpc.ClientConn) func(*Client) {
 	return func(c *Client) {
 		// we use a different variable here because we don't want to close a connection that wasn't created by us.
 		c.userConn = userConn
 	}
 }
 
-func WithSourceNoSentry() func(*Client) {
+func WithNoSentry() func(*Client) {
 	return func(c *Client) {
 		c.noSentry = true
 	}

--- a/serve/destination_v0_test.go
+++ b/serve/destination_v0_test.go
@@ -62,7 +62,7 @@ func TestDestination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithDestinationGrpcConn(conn), clients.WithDestinationNoSentry())
+	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithGrpcConn(conn), clients.WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/serve/source_v0_test.go
+++ b/serve/source_v0_test.go
@@ -56,7 +56,7 @@ func TestSourceSuccessV1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGRPCConnection(conn), clients.WithSourceNoSentry())
+	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithGRPCConnection(conn), clients.WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/serve/source_v1_test.go
+++ b/serve/source_v1_test.go
@@ -115,7 +115,7 @@ func TestSourceSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGRPCConnection(conn), clients.WithSourceNoSentry())
+	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithGRPCConnection(conn), clients.WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestSourceFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to dial bufnet: %v", err)
 	}
-	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithSourceGRPCConnection(conn), clients.WithSourceNoSentry())
+	c, err := clients.NewClient(ctx, specs.RegistryGrpc, "", "", clients.WithGRPCConnection(conn), clients.WithNoSentry())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Import paths and references will need to be updated after https://github.com/cloudquery/plugin-sdk/pull/610 anyway, let's use this opportunity to change from e.g. `destination.WithDestinationLogger(log.Logger)` to `destination.WithLogger(log.Logger)`

~I will update the tests momentarily...~ done