### PR TITLE
fix(logging): Log more explicit message when OOM and other status codes occur

### DIFF
--- a/clients/destination/v0/destination_terminate.go
+++ b/clients/destination/v0/destination_terminate.go
@@ -23,7 +23,11 @@ func (c *Client) terminateProcess() error {
 		return err
 	}
 	if !st.Success() {
-		return fmt.Errorf("destination plugin process exited with status %s", st.String())
+		additionalInfo := ""
+		if st.ExitCode() == 137 {
+			additionalInfo = " (Out of Memory, killed by OOM killer)"
+		}
+		return fmt.Errorf("destination plugin process exited with status %s (%d)%s", st.String(), st.ExitCode(), additionalInfo)
 	}
 
 	return nil

--- a/clients/source/v1/source_terminate.go
+++ b/clients/source/v1/source_terminate.go
@@ -23,7 +23,11 @@ func (c *Client) terminateProcess() error {
 		return err
 	}
 	if !st.Success() {
-		return fmt.Errorf("source plugin process exited with status %s", st.String())
+		additionalInfo := ""
+		if st.ExitCode() == 137 {
+			additionalInfo = "(Out of Memory, killed by OOM killer)"
+		}
+		return fmt.Errorf("source plugin process exited with status %s (%d)%s", st.String(), st.ExitCode(), additionalInfo)
 	}
 
 	return nil

--- a/clients/source/v1/source_terminate.go
+++ b/clients/source/v1/source_terminate.go
@@ -5,6 +5,7 @@ package source
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -23,11 +24,15 @@ func (c *Client) terminateProcess() error {
 		return err
 	}
 	if !st.Success() {
-		additionalInfo := ""
-		if st.ExitCode() == 137 {
-			additionalInfo = "(Out of Memory, killed by OOM killer)"
+		var additionalInfo string
+		status := st.Sys().(syscall.WaitStatus)
+		if status.Signaled() && st.ExitCode() != -1 {
+			additionalInfo += fmt.Sprintf(" (exit code: %d)", st.ExitCode())
 		}
-		return fmt.Errorf("source plugin process exited with status %s (%d)%s", st.String(), st.ExitCode(), additionalInfo)
+		if st.ExitCode() == 137 {
+			additionalInfo = " (Out of Memory)"
+		}
+		return fmt.Errorf("destination plugin process failed with %s%s", st.String(), additionalInfo)
 	}
 
 	return nil


### PR DESCRIPTION
Related to https://github.com/cloudquery/cloudquery/issues/6431

This change should inform users if either the source or destination gets killed by the OOM Killer.