### PR TITLE
fix(test-migrate): Add CqId to migrate tests tables

### DIFF
--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -25,10 +25,12 @@ func testMigration(ctx context.Context, p *Plugin, logger zerolog.Logger, spec s
 	source.Columns = append(schema.ColumnList{
 		schema.CqSourceNameColumn,
 		schema.CqSyncTimeColumn,
+		schema.CqIDColumn,
 	}, source.Columns...)
 	target.Columns = append(schema.ColumnList{
 		schema.CqSourceNameColumn,
 		schema.CqSyncTimeColumn,
+		schema.CqIDColumn,
 	}, target.Columns...)
 
 	if err := p.Migrate(ctx, []*schema.Table{source}); err != nil {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Extracted from https://github.com/cloudquery/plugin-sdk/pull/694.
Some destinations need at least one not null column (for example a sorting key in ClickHouse). This PRs adds the CqId column for tables created during migrate tests.
I think this is also closer to reality as we always have that column in our schema.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
