### PR TITLE
fix(logging): Send more info logs when plugins are being terminated

### DIFF
--- a/clients/destination/v0/destination_terminate.go
+++ b/clients/destination/v0/destination_terminate.go
@@ -13,10 +13,12 @@ func (c *Client) terminateProcess() error {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to destination plugin")
 	}
 	timer := time.AfterFunc(5*time.Second, func() {
+		c.logger.Info().Msg("sending kill signal to destination plugin")
 		if err := c.cmd.Process.Kill(); err != nil {
 			c.logger.Error().Err(err).Msg("failed to kill destination plugin")
 		}
 	})
+	c.logger.Info().Msg("waiting for destination plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	timer.Stop()
 	if err != nil {

--- a/clients/destination/v0/destination_terminate_windows.go
+++ b/clients/destination/v0/destination_terminate_windows.go
@@ -6,6 +6,7 @@ func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill destination plugin")
 	}
+	c.logger.Info().Msg("waiting for source plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	if err != nil {
 		return err

--- a/clients/source/v1/source_terminate.go
+++ b/clients/source/v1/source_terminate.go
@@ -13,10 +13,12 @@ func (c *Client) terminateProcess() error {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to source plugin")
 	}
 	timer := time.AfterFunc(5*time.Second, func() {
+		c.logger.Info().Msg("sending kill signal to source plugin")
 		if err := c.cmd.Process.Kill(); err != nil {
 			c.logger.Error().Err(err).Msg("failed to kill source plugin")
 		}
 	})
+	c.logger.Info().Msg("waiting for source plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	timer.Stop()
 	if err != nil {

--- a/clients/source/v1/source_terminate_windows.go
+++ b/clients/source/v1/source_terminate_windows.go
@@ -6,6 +6,7 @@ func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill source plugin")
 	}
+	c.logger.Info().Msg("waiting for source plugin to terminate")
 	st, err := c.cmd.Process.Wait()
 	if err != nil {
 		return err


### PR DESCRIPTION
It's hard to tell from our current logs whether the source plugin got killed by another process or by our own. It's usually our own, but having a few more info logs around this event will make it unambiguous. 