### PR TITLE
fix: Remove sentry sending from destinations

### DIFF
--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -69,7 +69,7 @@ func (p *Plugin) flush(ctx context.Context, metrics *Metrics, table *schema.Tabl
 	}
 }
 
-func (p *Plugin) removeDuplicatesByPK(table *schema.Table, resources [][]any) [][]any {
+func (*Plugin) removeDuplicatesByPK(table *schema.Table, resources [][]any) [][]any {
 	pks := make(map[string]struct{}, len(resources))
 	res := make([][]any, 0, len(resources))
 	for _, r := range resources {


### PR DESCRIPTION
Right now the logic is not quite correct as if there are duplicate pks in the destination we should just filter but no reason to send to sentry. multiple sources can sync the same resources and it should be all good. We also check duplicates on the source level (and I think send to sentry) so no need to do it twice.