### PR TITLE
fix(destination): Set CqID to unique at the destination level

### DIFF
--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -186,7 +186,7 @@ func (p *Plugin) Init(ctx context.Context, logger zerolog.Logger, spec specs.Des
 // we implement all DestinationClient functions so we can hook into pre-post behavior
 func (p *Plugin) Migrate(ctx context.Context, tables schema.Tables) error {
 	SetDestinationManagedCqColumns(tables)
-	setCqIDNotNullColumnForTables(tables)
+	setCqIDColumnOptionsForTables(tables)
 	return p.client.Migrate(ctx, tables)
 }
 
@@ -292,13 +292,14 @@ func SetDestinationManagedCqColumns(tables []*schema.Table) {
 
 // this is for backward compatibility for sources that didn't update the SDK yet
 // TODO: remove this in the future once all sources have updated the SDK
-func setCqIDNotNullColumnForTables(tables []*schema.Table) {
+func setCqIDColumnOptionsForTables(tables []*schema.Table) {
 	for _, table := range tables {
 		for i, c := range table.Columns {
 			if c.Name == schema.CqIDColumn.Name {
 				table.Columns[i].CreationOptions.NotNull = true
+				table.Columns[i].CreationOptions.Unique = true
 			}
 		}
-		setCqIDNotNullColumnForTables(table.Relations)
+		setCqIDColumnOptionsForTables(table.Relations)
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Follow up to https://github.com/cloudquery/plugin-sdk/pull/702.
Since we add CqID as the source plugins level:
https://github.com/cloudquery/plugin-sdk/blob/47440c2fc485c0609a481f5a6d6f12d00f530402/plugins/source/plugin.go#L78

https://github.com/cloudquery/plugin-sdk/pull/702 doesn't work unless sources are using the latest SDK.
This PR adds it as the destination level too, similar to `NotNull`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
