### PR TITLE
feat: Add ability to store table titles and render them in documentation

### DIFF
--- a/caser/caser_test.go
+++ b/caser/caser_test.go
@@ -66,6 +66,36 @@ func Test_ToCamel(t *testing.T) {
 	}
 }
 
+func Test_ToTitle(t *testing.T) {
+	type test struct {
+		Title string
+		Snake string
+	}
+
+	generatorTests := []test{
+		{Title: "Test Camel Case", Snake: "test_camel_case"},
+		{Title: "Account ID", Snake: "account_id"},
+		{Title: "ARNs", Snake: "arns"},
+		{Title: "Postgre SQL", Snake: "postgre_sql"},
+		{Title: "Query Store Retention", Snake: "query_store_retention"},
+		{Title: "Test Camel Case Long String", Snake: "test_camel_case_long_string"},
+		{Title: "Test Camel Case Long String", Snake: "test_camel_case_long_string"},
+		{Title: "Test IPv4", Snake: "test_ipv4"},
+		{Title: "AWS Test Table", Snake: "aws_test_table"},
+		{Title: "Gcp Test Table", Snake: "gcp_test_table"}, // no exception specified
+	}
+	t.Parallel()
+	c := New(WithCustomExceptions(map[string]string{
+		"arns": "ARNs",
+		"aws":  "AWS",
+	}))
+	for _, tc := range generatorTests {
+		t.Run(tc.Title, func(t *testing.T) {
+			assert.Equal(t, tc.Title, c.ToTitle(tc.Snake))
+		})
+	}
+}
+
 func Test_ToPascal(t *testing.T) {
 	type test struct {
 		Pascal string

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-JSON-__tables.json
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-JSON-__tables.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "incremental_table",
+    "title": "Incremental Table",
     "description": "Description for incremental table",
     "columns": [
       {
@@ -39,6 +40,7 @@
   },
   {
     "name": "test_table",
+    "title": "Test Table",
     "description": "Description for test table",
     "columns": [
       {
@@ -75,6 +77,7 @@
     "relations": [
       {
         "name": "relation_table",
+        "title": "Relation Table",
         "description": "Description for relational table",
         "columns": [
           {
@@ -102,6 +105,7 @@
         "relations": [
           {
             "name": "relation_relation_table_a",
+            "title": "Relation Relation Table A",
             "description": "Description for relational table's relation",
             "columns": [
               {
@@ -130,6 +134,7 @@
           },
           {
             "name": "relation_relation_table_b",
+            "title": "Relation Relation Table B",
             "description": "Description for relational table's relation",
             "columns": [
               {
@@ -160,6 +165,7 @@
       },
       {
         "name": "relation_table2",
+        "title": "Relation Table2",
         "description": "Description for second relational table",
         "columns": [
           {

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-incremental_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-incremental_table.md
@@ -1,5 +1,7 @@
 # Table: incremental_table
 
+This table shows data for Incremental Table.
+
 Description for incremental table
 
 The primary key for this table is **id_col**.

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table_a.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table_a.md
@@ -1,5 +1,7 @@
 # Table: relation_relation_table_a
 
+This table shows data for Relation Relation Table A.
+
 Description for relational table's relation
 
 The primary key for this table is **_cq_id**.

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table_b.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_relation_table_b.md
@@ -1,5 +1,7 @@
 # Table: relation_relation_table_b
 
+This table shows data for Relation Relation Table B.
+
 Description for relational table's relation
 
 The primary key for this table is **_cq_id**.

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-relation_table.md
@@ -1,5 +1,7 @@
 # Table: relation_table
 
+This table shows data for Relation Table.
+
 Description for relational table
 
 The primary key for this table is **_cq_id**.

--- a/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-test_table.md
+++ b/plugins/source/.snapshots/TestGeneratePluginDocs-Markdown-test_table.md
@@ -1,5 +1,7 @@
 # Table: test_table
 
+This table shows data for Test Table.
+
 Description for test table
 
 The composite primary key for this table is (**id_col**, **id_col2**).

--- a/plugins/source/options.go
+++ b/plugins/source/options.go
@@ -29,3 +29,11 @@ func WithUnmanaged() Option {
 		p.unmanaged = true
 	}
 }
+
+// WithTitleTransformer allows the plugin to control how table names get turned into titles for the
+// generated documentation.
+func WithTitleTransformer(t func(*schema.Table) string) Option {
+	return func(p *Plugin) {
+		p.titleTransformer = t
+	}
+}

--- a/plugins/source/plugin.go
+++ b/plugins/source/plugin.go
@@ -333,10 +333,3 @@ func (p *Plugin) Close(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (p *Plugin) tableTitle(table *schema.Table) string {
-	if table.Title != "" {
-		return table.Title
-	}
-	return p.titleTransformer(table)
-}

--- a/plugins/source/plugin.go
+++ b/plugins/source/plugin.go
@@ -68,6 +68,8 @@ type Plugin struct {
 	internalColumns bool
 	// unmanaged if set to true then the plugin will call Sync directly and not use the scheduler
 	unmanaged bool
+	// titleTransformer allows the plugin to control how table names get turned into titles for generated documentation
+	titleTransformer func(*schema.Table) string
 }
 
 const (
@@ -139,6 +141,7 @@ func NewPlugin(name string, version string, tables []*schema.Table, newExecution
 		newExecutionClient: newExecutionClient,
 		metrics:            &Metrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
 		caser:              caser.New(),
+		titleTransformer:   DefaultTitleTransformer,
 		internalColumns:    true,
 	}
 	for _, opt := range options {
@@ -329,4 +332,11 @@ func (p *Plugin) Close(ctx context.Context) error {
 		p.backend = nil
 	}
 	return nil
+}
+
+func (p *Plugin) tableTitle(table *schema.Table) string {
+	if table.Title != "" {
+		return table.Title
+	}
+	return p.titleTransformer(table)
 }

--- a/plugins/source/templates/table.md.go.tpl
+++ b/plugins/source/templates/table.md.go.tpl
@@ -1,5 +1,7 @@
 # Table: {{$.Name}}
 
+This table shows data for {{.|title}}.
+
 {{ $.Description }}
 {{ $length := len $.PrimaryKeys -}}
 {{ if eq $length 1 }}

--- a/schema/table.go
+++ b/schema/table.go
@@ -50,6 +50,8 @@ type TableColumnChange struct {
 type Table struct {
 	// Name of table
 	Name string `json:"name"`
+	// Title to be used in documentation (optional: will be generated from name if not set)
+	Title string `json:"title"`
 	// table description
 	Description string `json:"description"`
 	// Columns are the set of fields that are part of this table


### PR DESCRIPTION
This adds the ability to set titles for tables, and starts rendering them in the documentation. 

For example, docs for an example AWS table will now be rendered as:

```
# Table: aws_accessanalyzer_analyzer_findings

This table shows data for AWS Access Analyzer Analyzer Findings.
```

This change should help human readers more quickly parse what a table is about, and in some cases developers may want to change the `Title` attribute to make it more descriptive. It is also useful for search, as many search engines will not tokenize on the underscores, leaving these pages excluded from relevant searches.