### PR TITLE
feat: Retain Order of Columns from struct

### DIFF
--- a/schema/column.go
+++ b/schema/column.go
@@ -41,6 +41,9 @@ type Column struct {
 	// If IgnoreInTests is true, verification is skipped for this column.
 	// Used when it is hard to create a reproducible environment with this column being non-nil (e.g. various error columns).
 	IgnoreInTests bool `json:"-"`
+
+	// Column definition should be merged into struct or kept in order
+	RetainOrder bool `json:"retain_order,omitempty"`
 }
 
 func (c *ColumnList) UnmarshalJSON(data []byte) (err error) {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


When we update a column resolver it will always change the order of the fields... This PR only changes the order if it is specifically requested (Adds an attribute to Columns `RetainOrder`) or if it is a primary key.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
