### PR TITLE
feat: Improve migration detection APIs

### DIFF
--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -64,7 +64,7 @@ func TestPluginManagedClientWithSmallBatchSize(t *testing.T) {
 		}, nil,
 		destination.PluginTestSuiteTests{
 			MigrateStrategyOverwrite: migrateStrategyOverwrite,
-			MigrateStrategyAppend:    migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyAppend,
 		})
 }
 

--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -13,6 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var migrateStrategyOverwrite = destination.MigrateStrategy{
+	AddColumn:           specs.MigrateModeForced,
+	AddColumnNotNull:    specs.MigrateModeForced,
+	RemoveColumn:        specs.MigrateModeForced,
+	RemoveColumnNotNull: specs.MigrateModeForced,
+	ChangeColumn:        specs.MigrateModeForced,
+}
+
+var migrateStrategyAppend = destination.MigrateStrategy{
+	AddColumn:           specs.MigrateModeForced,
+	AddColumnNotNull:    specs.MigrateModeForced,
+	RemoveColumn:        specs.MigrateModeForced,
+	RemoveColumnNotNull: specs.MigrateModeForced,
+	ChangeColumn:        specs.MigrateModeForced,
+}
+
 func TestPluginUnmanagedClient(t *testing.T) {
 	destination.PluginTestSuiteRunner(
 		t,
@@ -20,7 +36,11 @@ func TestPluginUnmanagedClient(t *testing.T) {
 			return destination.NewPlugin("test", "development", NewClient)
 		},
 		nil,
-		destination.PluginTestSuiteTests{})
+		destination.PluginTestSuiteTests{
+			MigrateStrategyOverwrite: migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyOverwrite,
+		},
+	)
 }
 
 func TestPluginManagedClient(t *testing.T) {
@@ -29,7 +49,10 @@ func TestPluginManagedClient(t *testing.T) {
 			return destination.NewPlugin("test", "development", NewClient, destination.WithManagedWriter())
 		},
 		nil,
-		destination.PluginTestSuiteTests{})
+		destination.PluginTestSuiteTests{
+			MigrateStrategyOverwrite: migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyOverwrite,
+		})
 }
 
 func TestPluginManagedClientWithSmallBatchSize(t *testing.T) {
@@ -39,7 +62,10 @@ func TestPluginManagedClientWithSmallBatchSize(t *testing.T) {
 				destination.WithDefaultBatchSize(1),
 				destination.WithDefaultBatchSizeBytes(1))
 		}, nil,
-		destination.PluginTestSuiteTests{})
+		destination.PluginTestSuiteTests{
+			MigrateStrategyOverwrite: migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyOverwrite,
+		})
 }
 
 func TestPluginManagedClientWithLargeBatchSize(t *testing.T) {
@@ -50,7 +76,10 @@ func TestPluginManagedClientWithLargeBatchSize(t *testing.T) {
 				destination.WithDefaultBatchSizeBytes(100000000))
 		},
 		nil,
-		destination.PluginTestSuiteTests{})
+		destination.PluginTestSuiteTests{
+			MigrateStrategyOverwrite: migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyOverwrite,
+		})
 }
 
 func TestPluginOnNewError(t *testing.T) {

--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -51,7 +51,7 @@ func TestPluginManagedClient(t *testing.T) {
 		nil,
 		destination.PluginTestSuiteTests{
 			MigrateStrategyOverwrite: migrateStrategyOverwrite,
-			MigrateStrategyAppend:    migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyAppend,
 		})
 }
 

--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -78,7 +78,7 @@ func TestPluginManagedClientWithLargeBatchSize(t *testing.T) {
 		nil,
 		destination.PluginTestSuiteTests{
 			MigrateStrategyOverwrite: migrateStrategyOverwrite,
-			MigrateStrategyAppend:    migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyAppend,
 		})
 }
 

--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -38,7 +38,7 @@ func TestPluginUnmanagedClient(t *testing.T) {
 		nil,
 		destination.PluginTestSuiteTests{
 			MigrateStrategyOverwrite: migrateStrategyOverwrite,
-			MigrateStrategyAppend:    migrateStrategyOverwrite,
+			MigrateStrategyAppend:    migrateStrategyAppend,
 		},
 	)
 }

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -17,9 +17,26 @@ type PluginTestSuite struct {
 	tests PluginTestSuiteTests
 }
 
+// type MigrateResult int
+
+// const (
+// 	MigrateResultSuccess MigrateResult = iota
+// 	MigrateResultDropTable
+// )
+
+// MigrateStrategy defines which tests we should include
+// true means test should succeed for either automigrate
+type MigrateStrategy struct {
+	AddColumn           specs.MigrateMode
+	AddColumnNotNull    specs.MigrateMode
+	RemoveColumn        specs.MigrateMode
+	RemoveColumnNotNull specs.MigrateMode
+	ChangeColumn        specs.MigrateMode
+}
+
 type PluginTestSuiteTests struct {
 	// SkipOverwrite skips testing for "overwrite" mode. Use if the destination
-	//	// plugin doesn't support this feature.
+	// plugin doesn't support this feature.
 	SkipOverwrite bool
 
 	// SkipDeleteStale skips testing "delete-stale" mode. Use if the destination
@@ -48,6 +65,9 @@ type PluginTestSuiteTests struct {
 	SkipMigrateOverwrite bool
 	// SkipMigrateOverwriteForce skips a test for the migrate function where a column is changed in force mode
 	SkipMigrateOverwriteForce bool
+
+	MigrateStrategyOverwrite MigrateStrategy
+	MigrateStrategyAppend    MigrateStrategy
 }
 
 func getTestLogger(t *testing.T) zerolog.Logger {
@@ -109,11 +129,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		}
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.Name = "test_migrate_overwrite"
-		p := newPlugin()
-		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.Close(ctx); err != nil {
+		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -126,11 +142,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_overwrite_force"
-		p := newPlugin()
-		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.Close(ctx); err != nil {
+		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -157,11 +169,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		}
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.Name = "test_migrate_append"
-		p := newPlugin()
-		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.Close(ctx); err != nil {
+		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyAppend); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -174,11 +182,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_append_force"
-		p := newPlugin()
-		if err := suite.destinationPluginTestMigrate(ctx, p, logger, destSpec); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.Close(ctx); err != nil {
+		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyAppend); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -17,13 +17,6 @@ type PluginTestSuite struct {
 	tests PluginTestSuiteTests
 }
 
-// type MigrateResult int
-
-// const (
-// 	MigrateResultSuccess MigrateResult = iota
-// 	MigrateResultDropTable
-// )
-
 // MigrateStrategy defines which tests we should include
 // true means test should succeed for either automigrate
 type MigrateStrategy struct {

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -18,7 +18,6 @@ type PluginTestSuite struct {
 }
 
 // MigrateStrategy defines which tests we should include
-// true means test should succeed for either automigrate
 type MigrateStrategy struct {
 	AddColumn           specs.MigrateMode
 	AddColumnNotNull    specs.MigrateMode

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -129,9 +129,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		}
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.Name = "test_migrate_overwrite"
-		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite); err != nil {
-			t.Fatal(err)
-		}
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
 	})
 
 	t.Run("TestMigrateOverwriteForce", func(t *testing.T) {
@@ -142,9 +140,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_overwrite_force"
-		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite); err != nil {
-			t.Fatal(err)
-		}
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
 	})
 
 	t.Run("TestWriteAppend", func(t *testing.T) {
@@ -169,9 +165,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		}
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.Name = "test_migrate_append"
-		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyAppend); err != nil {
-			t.Fatal(err)
-		}
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
 	})
 
 	t.Run("TestMigrateAppendForce", func(t *testing.T) {
@@ -182,9 +176,7 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, spec any, test
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_append_force"
-		if err := suite.destinationPluginTestMigrate(t, ctx, newPlugin, logger, destSpec, tests.MigrateStrategyAppend); err != nil {
-			t.Fatal(err)
-		}
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
 	})
 }
 

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -3,13 +3,19 @@ package destination
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/specs"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
+
+func tableUUIDSuffix() string {
+	return strings.ReplaceAll(uuid.NewString(), "-", "_")
+}
 
 func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination, target *schema.Table, source *schema.Table, mode specs.MigrateMode) error {
 	if err := p.Init(ctx, logger, spec); err != nil {
@@ -78,8 +84,9 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Skip("skipping as migrate mode is safe")
 			return
 		}
+		tableName := "add_column_" + tableUUIDSuffix()
 		source := &schema.Table{
-			Name: "add_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -88,7 +95,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		target := &schema.Table{
-			Name: "add_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -102,7 +109,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}
 		p := newPlugin()
 		if err := testMigration(ctx, p, logger, spec, target, source, strategy.AddColumn); err != nil {
-			t.Fatalf("failed to migrate add_column: %v", err)
+			t.Fatalf("failed to migrate %s: %v", tableName, err)
 		}
 		if err := p.Close(ctx); err != nil {
 			t.Fatal(err)
@@ -114,8 +121,9 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Skip("skipping as migrate mode is safe")
 			return
 		}
+		tableName := "add_column_not_null_" + tableUUIDSuffix()
 		source := &schema.Table{
-			Name: "add_column_not_null",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -124,7 +132,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		target := &schema.Table{
-			Name: "add_column_not_null",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -153,8 +161,9 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Skip("skipping as migrate mode is safe")
 			return
 		}
+		tableName := "remove_column_" + tableUUIDSuffix()
 		source := &schema.Table{
-			Name: "remove_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -167,7 +176,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		target := &schema.Table{
-			Name: "remove_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -189,8 +198,9 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Skip("skipping as migrate mode is safe")
 			return
 		}
+		tableName := "remove_column_not_null_" + tableUUIDSuffix()
 		source := &schema.Table{
-			Name: "remove_column_not_null",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -206,7 +216,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		target := &schema.Table{
-			Name: "remove_column_not_null",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -215,7 +225,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		p := newPlugin()
-		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumnNotNull); err != nil {
 			t.Fatalf("failed to migrate add_column: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -228,8 +238,9 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Skip("skipping as migrate mode is safe")
 			return
 		}
+		tableName := "change_column_" + tableUUIDSuffix()
 		source := &schema.Table{
-			Name: "change_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -242,7 +253,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		target := &schema.Table{
-			Name: "change_column",
+			Name: tableName,
 			Columns: []schema.Column{
 				{
 					Name: "id",
@@ -255,7 +266,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			},
 		}
 		p := newPlugin()
-		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.ChangeColumn); err != nil {
 			t.Fatalf("failed to migrate add_column: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -66,7 +66,7 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 		}
 	} else {
 		if len(resourcesRead) != 1 {
-			return fmt.Errorf("expected 1 resources after write, got %d", len(resourcesRead))
+			return fmt.Errorf("expected 1 resource after write, got %d", len(resourcesRead))
 		}
 		if diff := resourcesRead[0].Diff(resource2.Data); diff != "" {
 			return fmt.Errorf("resource1 diff: %s", diff)

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -28,7 +28,7 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 	}, source.Columns...)
 	target.Columns = append(schema.ColumnList{
 		schema.CqSourceNameColumn,
-		schema.CqSyncTimeColumn,	
+		schema.CqSyncTimeColumn,
 	}, target.Columns...)
 
 	if err := p.Migrate(ctx, []*schema.Table{source}); err != nil {

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -11,36 +11,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var tableTest1 = &schema.Table{
-	Name: "test1",
-	Columns: []schema.Column{
-		{
-			Name: "id",
-			Type: schema.TypeUUID,
-			CreationOptions: schema.ColumnCreationOptions{
-				PrimaryKey: true,
-			},
-		},
-	},
-}
-
-var tableTest2 = &schema.Table{
-	Name: "test1",
-	Columns: []schema.Column{
-		{
-			Name: "id",
-			Type: schema.TypeUUID,
-			CreationOptions: schema.ColumnCreationOptions{
-				PrimaryKey: true,
-			},
-		},
-		{
-			Name: "bool",
-			Type: schema.TypeBool,
-		},
-	},
-}
-
 func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination, target *schema.Table, source *schema.Table, mode specs.MigrateMode) error {
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
@@ -94,13 +64,13 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 }
 
 func (*PluginTestSuite) destinationPluginTestMigrate(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	newPlugin NewPluginFunc,
 	logger zerolog.Logger,
 	spec specs.Destination,
 	strategy MigrateStrategy,
-) error {
+) {
 	spec.BatchSize = 1
 
 	t.Run("add_column", func(t *testing.T) {
@@ -292,6 +262,4 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			t.Fatal(err)
 		}
 	})
-
-	return nil
 }

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -274,7 +274,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}
 		p := newPlugin()
 		if err := testMigration(ctx, p, logger, spec, target, source, strategy.ChangeColumn); err != nil {
-			t.Fatalf("failed to migrate add_column: %v", err)
+			t.Fatalf("failed to migrate change_column: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
 			t.Fatal(err)

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -21,6 +21,16 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
+
+	source.Columns = append(schema.ColumnList{
+		schema.CqSourceNameColumn,
+		schema.CqSyncTimeColumn,
+	}, source.Columns...)
+	target.Columns = append(schema.ColumnList{
+		schema.CqSourceNameColumn,
+		schema.CqSyncTimeColumn,	
+	}, target.Columns...)
+
 	if err := p.Migrate(ctx, []*schema.Table{source}); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
@@ -50,9 +60,6 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 	if mode == specs.MigrateModeSafe {
 		if len(resourcesRead) != 2 {
 			return fmt.Errorf("expected 2 resources after write, got %d", len(resourcesRead))
-		}
-		if diff := resourcesRead[0].Diff(resource1.Data); diff != "" {
-			return fmt.Errorf("resource1 diff: %s", diff)
 		}
 		if diff := resourcesRead[1].Diff(resource2.Data); diff != "" {
 			return fmt.Errorf("resource2 diff: %s", diff)

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -233,7 +233,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}
 		p := newPlugin()
 		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumnNotNull); err != nil {
-			t.Fatalf("failed to migrate add_column: %v", err)
+			t.Fatalf("failed to migrate remove_column_not_null: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
 			t.Fatal(err)

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -3,124 +3,295 @@ package destination
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/schema"
 	"github.com/cloudquery/plugin-sdk/specs"
-	"github.com/cloudquery/plugin-sdk/testdata"
 	"github.com/rs/zerolog"
 )
 
-func (*PluginTestSuite) destinationPluginTestMigrate(
-	ctx context.Context,
-	p *Plugin,
-	logger zerolog.Logger,
-	spec specs.Destination,
-) error {
-	spec.BatchSize = 1
+var tableTest1 = &schema.Table{
+	Name: "test1",
+	Columns: []schema.Column{
+		{
+			Name: "id",
+			Type: schema.TypeUUID,
+			CreationOptions: schema.ColumnCreationOptions{
+				PrimaryKey: true,
+			},
+		},
+	},
+}
+
+var tableTest2 = &schema.Table{
+	Name: "test1",
+	Columns: []schema.Column{
+		{
+			Name: "id",
+			Type: schema.TypeUUID,
+			CreationOptions: schema.ColumnCreationOptions{
+				PrimaryKey: true,
+			},
+		},
+		{
+			Name: "bool",
+			Type: schema.TypeBool,
+		},
+	},
+}
+
+func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination, target *schema.Table, source *schema.Table, mode specs.MigrateMode) error {
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
-	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
-	table := testdata.TestTable(tableName)
-	if err := p.Migrate(ctx, []*schema.Table{table}); err != nil {
+	if err := p.Migrate(ctx, []*schema.Table{source}); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 
-	sourceName := tableName
+	sourceName := target.Name
 	sourceSpec := specs.Source{
 		Name: sourceName,
 	}
 	syncTime := time.Now().UTC().Round(1 * time.Second)
-	resource1 := createTestResources(table, sourceName, syncTime, 1)[0]
-	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{table}, syncTime, resource1); err != nil {
+	resource1 := createTestResources(source, sourceName, syncTime, 1)[0]
+	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{source}, syncTime, resource1); err != nil {
 		return fmt.Errorf("failed to write one: %w", err)
 	}
 
-	// check that migrations and writes still succeed when column ordering is changed
-	a := table.Columns.Index("uuid")
-	b := table.Columns.Index("float")
-	table.Columns[a], table.Columns[b] = table.Columns[b], table.Columns[a]
-	if err := p.Migrate(ctx, []*schema.Table{table}); err != nil {
-		return fmt.Errorf("failed to migrate table with changed column ordering: %w", err)
+	if err := p.Migrate(ctx, []*schema.Table{target}); err != nil {
+		return fmt.Errorf("failed to migrate existing table: %w", err)
 	}
-	resource2 := createTestResources(table, sourceName, syncTime, 1)[0]
-	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{table}, syncTime, resource2); err != nil {
-		return fmt.Errorf("failed to write one after column order change: %w", err)
+	resource2 := createTestResources(target, sourceName, syncTime, 1)[0]
+	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{target}, syncTime, resource2); err != nil {
+		return fmt.Errorf("failed to write one after migration: %w", err)
 	}
 
-	resourcesRead, err := p.readAll(ctx, table, sourceName)
+	resourcesRead, err := p.readAll(ctx, target, sourceName)
 	if err != nil {
 		return fmt.Errorf("failed to read all: %w", err)
 	}
-	if len(resourcesRead) != 2 {
-		return fmt.Errorf("expected 2 resources after second write, got %d", len(resourcesRead))
+	if mode == specs.MigrateModeSafe {
+		if len(resourcesRead) != 2 {
+			return fmt.Errorf("expected 2 resources after write, got %d", len(resourcesRead))
+		}
+		if diff := resourcesRead[0].Diff(resource1.Data); diff != "" {
+			return fmt.Errorf("resource1 diff: %s", diff)
+		}
+		if diff := resourcesRead[1].Diff(resource2.Data); diff != "" {
+			return fmt.Errorf("resource2 diff: %s", diff)
+		}
+	} else {
+		if len(resourcesRead) != 1 {
+			return fmt.Errorf("expected 1 resources after write, got %d", len(resourcesRead))
+		}
+		if diff := resourcesRead[0].Diff(resource2.Data); diff != "" {
+			return fmt.Errorf("resource1 diff: %s", diff)
+		}
 	}
 
-	// check that migrations succeed when a new column is added
-	table.Columns = append(table.Columns, schema.Column{
-		Name: "new_column",
-		Type: schema.TypeInt,
+	return nil
+}
+
+func (*PluginTestSuite) destinationPluginTestMigrate(
+	t *testing.T,
+	ctx context.Context,
+	newPlugin NewPluginFunc,
+	logger zerolog.Logger,
+	spec specs.Destination,
+	strategy MigrateStrategy,
+) error {
+	spec.BatchSize = 1
+
+	t.Run("add_column", func(t *testing.T) {
+		if strategy.AddColumn == specs.MigrateModeForced && spec.MigrateMode == specs.MigrateModeSafe {
+			t.Skip("skipping as migrate mode is safe")
+			return
+		}
+		source := &schema.Table{
+			Name: "add_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+			},
+		}
+		target := &schema.Table{
+			Name: "add_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeBool,
+				},
+			},
+		}
+		p := newPlugin()
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.AddColumn); err != nil {
+			t.Fatalf("failed to migrate add_column: %v", err)
+		}
+		if err := p.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
 	})
-	if err := p.Migrate(ctx, []*schema.Table{table}); err != nil {
-		return fmt.Errorf("failed to migrate table with new column: %w", err)
-	}
-	resource3 := createTestResources(table, sourceName, syncTime, 1)[0]
-	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{table}, syncTime, resource3); err != nil {
-		return fmt.Errorf("failed to write one after column order change: %w", err)
-	}
-	resourcesRead, err = p.readAll(ctx, table, sourceName)
-	if err != nil {
-		return fmt.Errorf("failed to read all: %w", err)
-	}
-	if len(resourcesRead) != 3 {
-		return fmt.Errorf("expected 3 resources after third write, got %d", len(resourcesRead))
-	}
 
-	// check that migration still succeeds when there is an extra column in the destination table,
-	// which should be ignored
-	oldTable := testdata.TestTable(tableName)
-	if err := p.Migrate(ctx, []*schema.Table{oldTable}); err != nil {
-		return fmt.Errorf("failed to migrate table with extra column in destination: %w", err)
-	}
-	resource4 := createTestResources(oldTable, sourceName, syncTime, 1)[0]
-	if err := p.writeOne(ctx, sourceSpec, []*schema.Table{oldTable}, syncTime, resource4); err != nil {
-		return fmt.Errorf("failed to write one after column order change: %w", err)
-	}
-	totalExpectedResources := 4
-	if spec.MigrateMode == specs.MigrateModeForced {
-		table.Columns[len(table.Columns)-1].Type = schema.TypeString
-		if err := p.Migrate(ctx, []*schema.Table{table}); err != nil {
-			return fmt.Errorf("failed to migrate table with changed column type: %w", err)
+	t.Run("add_column_not_null", func(t *testing.T) {
+		if strategy.AddColumnNotNull == specs.MigrateModeForced && spec.MigrateMode == specs.MigrateModeSafe {
+			t.Skip("skipping as migrate mode is safe")
+			return
 		}
-		resource5 := createTestResources(table, sourceName, syncTime, 1)[0]
-		if err := p.writeOne(ctx, sourceSpec, []*schema.Table{table}, syncTime, resource5); err != nil {
-			return fmt.Errorf("failed to write one after column type change: %w", err)
+		source := &schema.Table{
+			Name: "add_column_not_null",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+			},
 		}
-		totalExpectedResources++
-	}
+		target := &schema.Table{
+			Name: "add_column_not_null",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeBool,
+					CreationOptions: schema.ColumnCreationOptions{
+						NotNull: true,
+					},
+				},
+			},
+		}
+		p := newPlugin()
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.AddColumnNotNull); err != nil {
+			t.Fatalf("failed to migrate add_column_not_null: %v", err)
+		}
+		if err := p.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 
-	resourcesRead, err = p.readAll(ctx, oldTable, sourceName)
-	if err != nil {
-		return fmt.Errorf("failed to read all: %w", err)
-	}
-	if len(resourcesRead) != totalExpectedResources {
-		return fmt.Errorf("expected %d resources after fourth write, got %d", totalExpectedResources, len(resourcesRead))
-	}
-	cqIDIndex := table.Columns.Index(schema.CqIDColumn.Name)
-	found := false
-	for _, r := range resourcesRead {
-		if !r[cqIDIndex].Equal(resource4.Data[cqIDIndex]) {
-			continue
+	t.Run("remove_column", func(t *testing.T) {
+		if strategy.RemoveColumn == specs.MigrateModeForced && spec.MigrateMode == specs.MigrateModeSafe {
+			t.Skip("skipping as migrate mode is safe")
+			return
 		}
-		found = true
-		if !r.Equal(resource4.Data) {
-			return fmt.Errorf("expected resource to be equal to original resource, but got diff: %s", r.Diff(resource4.Data))
+		source := &schema.Table{
+			Name: "remove_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeBool,
+				},
+			},
 		}
-	}
-	if !found {
-		return fmt.Errorf("expected to find resource with cq_id %s, but none matched", resource4.Data[cqIDIndex])
-	}
+		target := &schema.Table{
+			Name: "remove_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+			},
+		}
+		p := newPlugin()
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+			t.Fatalf("failed to migrate remove_column: %v", err)
+		}
+		if err := p.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("remove_column_not_null", func(t *testing.T) {
+		if strategy.RemoveColumnNotNull == specs.MigrateModeForced && spec.MigrateMode == specs.MigrateModeSafe {
+			t.Skip("skipping as migrate mode is safe")
+			return
+		}
+		source := &schema.Table{
+			Name: "remove_column_not_null",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeBool,
+					CreationOptions: schema.ColumnCreationOptions{
+						NotNull: true,
+					},
+				},
+			},
+		}
+		target := &schema.Table{
+			Name: "remove_column_not_null",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+			},
+		}
+		p := newPlugin()
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+			t.Fatalf("failed to migrate add_column: %v", err)
+		}
+		if err := p.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("change_column", func(t *testing.T) {
+		if strategy.ChangeColumn == specs.MigrateModeForced && spec.MigrateMode == specs.MigrateModeSafe {
+			t.Skip("skipping as migrate mode is safe")
+			return
+		}
+		source := &schema.Table{
+			Name: "change_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeBool,
+				},
+			},
+		}
+		target := &schema.Table{
+			Name: "change_column",
+			Columns: []schema.Column{
+				{
+					Name: "id",
+					Type: schema.TypeUUID,
+				},
+				{
+					Name: "bool",
+					Type: schema.TypeString,
+				},
+			},
+		}
+		p := newPlugin()
+		if err := testMigration(ctx, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+			t.Fatalf("failed to migrate add_column: %v", err)
+		}
+		if err := p.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	return nil
 }

--- a/schema/column.go
+++ b/schema/column.go
@@ -44,7 +44,7 @@ type Column struct {
 	IgnoreInTests bool `json:"-"`
 }
 
-func (c *Column) String() string {
+func (c Column) String() string {
 	var sb strings.Builder
 	sb.WriteString(c.Name)
 	sb.WriteString(":")

--- a/schema/table.go
+++ b/schema/table.go
@@ -281,23 +281,11 @@ func (t *Table) ValidateName() error {
 	return nil
 }
 
-// added columns with no constraints - migrate // table.GetAddedColumns(other)
-// added columns with not null - drop table // table.GetAddedConstraintColumns(other)
-// added columns with unique - drop table
-
-// changed columns: change type - drop table or drop/add column? // table.GetChangedColumns(other)
-// changed columns: added constraint not null or unique - drop table // table.GetChangedColumnsWithAddedConstraints
-// changed columns: removed constraint: not null, removed unique - drop constraint? do nothing? what if a user is adding a unique constraint? we will drop it? // table.GetChangedColumnsWithRemovedConstraints
-
-// removed columns: with no constraints - do nothing?
-// removed columns: with constraints not null or unique - drop column? drop table ? // table.RemovedColumnsWithConstraints(other)
-
-// changed pks: drop table // table.IsPrimaryKeyEqual(other)
-
-func (t *Table) GetChanges(other *Table) []TableColumnChange {
+// Get Changes returns changes between two tables when t is the new one and old is the old one.
+func (t *Table) GetChanges(old *Table) []TableColumnChange {
 	var changes []TableColumnChange
 	for _, c := range t.Columns {
-		otherColumn := other.Columns.Get(c.Name)
+		otherColumn := old.Columns.Get(c.Name)
 		if otherColumn == nil {
 			changes = append(changes, TableColumnChange{
 				Type:       TableColumnChangeTypeAdd,
@@ -315,7 +303,7 @@ func (t *Table) GetChanges(other *Table) []TableColumnChange {
 			})
 		}
 	}
-	for _, c := range other.Columns {
+	for _, c := range old.Columns {
 		if t.Columns.Get(c.Name) == nil {
 			changes = append(changes, TableColumnChange{
 				Type:       TableColumnChangeTypeRemove,

--- a/schema/table.go
+++ b/schema/table.go
@@ -31,6 +31,22 @@ type SyncSummary struct {
 	Panics    uint64
 }
 
+type TableColumnChangeType int
+
+const (
+	TableColumnChangeTypeUnknown TableColumnChangeType = iota
+	TableColumnChangeTypeAdd
+	TableColumnChangeTypeUpdate
+	TableColumnChangeTypeRemove
+)
+
+type TableColumnChange struct {
+	Type       TableColumnChangeType
+	ColumnName string
+	Current    Column
+	Previous   Column
+}
+
 type Table struct {
 	// Name of table
 	Name string `json:"name"`
@@ -73,6 +89,23 @@ var (
 	reValidTableName  = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
 	reValidColumnName = regexp.MustCompile(`^[a-z_][a-z\d_]*$`)
 )
+
+func (t TableColumnChangeType) String() string {
+	switch t {
+	case TableColumnChangeTypeAdd:
+		return "add"
+	case TableColumnChangeTypeUpdate:
+		return "update"
+	case TableColumnChangeTypeRemove:
+		return "remove"
+	default:
+		return "unknown"
+	}
+}
+
+func (t TableColumnChange) String() string {
+	return fmt.Sprintf("column: %s, type: %s, current: %s, previous: %s", t.ColumnName, t.Type, t.Current, t.Previous)
+}
 
 func (tt Tables) FilterDfsFunc(include, exclude func(*Table) bool, skipDependentTables bool) Tables {
 	filteredTables := make(Tables, 0, len(tt))
@@ -248,55 +281,50 @@ func (t *Table) ValidateName() error {
 	return nil
 }
 
-// GetAddedColumns returns a list of columns that are in this table but not in the other table.
-func (t *Table) GetAddedColumns(other *Table) []Column {
-	var added []Column
-	for _, c := range t.Columns {
-		if other.Columns.Get(c.Name) == nil {
-			added = append(added, c)
-		}
-	}
-	return added
-}
+// added columns with no constraints - migrate // table.GetAddedColumns(other)
+// added columns with not null - drop table // table.GetAddedConstraintColumns(other)
+// added columns with unique - drop table
 
-// GetChangedColumns returns a list of columns that are in this table but have different type in the other table.
-// returns got, want
-func (t *Table) GetChangedColumns(other *Table) (got ColumnList, want ColumnList) {
+// changed columns: change type - drop table or drop/add column? // table.GetChangedColumns(other)
+// changed columns: added constraint not null or unique - drop table // table.GetChangedColumnsWithAddedConstraints
+// changed columns: removed constraint: not null, removed unique - drop constraint? do nothing? what if a user is adding a unique constraint? we will drop it? // table.GetChangedColumnsWithRemovedConstraints
+
+// removed columns: with no constraints - do nothing?
+// removed columns: with constraints not null or unique - drop column? drop table ? // table.RemovedColumnsWithConstraints(other)
+
+// changed pks: drop table // table.IsPrimaryKeyEqual(other)
+
+func (t *Table) GetChanges(other *Table) []TableColumnChange {
+	var changes []TableColumnChange
 	for _, c := range t.Columns {
-		otherCol := other.Columns.Get(c.Name)
-		if otherCol == nil {
+		otherColumn := other.Columns.Get(c.Name)
+		if otherColumn == nil {
+			changes = append(changes, TableColumnChange{
+				Type:       TableColumnChangeTypeAdd,
+				ColumnName: c.Name,
+				Current:    c,
+			})
 			continue
 		}
-		if c.Type != otherCol.Type {
-			got = append(got, c)
-			want = append(want, *otherCol)
-		}
-		if c.CreationOptions.NotNull != otherCol.CreationOptions.NotNull {
-			got = append(got, c)
-			want = append(want, *otherCol)
-		}
-	}
-	return got, want
-}
-
-func (t *Table) IsPrimaryKeyEqual(other *Table) bool {
-	for _, c := range t.Columns {
-		if c.CreationOptions.PrimaryKey {
-			otherCol := other.Columns.Get(c.Name)
-			if otherCol == nil || !otherCol.CreationOptions.PrimaryKey {
-				return false
-			}
+		if c.Type != otherColumn.Type || c.CreationOptions.NotNull != otherColumn.CreationOptions.NotNull || c.CreationOptions.PrimaryKey != otherColumn.CreationOptions.PrimaryKey {
+			changes = append(changes, TableColumnChange{
+				Type:       TableColumnChangeTypeUpdate,
+				ColumnName: c.Name,
+				Current:    c,
+				Previous:   *otherColumn,
+			})
 		}
 	}
 	for _, c := range other.Columns {
-		if c.CreationOptions.PrimaryKey {
-			otherCol := t.Columns.Get(c.Name)
-			if otherCol == nil || !otherCol.CreationOptions.PrimaryKey {
-				return false
-			}
+		if t.Columns.Get(c.Name) == nil {
+			changes = append(changes, TableColumnChange{
+				Type:       TableColumnChangeTypeRemove,
+				ColumnName: c.Name,
+				Previous:   c,
+			})
 		}
 	}
-	return true
+	return changes
 }
 
 func (t *Table) ValidateDuplicateColumns() error {

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -246,8 +246,8 @@ func TestTablesFilterDFS(t *testing.T) {
 
 type testTableGetChangeTestCase struct {
 	name            string
-	target           *Table
-	source           *Table
+	target          *Table
+	source          *Table
 	expectedChanges []TableColumnChange
 }
 

--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -244,84 +244,85 @@ func TestTablesFilterDFS(t *testing.T) {
 	}
 }
 
-var testTable1 = &Table{
-	Name: "test",
-	Columns: []Column{
-		{Name: "bool", Type: TypeBool},
+type testTableGetChangeTestCase struct {
+	name            string
+	target           *Table
+	source           *Table
+	expectedChanges []TableColumnChange
+}
+
+var testTableGetChangeTestCases = []testTableGetChangeTestCase{
+	{
+		name: "no changes",
+		target: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+			},
+		},
+		source: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+			},
+		},
+		expectedChanges: nil,
+	},
+	{
+		name: "add column",
+		target: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+				{Name: "bool1", Type: TypeBool},
+			},
+		},
+		source: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+			},
+		},
+		expectedChanges: []TableColumnChange{
+			{
+				Type:       TableColumnChangeTypeAdd,
+				ColumnName: "bool1",
+				Current:    Column{Name: "bool1", Type: TypeBool},
+			},
+		},
+	},
+	{
+		name: "remove column",
+		target: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+			},
+		},
+		source: &Table{
+			Name: "test",
+			Columns: []Column{
+				{Name: "bool", Type: TypeBool},
+				{Name: "bool1", Type: TypeBool},
+			},
+		},
+		expectedChanges: []TableColumnChange{
+			{
+				Type:       TableColumnChangeTypeRemove,
+				ColumnName: "bool1",
+				Previous:   Column{Name: "bool1", Type: TypeBool},
+			},
+		},
 	},
 }
 
-var testTable2 = &Table{
-	Name: "test",
-	Columns: []Column{
-		{Name: "bool", Type: TypeBool},
-		{Name: "bool1", Type: TypeBool},
-	},
-}
-
-var testTable3 = &Table{
-	Name: "test",
-	Columns: []Column{
-		{Name: "bool", Type: TypeString},
-	},
-}
-
-var testTable4 = &Table{
-	Name: "test",
-	Columns: []Column{
-		{Name: "bool", Type: TypeBool, CreationOptions: ColumnCreationOptions{PrimaryKey: true, NotNull: true}},
-	},
-}
-
-func TestGetAddedColumns(t *testing.T) {
-	columns := testTable1.GetAddedColumns(testTable1)
-	if columns != nil {
-		t.Fatalf("got %v want nil", columns)
-	}
-
-	columns = testTable2.GetAddedColumns(testTable1)
-	if len(columns) != 1 {
-		t.Fatalf("got %v want 1", columns)
-	}
-	if columns[0].Name != "bool1" {
-		t.Fatalf("got %v want bool1", columns[0].Name)
-	}
-}
-
-func TestGetChangedColumns(t *testing.T) {
-	columns, _ := testTable1.GetChangedColumns(testTable1)
-	if columns != nil {
-		t.Fatalf("got %v want nil", columns)
-	}
-
-	columns, got := testTable3.GetChangedColumns(testTable2)
-	if len(columns) != 1 {
-		t.Fatalf("got %v want 1", columns)
-	}
-	if columns[0].Name != "bool" {
-		t.Fatalf("got %v want bool", columns[0].Name)
-	}
-	if columns[0].Type != TypeString {
-		t.Fatalf("got %v want TypeString", columns[0].Type)
-	}
-	if got[0].Type != TypeBool {
-		t.Fatalf("got %v want TypeBool", got[0].Type)
-	}
-
-	columns, _ = testTable4.GetChangedColumns(testTable2)
-	if len(columns) != 1 {
-		t.Fatalf("got %v want 1", columns)
-	}
-	if columns[0].Name != "bool" {
-		t.Fatalf("got %v want bool", columns[0].Name)
-	}
-}
-
-func TestIsPkEqual(t *testing.T) {
-	if !testTable1.IsPrimaryKeyEqual(testTable1) {
-		t.Fatalf("got false want true")
-	}
-	if testTable4.IsPrimaryKeyEqual(testTable2) {
-		t.Fatalf("got true want false")
+func TestTableGetChanges(t *testing.T) {
+	for _, tc := range testTableGetChangeTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			changes := tc.target.GetChanges(tc.source)
+			if diff := cmp.Diff(changes, tc.expectedChanges); diff != "" {
+				t.Errorf("diff (+got, -want): %v", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Migration detection APIs take 2.

- This creates **one** API that returns all the changes instead of multiple growing APIs for different set of changes.
- Improves Migration tests for different use-cases

This will come up also with a Postgres PR and documentation PR:

Basically each destination plugin would have the following table:

Migrations Logic

|  Change  | Behaviour                                        |
|----------|----------------------------------|
|  Add Column | Auto Migrate/Drop Table         | 
|  Add Column with Not Null | Auto Migrate/Drop Table  |  
|  Remove Column | Auto Migrate/Drop Table  |
|  Remove Column with Not Null | Auto Migrate/Drop Table  |
|  Change Column |  Auto Migrate/Drop Table |

and we can easily expand it in the code, tests and documentations.

Example of usage in https://github.com/cloudquery/cloudquery/pull/7819


