### PR TITLE
fix: Potential database lock/race in destination testing

### DIFF
--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -75,6 +75,7 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 		if suite.tests.SkipOverwrite {
 			t.Skip("skipping " + t.Name())
 		}
+		destSpec.Name = "test_write_overwrite"
 		if err := suite.destinationPluginTestWriteOverwrite(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
@@ -85,29 +86,32 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 		if suite.tests.SkipOverwrite || suite.tests.SkipDeleteStale {
 			t.Skip("skipping " + t.Name())
 		}
+		destSpec.Name = "test_write_overwrite_delete_stale"
 		if err := suite.destinationPluginTestWriteOverwriteDeleteStale(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	t.Run("TestWriteMigrateOverwrite", func(t *testing.T) {
+	t.Run("TestMigrateOverwrite", func(t *testing.T) {
 		t.Helper()
 		if suite.tests.SkipMigrateOverwrite {
 			t.Skip("skipping " + t.Name())
 		}
 		destSpec.WriteMode = specs.WriteModeOverwrite
+		destSpec.Name = "test_migrate_overwrite"
 		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 	})
 
-	t.Run("TestWriteMigrateOverwriteForce", func(t *testing.T) {
+	t.Run("TestMigrateOverwriteForce", func(t *testing.T) {
 		t.Helper()
 		if suite.tests.SkipMigrateOverwriteForce {
 			t.Skip("skipping " + t.Name())
 		}
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.MigrateMode = specs.MigrateModeForced
+		destSpec.Name = "test_migrate_overwrite_force"
 		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
@@ -118,6 +122,7 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 		if suite.tests.SkipAppend {
 			t.Skip("skipping " + t.Name())
 		}
+		destSpec.Name = "test_write_append"
 		if err := suite.destinationPluginTestWriteAppend(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
@@ -129,6 +134,7 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 			t.Skip("skipping " + t.Name())
 		}
 		destSpec.WriteMode = specs.WriteModeAppend
+		destSpec.Name = "test_migrate_append"
 		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
@@ -141,6 +147,7 @@ func PluginTestSuiteRunner(t *testing.T, p *Plugin, spec any, tests PluginTestSu
 		}
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.MigrateMode = specs.MigrateModeForced
+		destSpec.Name = "test_migrate_append_force"
 		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -3,14 +3,11 @@ package destination
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/cloudquery/plugin-sdk/caser"
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/specs"
 	"github.com/cloudquery/plugin-sdk/testdata"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
 
@@ -24,14 +21,13 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
-	suffix := strings.ToLower(strings.ReplaceAll(spec.WriteMode.String(), "-", "_"))
-	tableName := fmt.Sprintf("cq_test_migrate_%s_%d", suffix, time.Now().Unix())
+	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
 	table := testdata.TestTable(tableName)
 	if err := p.Migrate(ctx, []*schema.Table{table}); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 
-	sourceName := "testMigrate" + caser.New().ToPascal(suffix) + "Source" + uuid.NewString()
+	sourceName := tableName
 	sourceSpec := specs.Source{
 		Name: sourceName,
 	}

--- a/plugins/destination/plugin_testing_overwrite.go
+++ b/plugins/destination/plugin_testing_overwrite.go
@@ -17,7 +17,7 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Context,
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
-	tableName := fmt.Sprintf("cq_test_write_overwrite_%d", time.Now().Unix())
+	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
 	table := testdata.TestTable(tableName)
 	syncTime := time.Now().UTC().Round(1 * time.Second)
 	tables := []*schema.Table{

--- a/plugins/destination/plugin_testing_overwrite_delete_stale.go
+++ b/plugins/destination/plugin_testing_overwrite_delete_stale.go
@@ -17,7 +17,7 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
-	tableName := fmt.Sprintf("cq_test_write_overwrite_delete_stale_%d", time.Now().Unix())
+	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
 	table := testdata.TestTable(tableName)
 	incTable := testdata.TestTable(tableName + "_incremental")
 	incTable.IsIncremental = true

--- a/plugins/destination/plugin_testing_write_append.go
+++ b/plugins/destination/plugin_testing_write_append.go
@@ -17,7 +17,7 @@ func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, 
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
-	tableName := "cq_test_write_append"
+	tableName := spec.Name
 	table := testdata.TestTable(tableName)
 	syncTime := time.Now().UTC().Round(1 * time.Second)
 	tables := []*schema.Table{


### PR DESCRIPTION
For each test in the destination testing suite we use unique table now.

This should solve the bug I've hit this PR - https://github.com/cloudquery/cloudquery/pull/7819