### PR TITLE
fix: Fix source log message, and some debug messages

### DIFF
--- a/clients/destination/v0/destination_unix.go
+++ b/clients/destination/v0/destination_unix.go
@@ -17,6 +17,7 @@ func getSysProcAttr() *syscall.SysProcAttr {
 }
 
 func (c *Client) terminateProcess() error {
+	c.logger.Debug().Msg("sending interrupt signal to destination plugin")
 	if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to destination plugin")
 	}

--- a/clients/destination/v0/destination_windows.go
+++ b/clients/destination/v0/destination_windows.go
@@ -14,6 +14,7 @@ func getSysProcAttr() *syscall.SysProcAttr {
 }
 
 func (c *Client) terminateProcess() error {
+	c.logger.Debug().Msg("sending kill signal to destination plugin")
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill destination plugin")
 	}

--- a/clients/source/v1/source_unix.go
+++ b/clients/source/v1/source_unix.go
@@ -17,6 +17,7 @@ func getSysProcAttr() *syscall.SysProcAttr {
 }
 
 func (c *Client) terminateProcess() error {
+	c.logger.Debug().Msg("sending interrupt signal to source plugin")
 	if err := c.cmd.Process.Signal(os.Interrupt); err != nil {
 		c.logger.Error().Err(err).Msg("failed to send interrupt signal to source plugin")
 	}
@@ -41,7 +42,7 @@ func (c *Client) terminateProcess() error {
 		if st.ExitCode() == 137 {
 			additionalInfo = " (Out of Memory)"
 		}
-		return fmt.Errorf("destination plugin process failed with %s%s", st.String(), additionalInfo)
+		return fmt.Errorf("source plugin process failed with %s%s", st.String(), additionalInfo)
 	}
 
 	return nil

--- a/clients/source/v1/source_windows.go
+++ b/clients/source/v1/source_windows.go
@@ -14,6 +14,7 @@ func getSysProcAttr() *syscall.SysProcAttr {
 }
 
 func (c *Client) terminateProcess() error {
+	c.logger.Debug().Msg("sending kill signal to destination plugin")
 	if err := c.cmd.Process.Kill(); err != nil {
 		c.logger.Error().Err(err).Msg("failed to kill source plugin")
 	}


### PR DESCRIPTION
One log message is incorrect (says `destination` when it should be `source`). I'm also adding a few more debug logs to help diagnose issues.