### PR TITLE
fix(transform): Use path instead of field name for PK options

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -272,9 +272,12 @@ func (t *structTransformer) addColumnFromField(field reflect.StructField, parent
 	}
 
 	for _, pk := range t.pkFields {
-		if pk == field.Name {
+		if pk == path {
+			// use path to allow the following
+			// 1. Don't duplicate the PK fields if the unwrapped struct contains a fields with the same name
+			// 2. Allow specifying the nested unwrapped field as part of the PK.
 			column.CreationOptions.PrimaryKey = true
-			t.pkFieldsFound = append(t.pkFieldsFound, field.Name)
+			t.pkFieldsFound = append(t.pkFieldsFound, pk)
 		}
 	}
 


### PR DESCRIPTION
While using `transformers.WithPrimaryKeys` option there is an odd behavior being observed, where the unwrapped struct field also gets promoted to be PK.

Consider the following example:
```
type A struct {
  ID string
  B B
}

type B struct {
  ID string
}
```

Currently, if `transformers.WithPrimaryKeys("ID")` option was used to transform struct `A` we would get the following columns:
* `id`: PK, taken from `A`
* `b_id`: PK, taken from `B`

However, with the current change, the following becomes possible:

| `transformers.WithPrimaryKeys` | `id` is PK | `b_id` is PK |
| --- | --- | --- |
| `"ID"` |  `true` | `false` |
| `"B.ID"` |  `false` | `true` |
| `"ID", "B.ID"` |  `true` | `true` |