### PR TITLE
feat(multiplex): Detect duplicated clients

### DIFF
--- a/plugins/source/scheduler_dfs.go
+++ b/plugins/source/scheduler_dfs.go
@@ -37,6 +37,19 @@ func (p *Plugin) syncDfs(ctx context.Context, spec specs.Source, client schema.C
 		if table.Multiplex != nil {
 			clients = table.Multiplex(client)
 		}
+		// Detect duplicate clients while multiplexing
+		seenClients := make(map[string]bool)
+		for _, c := range clients {
+			if _, ok := seenClients[c.ID()]; !ok {
+				seenClients[c.ID()] = true
+			} else {
+				sentry.WithScope(func(scope *sentry.Scope) {
+					scope.SetTag("table", table.Name)
+					sentry.CurrentHub().CaptureMessage("duplicate client ID in " + table.Name)
+				})
+				p.logger.Warn().Str("client", c.ID()).Str("table", table.Name).Msg("multiplex returned duplicate client")
+			}
+		}
 		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/plugin-sdk/issues/713. This PR detects duplicated client IDs, sends a sentry report when that happens and also logs a warning.
It not this does not skip those clients (yet). I'll do a follow up based on the sentry data as we can have duplicate clients due to:
1. User errors creating a configuration that generates duplicated clients like in https://github.com/cloudquery/cloudquery/pull/8099
2. Plugins bug, not implementing the ID method correctly

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
