### PR TITLE
fix: Set _cq_id not null for all tables

### DIFF
--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -297,7 +297,6 @@ func setCqIDNotNullColumnForTables(tables []*schema.Table) {
 		for i, c := range table.Columns {
 			if c.Name == schema.CqIDColumn.Name {
 				table.Columns[i].CreationOptions.NotNull = true
-				return
 			}
 		}
 		setCqIDNotNullColumnForTables(table.Relations)


### PR DESCRIPTION
Have no idea how the `return` got in there 😢 