### PR TITLE
feat: Add skip_dependent_tables option

### DIFF
--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -262,7 +262,7 @@ func (p *Plugin) Write(ctx context.Context, sourceSpec specs.Source, tables sche
 			exclude := func(t *schema.Table) bool {
 				return t.IsIncremental
 			}
-			tablesToDelete = tables.FilterDfsFunc(include, exclude)
+			tablesToDelete = tables.FilterDfsFunc(include, exclude, sourceSpec.SkipDependentTables)
 		}
 		if err := p.DeleteStale(ctx, tablesToDelete, sourceSpec.Name, syncTime); err != nil {
 			return err

--- a/plugins/source/plugin.go
+++ b/plugins/source/plugin.go
@@ -175,7 +175,7 @@ func (p *Plugin) TablesForSpec(spec specs.Source) (schema.Tables, error) {
 	if err := spec.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
-	tables, err := p.tables.FilterDfs(spec.Tables, spec.SkipTables)
+	tables, err := p.tables.FilterDfs(spec.Tables, spec.SkipTables, spec.SkipDependentTables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter tables: %w", err)
 	}
@@ -232,7 +232,7 @@ func (p *Plugin) Init(ctx context.Context, spec specs.Source) error {
 			return fmt.Errorf("failed to get dynamic tables: %w", err)
 		}
 
-		tables, err = tables.FilterDfs(spec.Tables, spec.SkipTables)
+		tables, err = tables.FilterDfs(spec.Tables, spec.SkipTables, spec.SkipDependentTables)
 		if err != nil {
 			return fmt.Errorf("failed to filter tables: %w", err)
 		}
@@ -255,7 +255,7 @@ func (p *Plugin) Init(ctx context.Context, spec specs.Source) error {
 			return fmt.Errorf("max depth of tables is %d, max allowed is %d", p.maxDepth, maxAllowedDepth)
 		}
 	} else {
-		tables, err = tables.FilterDfs(spec.Tables, spec.SkipTables)
+		tables, err = tables.FilterDfs(spec.Tables, spec.SkipTables, spec.SkipDependentTables)
 		if err != nil {
 			return fmt.Errorf("failed to filter tables: %w", err)
 		}

--- a/schema/table.go
+++ b/schema/table.go
@@ -72,11 +72,11 @@ var (
 	reValidColumnName = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
 )
 
-func (tt Tables) FilterDfsFunc(include, exclude func(*Table) bool) Tables {
+func (tt Tables) FilterDfsFunc(include, exclude func(*Table) bool, skipDependentTables bool) Tables {
 	filteredTables := make(Tables, 0, len(tt))
 	for _, t := range tt {
 		filteredTable := t.Copy(nil)
-		filteredTable = filteredTable.filterDfs(false, include, exclude)
+		filteredTable = filteredTable.filterDfs(false, include, exclude, skipDependentTables)
 		if filteredTable != nil {
 			filteredTables = append(filteredTables, filteredTable)
 		}
@@ -84,7 +84,7 @@ func (tt Tables) FilterDfsFunc(include, exclude func(*Table) bool) Tables {
 	return filteredTables
 }
 
-func (tt Tables) FilterDfs(tables, skipTables []string) (Tables, error) {
+func (tt Tables) FilterDfs(tables, skipTables []string, skipDependentTables bool) (Tables, error) {
 	flattenedTables := tt.FlattenTables()
 	for _, includePattern := range tables {
 		matched := false
@@ -126,7 +126,7 @@ func (tt Tables) FilterDfs(tables, skipTables []string) (Tables, error) {
 		}
 		return false
 	}
-	return tt.FilterDfsFunc(include, exclude), nil
+	return tt.FilterDfsFunc(include, exclude, skipDependentTables), nil
 }
 
 func (tt Tables) FlattenTables() Tables {
@@ -215,17 +215,17 @@ func (tt Tables) ValidateColumnNames() error {
 }
 
 // this will filter the tree in-place
-func (t *Table) filterDfs(parentMatched bool, include, exclude func(*Table) bool) *Table {
+func (t *Table) filterDfs(parentMatched bool, include, exclude func(*Table) bool, skipDependentTables bool) *Table {
 	if exclude(t) {
 		return nil
 	}
-	matched := parentMatched
+	matched := parentMatched && !skipDependentTables
 	if include(t) {
 		matched = true
 	}
 	filteredRelations := make([]*Table, 0, len(t.Relations))
 	for _, r := range t.Relations {
-		filteredChild := r.filterDfs(matched, include, exclude)
+		filteredChild := r.filterDfs(matched, include, exclude, skipDependentTables)
 		if filteredChild != nil {
 			matched = true
 			filteredRelations = append(filteredRelations, r)

--- a/specs/source.go
+++ b/specs/source.go
@@ -34,6 +34,8 @@ type Source struct {
 	Tables []string `json:"tables,omitempty"`
 	// SkipTables defines tables to skip when syncing data. Useful if a glob pattern is used in Tables
 	SkipTables []string `json:"skip_tables,omitempty"`
+	// SkipDependentTables changes the matching behavior with regard to dependent tables. If set to true, dependent tables will not be synced unless they are explicitly matched by Tables.
+	SkipDependentTables bool `json:"skip_dependent_tables,omitempty"`
 	// Destinations are the names of destination plugins to send sync data to
 	Destinations []string `json:"destinations,omitempty"`
 


### PR DESCRIPTION
This adds a flag to the source config that allows users to opt out of syncing dependent tables by default. This has been raised as an issue by users a few times already, most recently [here](https://discord.com/channels/872925471417962546/873606591335759872/1071081863105495178). 

The issue with the current default behavior is that new dependencies can be added with minor versions, which can 1) drastically slow down a sync and 2) create unexpected migrations or new tables. It can also be surprising for new users, when selecting e.g. only the `aws_s3_buckets` table, that they get ~6 tables synced.

This should ideally be the default behavior, but that would be a breaking change. For now, I think we should keep backwards-compatibility but add this flag (and recommend it as best-practice).

Note about naming: `dependent` is the standard American spelling. `dependant` is used in the UK. I went with the American spelling here.