### PR TITLE
fix: Remove unused `OnlyIncrementalTables` spec property

### DIFF
--- a/specs/source.go
+++ b/specs/source.go
@@ -39,8 +39,6 @@ type Source struct {
 
 	// Backend is the name of the state backend to use
 	Backend Backend `json:"backend,omitempty"`
-	// Sync on
-	OnlyIncrementalTables bool `json:"only_incremental_tables,omitempty"`
 	// BackendSpec contains any backend-specific configuration
 	BackendSpec any `json:"backend_spec,omitempty"`
 	// Scheduler defines the scheduling algorithm that should be used to sync data


### PR DESCRIPTION
This property is no longer necessary (and is unused) - instead, users can update their config to only select the incremental tables they are interested in.