### PR TITLE
feat: Use Setpgid=true on Unix systems so that signals are not sent to the child process

### DIFF
--- a/clients/destination/v0/destination.go
+++ b/clients/destination/v0/destination.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/internal/logging"
@@ -138,10 +137,7 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
-		Setpgid: true, // linux
-	}
+	cmd.SysProcAttr = getSysProcAttr()
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start destination plugin %s: %w", path, err)
 	}

--- a/clients/destination/v0/destination.go
+++ b/clients/destination/v0/destination.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/internal/logging"
@@ -137,6 +138,10 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
+		Setpgid: true, // linux
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start destination plugin %s: %w", path, err)
 	}

--- a/clients/destination/v0/destination_unix.go
+++ b/clients/destination/v0/destination_unix.go
@@ -9,6 +9,13 @@ import (
 	"time"
 )
 
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
+		Setpgid: true, // UNIX systems
+	}
+}
+
 func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to destination plugin")

--- a/clients/destination/v0/destination_windows.go
+++ b/clients/destination/v0/destination_windows.go
@@ -2,6 +2,13 @@
 
 package destination
 
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// launch as new process group so that signals are not sent to the child process
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP, // windows
+	}
+}
+
 func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill destination plugin")

--- a/clients/destination/v0/destination_windows.go
+++ b/clients/destination/v0/destination_windows.go
@@ -2,6 +2,10 @@
 
 package destination
 
+import (
+	"syscall"
+)
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		// launch as new process group so that signals are not sent to the child process

--- a/clients/source/v1/source.go
+++ b/clients/source/v1/source.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/cloudquery/plugin-sdk/internal/logging"
 	pb "github.com/cloudquery/plugin-sdk/internal/pb/source/v1"
@@ -132,6 +133,10 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
+		Setpgid: true, // linux
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start source plugin %s: %w", path, err)
 	}

--- a/clients/source/v1/source.go
+++ b/clients/source/v1/source.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/cloudquery/plugin-sdk/internal/logging"
 	pb "github.com/cloudquery/plugin-sdk/internal/pb/source/v1"
@@ -133,10 +132,7 @@ func (c *Client) newManagedClient(ctx context.Context, path string) error {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
-		Setpgid: true, // linux
-	}
+	cmd.SysProcAttr = getSysProcAttr()
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start source plugin %s: %w", path, err)
 	}

--- a/clients/source/v1/source_unix.go
+++ b/clients/source/v1/source_unix.go
@@ -9,6 +9,13 @@ import (
 	"time"
 )
 
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// launch as new process group so that signals (ex: SIGINT) are not sent to the child process
+		Setpgid: true, // UNIX systems
+	}
+}
+
 func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to source plugin")

--- a/clients/source/v1/source_windows.go
+++ b/clients/source/v1/source_windows.go
@@ -2,6 +2,10 @@
 
 package source
 
+import (
+	"syscall"
+)
+
 func getSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		// launch as new process group so that signals are not sent to the child process

--- a/clients/source/v1/source_windows.go
+++ b/clients/source/v1/source_windows.go
@@ -2,6 +2,13 @@
 
 package source
 
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		// launch as new process group so that signals are not sent to the child process
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP, // windows
+	}
+}
+
 func (c *Client) terminateProcess() error {
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill source plugin")


### PR DESCRIPTION
By default, commands in Go are started in the same process group. When a signal is sent (e.g. ctrl+c), this gets sent to the entire group, causing plugins to shut down before the CLI has a chance to do closing operations and then relay the signal. By setting `Setpgid: true` on UNIX systems, we can get better control over the shutdown process of child processes.