### PR TITLE
fix: Trap terminate signal, log which signal we received

### DIFF
--- a/serve/destination.go
+++ b/serve/destination.go
@@ -154,7 +154,7 @@ func newCmdDestinationServe(serve *destinationServe) *cobra.Command {
 			go func() {
 				select {
 				case sig := <-c:
-					logger.Info().Str("address", listener.Addr().String()).Str("signal", sig.String()).Msg("Got stop signal. Source plugin server shutting down")
+					logger.Info().Str("address", listener.Addr().String()).Str("signal", sig.String()).Msg("Got stop signal. Destination plugin server shutting down")
 					s.Stop()
 				case <-ctx.Done():
 					logger.Info().Str("address", listener.Addr().String()).Msg("Context cancelled. Destination plugin server shutting down")


### PR DESCRIPTION
This should help debug issues with ECS a bit more effectively, by knowing when the source or destination plugins receive terminate signals. 