### PR TITLE
chore: Revert "fix: Add cq-dir param to discovery"

### DIFF
--- a/clients/discovery/v0/discovery.go
+++ b/clients/discovery/v0/discovery.go
@@ -50,10 +50,10 @@ func WithGrpcConn(userConn *grpc.ClientConn) func(*Client) {
 	}
 }
 
-func NewClient(ctx context.Context, cqDir string, registrySpec specs.Registry, pluginType registry.PluginType, path string, version string, opts ...ClientOption) (*Client, error) {
+func NewClient(ctx context.Context, registrySpec specs.Registry, pluginType registry.PluginType, path string, version string, opts ...ClientOption) (*Client, error) {
 	var err error
 	c := &Client{
-		directory: cqDir,
+		directory: registry.DefaultDownloadDir,
 		wg:        &sync.WaitGroup{},
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
Reverts cloudquery/plugin-sdk#633

Seems like it wasn't right - we can pass in an option to set the directory instead.