### PR TITLE
fix: Ignore env variables in comments

### DIFF
--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -107,6 +107,28 @@ var specLoaderTestCases = []specLoaderTestCase{
 			"DESTINATIONS": "postgresql",
 		},
 	},
+	{
+		name: "environment variables in string without error",
+		path: []string{getPath("env_variable_in_string.yml")},
+		err: func() string {
+			return ""
+		},
+		sources:      1,
+		destinations: 1,
+		envVariables: map[string]string{
+			"VERSION": "v1",
+		},
+	},
+	{
+		name: "environment variables in string with error",
+		path: []string{getPath("env_variable_in_string.yml")},
+		err: func() string {
+			return "failed to expand environment variable in file testdata/env_variable_in_string.yml (section 2): env variable VERSION not found"
+		},
+		sources:      1,
+		destinations: 1,
+		envVariables: map[string]string{},
+	},
 }
 
 func TestLoadSpecs(t *testing.T) {

--- a/specs/testdata/env_variable_in_string.yml
+++ b/specs/testdata/env_variable_in_string.yml
@@ -1,0 +1,14 @@
+kind: source
+spec:
+  name: test
+  path: cloudquery/test
+  version: "v1"
+  destinations: [postgresql]
+---
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: "v1"
+  spec:
+    custom_version: "#${VERSION}" # or ${ENV_VARIABLE}

--- a/specs/testdata/env_variables.yml
+++ b/specs/testdata/env_variables.yml
@@ -1,0 +1,22 @@
+kind: source
+spec:
+  name: aws
+  version: ${VERSION}
+  destinations: [postgresql]
+  path: cloudquery/aws
+---
+# comment with ${ENV_VARIABLE} that should not be expanded
+kind: source
+spec:
+  name: azure
+  version: v1.3.3
+  destinations: [${DESTINATIONS},postgresql]
+  path: cloudquery/azure
+---
+kind: destination
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v1.6.3 # or ${ENV_VARIABLE}
+  spec:
+    connection_string: ${CONNECTION_STRING}

--- a/specs/testdata/env_variables.yml
+++ b/specs/testdata/env_variables.yml
@@ -20,3 +20,4 @@ spec:
   version: v1.6.3 # or ${ENV_VARIABLE}
   spec:
     connection_string: ${CONNECTION_STRING}
+    version: "#${VERSION}"


### PR DESCRIPTION
- Fixes https://github.com/cloudquery/plugin-sdk/issues/613

This changes the yaml config parsing code to ignore comments entirely. The solution used here is relatively short and clean, but it required some unfortunate hacking because the curly brackets we use for env variable placeholders are not valid yaml, and so any attempt to parse the yaml with them still in place fails (unless we were to write our own parser). 

Simple regex replacement of comments would also be prone to issues, because it wouldn't be aware of the context (maybe the `#` is inside a string, for example). This solution replaces the variables with temporary placeholders, converts each yaml section to json and back to yaml to strip comments, and then replaces the temporary placeholders again before continuing as before.