### PR TITLE
fix: SpecReader to escape embedded JSON files

### DIFF
--- a/specs/spec_reader.go
+++ b/specs/spec_reader.go
@@ -2,10 +2,12 @@ package specs
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -32,6 +34,14 @@ func expandFileConfig(cfg []byte) ([]byte, error) {
 			expandErr = err
 			return nil
 		}
+		var isJSON any
+		if err := json.Unmarshal(content, &isJSON); err == nil {
+			k := reflect.TypeOf(isJSON).Kind()
+			if k == reflect.Map || k == reflect.Slice {
+				content, _ = json.Marshal(string(content))
+			}
+		}
+
 		return content
 	})
 	return cfg, expandErr

--- a/specs/spec_reader_test.go
+++ b/specs/spec_reader_test.go
@@ -287,6 +287,38 @@ spec:
 	}
 }
 
+func TestExpandFileJSON(t *testing.T) {
+	cfg := []byte(`
+kind: source
+spec:
+  name: gcp
+  path: cloudquery/gcp
+  version: v1.0.0
+  table_concurrency: 10
+  registry: local
+  destinations: [postgresql]
+  service_account_key_json: ${file:./testdata/creds2.json}
+	`)
+	expectedCfg := []byte(`
+kind: source
+spec:
+  name: gcp
+  path: cloudquery/gcp
+  version: v1.0.0
+  table_concurrency: 10
+  registry: local
+  destinations: [postgresql]
+  service_account_key_json: "{\"key\": \"foo\", \"secret\": \"bar\"}\n"
+	`)
+	expandedCfg, err := expandFileConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(expandedCfg, expectedCfg) {
+		t.Fatalf("got: %s expected: %s", expandedCfg, expectedCfg)
+	}
+}
+
 func TestExpandEnv(t *testing.T) {
 	os.Setenv("TEST_ENV_CREDS", "mytestcreds")
 	os.Setenv("TEST_ENV_CREDS2", "anothercredtest")

--- a/specs/testdata/creds2.json
+++ b/specs/testdata/creds2.json
@@ -1,0 +1,1 @@
+{"key": "foo", "secret": "bar"}


### PR DESCRIPTION
Should fix [#9094](https://github.com/cloudquery/cloudquery/issues/9094)
