### PR TITLE
feat: Support downloading plugins from other cloudquery repos

### DIFF
--- a/registry/download.go
+++ b/registry/download.go
@@ -26,7 +26,7 @@ const (
 	RetryWaitTime                    = 1 * time.Second
 )
 
-type pluginUrl struct {
+type pluginURL struct {
 	url      string
 	monorepo bool
 }
@@ -35,14 +35,14 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	downloadDir := filepath.Dir(localPath)
 	pluginZipPath := localPath + ".zip"
 	// https://github.com/cloudquery/cloudquery/releases/download/plugins-source-test-v1.1.5/test_darwin_amd64.zip
-	urls := []pluginUrl{
+	urls := []pluginURL{
 		// community plugin format
-		pluginUrl{url: fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH)},
+		{url: fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH)},
 	}
 	if org == "cloudquery" {
 		urls = append(
 			// CloudQuery monorepo plugin
-			[]pluginUrl{{url: fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH), monorepo: true}},
+			[]pluginURL{{url: fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH), monorepo: true}},
 			// fall back to community plugin format if the plugin is not found in the monorepo
 			urls...,
 		)
@@ -94,11 +94,11 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	return nil
 }
 
-func downloadFile(ctx context.Context, localPath string, urls ...pluginUrl) (used pluginUrl, err error) {
+func downloadFile(ctx context.Context, localPath string, urls ...pluginURL) (used pluginURL, err error) {
 	// Create the file
 	out, err := os.Create(localPath)
 	if err != nil {
-		return pluginUrl{}, fmt.Errorf("failed to create file %s: %w", localPath, err)
+		return pluginURL{}, fmt.Errorf("failed to create file %s: %w", localPath, err)
 	}
 	defer out.Close()
 
@@ -109,7 +109,7 @@ func downloadFile(ctx context.Context, localPath string, urls ...pluginUrl) (use
 		}
 		return url, err
 	}
-	return pluginUrl{}, fmt.Errorf("failed downloading from URL %v. Error %w", urls, err)
+	return pluginURL{}, fmt.Errorf("failed downloading from URL %v. Error %w", urls, err)
 }
 
 func downloadFileFromURL(ctx context.Context, out *os.File, url string) error {

--- a/registry/download.go
+++ b/registry/download.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,8 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
-
-	"github.com/avast/retry-go/v4"
 
 	"github.com/schollz/progressbar/v3"
 )
@@ -30,10 +29,20 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	downloadDir := filepath.Dir(localPath)
 	pluginZipPath := localPath + ".zip"
 	// https://github.com/cloudquery/cloudquery/releases/download/plugins-source-test-v1.1.5/test_darwin_amd64.zip
-	downloadURL := fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH)
-	if org != "cloudquery" {
+	var urls []string
+	if org == "cloudquery" {
+		urls = []string{
+			// monorepo plugin
+			fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH),
+			// community plugin under CloudQuery org
+			fmt.Sprintf("https://github.com/cloudquery/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
+		}
+	} else {
 		// https://github.com/yevgenypats/cq-source-test/releases/download/v1.0.1/cq-source-test_darwin_amd64.zip
-		downloadURL = fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH)
+		urls = []string{
+			// community plugin under user org
+			fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
+		}
 	}
 
 	if _, err := os.Stat(localPath); err == nil {
@@ -44,7 +53,7 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 		return fmt.Errorf("failed to create plugin directory %s: %w", downloadDir, err)
 	}
 
-	err := downloadFile(ctx, pluginZipPath, downloadURL)
+	urlIndex, err := downloadFile(ctx, pluginZipPath, urls...)
 	if err != nil {
 		return fmt.Errorf("failed to download plugin: %w", err)
 	}
@@ -55,8 +64,10 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	}
 	defer archive.Close()
 
-	pathInArchive := fmt.Sprintf("plugins/%s/%s", typ, name)
-	if org != "cloudquery" {
+	var pathInArchive string
+	if org == "cloudquery" && urlIndex == 0 {
+		pathInArchive = fmt.Sprintf("plugins/%s/%s", typ, name)
+	} else {
 		pathInArchive = fmt.Sprintf("cq-%s-%s", typ, name)
 	}
 	pathInArchive = WithBinarySuffix(pathInArchive)
@@ -80,34 +91,37 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	return nil
 }
 
-func downloadFile(ctx context.Context, localPath string, url string) (err error) {
+func downloadFile(ctx context.Context, localPath string, urls ...string) (urlIndex int, err error) {
 	// Create the file
 	out, err := os.Create(localPath)
 	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", localPath, err)
+		return 0, fmt.Errorf("failed to create file %s: %w", localPath, err)
 	}
 	defer out.Close()
 
-	// Get the data
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("failed create request %s: %w", url, err)
-	}
+	for r := 0; r < RetryAttempts; r++ {
+		for i, url := range urls {
+			// Get the data
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				return 0, fmt.Errorf("failed create request %s: %w", url, err)
+			}
 
-	err = retry.Do(
-		func() error {
 			// Do http request
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
-				return fmt.Errorf("failed to get url %s: %w", url, err)
+				return 0, fmt.Errorf("failed to get url %s: %w", url, err)
 			}
-
 			// Check server response
-			if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode == http.StatusNotFound && i < len(urls)-1 {
+				// check alternative url
+				resp.Body.Close()
+				continue
+			} else if resp.StatusCode != http.StatusOK {
 				fmt.Printf("Failed downloading %s with status code %d. Retrying\n", url, resp.StatusCode)
-				return fmt.Errorf("statusCode != 200")
+				resp.Body.Close()
+				break
 			}
-			defer resp.Body.Close()
 
 			fmt.Printf("Downloading %s\n", url)
 			bar := downloadProgressBar(resp.ContentLength, "Downloading")
@@ -115,23 +129,15 @@ func downloadFile(ctx context.Context, localPath string, url string) (err error)
 			// Writer the body to file
 			_, err = io.Copy(io.MultiWriter(out, bar), resp.Body)
 			if err != nil {
-				return fmt.Errorf("failed to copy body to file %s: %w", localPath, err)
+				return 0, fmt.Errorf("failed to copy body to file %s: %w", localPath, err)
 			}
-
-			return nil
-		},
-		retry.RetryIf(func(err error) bool {
-			return err.Error() == "statusCode != 200"
-		}),
-		retry.Attempts(RetryAttempts),
-		retry.Delay(RetryWaitTime),
-	)
-
-	if err != nil {
-		return fmt.Errorf("failed downloading: %s", url)
+			resp.Body.Close()
+			return i, nil
+		}
+		time.Sleep(RetryWaitTime)
 	}
 
-	return nil
+	return 0, errors.New("failed to download plugin")
 }
 
 func downloadProgressBar(maxBytes int64, description ...string) *progressbar.ProgressBar {

--- a/registry/download.go
+++ b/registry/download.go
@@ -35,12 +35,12 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 		fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
 	}
 	if org == "cloudquery" {
-		urls = []string{
+		urls = append(
 			// CloudQuery monorepo plugin
-			fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH),
+			[]string{fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH)},
 			// fall back to community plugin format if the plugin is not found in the monorepo
-			urls[0],
-		}
+			urls...,
+		)
 	}
 
 	if _, err := os.Stat(localPath); err == nil {

--- a/registry/download.go
+++ b/registry/download.go
@@ -29,19 +29,16 @@ func DownloadPluginFromGithub(ctx context.Context, localPath string, org string,
 	downloadDir := filepath.Dir(localPath)
 	pluginZipPath := localPath + ".zip"
 	// https://github.com/cloudquery/cloudquery/releases/download/plugins-source-test-v1.1.5/test_darwin_amd64.zip
-	var urls []string
+	urls := []string{
+		// community plugin format
+		fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
+	}
 	if org == "cloudquery" {
 		urls = []string{
-			// monorepo plugin
+			// CloudQuery monorepo plugin
 			fmt.Sprintf("https://github.com/cloudquery/cloudquery/releases/download/plugins-%s-%s-%s/%s_%s_%s.zip", typ, name, version, name, runtime.GOOS, runtime.GOARCH),
-			// community plugin under CloudQuery org
-			fmt.Sprintf("https://github.com/cloudquery/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
-		}
-	} else {
-		// https://github.com/yevgenypats/cq-source-test/releases/download/v1.0.1/cq-source-test_darwin_amd64.zip
-		urls = []string{
-			// community plugin under user org
-			fmt.Sprintf("https://github.com/%s/cq-%s-%s/releases/download/%s/cq-%s-%s_%s_%s.zip", org, typ, name, version, typ, name, runtime.GOOS, runtime.GOARCH),
+			// fall back to community plugin format if the plugin is not found in the monorepo
+			urls[0],
 		}
 	}
 

--- a/registry/download_test.go
+++ b/registry/download_test.go
@@ -1,0 +1,31 @@
+package registry
+
+import (
+	"context"
+	"path"
+	"testing"
+)
+
+func TestDownloadPluginFromGithubIntegration(t *testing.T) {
+	tmp := t.TempDir()
+	cases := []struct {
+		name       string
+		org        string
+		plugin     string
+		version    string
+		pluginType PluginType
+	}{
+		{name: "monorepo source", org: "cloudquery", plugin: "hackernews", version: "v1.1.4", pluginType: PluginTypeSource},
+		{name: "many repo source", org: "cloudquery", plugin: "simple-analytics", version: "v1.0.0", pluginType: PluginTypeSource},
+		{name: "monorepo destination", org: "cloudquery", plugin: "postgresql", version: "v2.0.7", pluginType: PluginTypeDestination},
+		{name: "community source", org: "hermanschaaf", plugin: "simple-analytics", version: "v1.0.0", pluginType: PluginTypeSource},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := DownloadPluginFromGithub(context.Background(), path.Join(tmp, tc.name), tc.org, tc.plugin, tc.version, tc.pluginType)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Right now, if a plugin is hosted in anywhere on the `cloudquery` org, it can only be downloaded if it is part of the `cloudquery/cloudquery` monorepo. This makes it impossible to temporarily host `cq-source-*` type plugins as other `cloudquery` repos, as can be done with community plugins on other orgs.

This changes the download logic to first check the monorepo, but fall back to the community standard of `cq-source-*` if it's A) `cloudquery` org and B) the monorepo download attempt resulted in a 404. If both fail with 404, the attempt is aborted. Other status codes are retried.

It would have been better if we could know, somehow, when a plugin is hosted in the monorepo or outside it, but right now this is not possible unless we change the spec in some way. 

This change allows us to use the CLI to download https://github.com/cloudquery/cq-source-simple-analytics