### PR TITLE
feat(test-migrate): Add `DataLossMode` enum

### DIFF
--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -14,19 +14,19 @@ import (
 )
 
 var migrateStrategyOverwrite = destination.MigrateStrategy{
-	AddColumn:           specs.MigrateModeForced,
-	AddColumnNotNull:    specs.MigrateModeForced,
-	RemoveColumn:        specs.MigrateModeForced,
-	RemoveColumnNotNull: specs.MigrateModeForced,
-	ChangeColumn:        specs.MigrateModeForced,
+	AddColumn:           destination.DataLossModeTable,
+	AddColumnNotNull:    destination.DataLossModeTable,
+	RemoveColumn:        destination.DataLossModeTable,
+	RemoveColumnNotNull: destination.DataLossModeTable,
+	ChangeColumn:        destination.DataLossModeTable,
 }
 
 var migrateStrategyAppend = destination.MigrateStrategy{
-	AddColumn:           specs.MigrateModeForced,
-	AddColumnNotNull:    specs.MigrateModeForced,
-	RemoveColumn:        specs.MigrateModeForced,
-	RemoveColumnNotNull: specs.MigrateModeForced,
-	ChangeColumn:        specs.MigrateModeForced,
+	AddColumn:           destination.DataLossModeTable,
+	AddColumnNotNull:    destination.DataLossModeTable,
+	RemoveColumn:        destination.DataLossModeTable,
+	RemoveColumnNotNull: destination.DataLossModeTable,
+	ChangeColumn:        destination.DataLossModeTable,
 }
 
 func TestPluginUnmanagedClient(t *testing.T) {

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -13,17 +13,25 @@ import (
 	"github.com/rs/zerolog"
 )
 
+type DataLossMode int
+
+const (
+	DataLossModeNone DataLossMode = iota
+	DataLossModeColumn
+	DataLossModeTable
+)
+
 type PluginTestSuite struct {
 	tests PluginTestSuiteTests
 }
 
 // MigrateStrategy defines which tests we should include
 type MigrateStrategy struct {
-	AddColumn           specs.MigrateMode
-	AddColumnNotNull    specs.MigrateMode
-	RemoveColumn        specs.MigrateMode
-	RemoveColumnNotNull specs.MigrateMode
-	ChangeColumn        specs.MigrateMode
+	AddColumn           DataLossMode
+	AddColumnNotNull    DataLossMode
+	RemoveColumn        DataLossMode
+	RemoveColumnNotNull DataLossMode
+	ChangeColumn        DataLossMode
 }
 
 type PluginTestSuiteTests struct {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Extracted from https://github.com/cloudquery/plugin-sdk/pull/694.

The current `MigrateStrategy` struct uses `MigrateMode` enum, however that only allows the following:
- Safe mode without any data loss
- Forced mode with table drop

If we only change a column type (without any other changes like adding not null), there's no reason to drop the table (in some destinations).
This PR adds an enum that lets destination plugins decide what kind of data loss is expected when doing a forced migrate.

See example https://github.com/cloudquery/cloudquery/pull/8255/files#diff-16b35c7fa05984f0e08cef54e2b7f6a4079474b4e6eb0a5a93e333ca54ed57e1R17

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
