### PR TITLE
fix(types-json): Disable HTML escaping during JSON marshalling

### DIFF
--- a/schema/json.go
+++ b/schema/json.go
@@ -124,13 +124,17 @@ func (dst *JSON) Set(src any) error {
 		return &ValidationError{Type: TypeJSON, Msg: "use pointer to JSON instead of value", Value: value}
 
 	default:
-		buf, err := json.Marshal(value)
+		buffer := &bytes.Buffer{}
+		encoder := json.NewEncoder(buffer)
+		encoder.SetEscapeHTML(false)
+		err := encoder.Encode(value)
 		if err != nil {
 			return err
 		}
 
+		buf := buffer.Bytes()
 		// For map and slice jsons, it is easier for users to work with '[]' or '{}' instead of JSON's 'null'.
-		if bytes.Equal(buf, []byte(`null`)) {
+		if bytes.Equal(buf, []byte("null\n")) {
 			if isEmptyStringMap(value) {
 				*dst = JSON{Bytes: []byte("{}"), Status: Present}
 				return nil

--- a/schema/json.go
+++ b/schema/json.go
@@ -132,9 +132,10 @@ func (dst *JSON) Set(src any) error {
 			return err
 		}
 
-		buf := buffer.Bytes()
+		// JSON encoder adds a newline to the end of the output that we don't want.
+		buf := bytes.TrimSuffix(buffer.Bytes(), []byte("\n"))
 		// For map and slice jsons, it is easier for users to work with '[]' or '{}' instead of JSON's 'null'.
-		if bytes.Equal(buf, []byte("null\n")) {
+		if bytes.Equal(buf, []byte(`null`)) {
 			if isEmptyStringMap(value) {
 				*dst = JSON{Bytes: []byte("{}"), Status: Present}
 				return nil

--- a/schema/json_test.go
+++ b/schema/json_test.go
@@ -43,6 +43,8 @@ func TestJSONSet(t *testing.T) {
 		{source: map[string]Foo{}, result: JSON{Bytes: []byte(`{}`), Status: Present}},
 
 		{source: nil, result: JSON{Status: Null}},
+
+		{source: map[string]any{"test1": "a&b", "test2": "😀"}, result: JSON{Bytes: []byte(`{"test1": "a&b", "test2": "😀"}`), Status: Present}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/plugin-sdk/issues/622

See docs about the default behavior of `json.Marshal`:
https://pkg.go.dev/encoding/json#Marshal
![image](https://user-images.githubusercontent.com/26760571/221586015-11f4f30b-0876-4a6f-8021-91ef4da94ffd.png)
See also https://pkg.go.dev/encoding/json#Encoder.SetEscapeHTML:
![image](https://user-images.githubusercontent.com/26760571/221586148-5f2c18b0-3ad7-46b4-a91b-1a56cfd6cfcd.png)


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
