### PR TITLE
fix: Update Overwrite and OverwriteDeleteStale Test

### DIFF
--- a/plugins/destination/plugin_testing_overwrite.go
+++ b/plugins/destination/plugin_testing_overwrite.go
@@ -56,15 +56,15 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Context,
 		return fmt.Errorf("expected second resource diff: %s", diff)
 	}
 
-	secondSyncTime := syncTime.Add(time.Second).UTC()
+	secondSyncTime := time.Now().UTC().Round(1 * time.Second).Add(time.Hour).UTC()
 
-	// copy first resource but update the sync time
-	updatedResource := schema.DestinationResource{
-		TableName: table.Name,
-		Data:      make(schema.CQTypes, len(resources[0].Data)),
+	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
+	for _, colIndex := range []int{2, 3, 7} {
+		old := resources[0].Data[colIndex].Get()
+		if err := updatedResource.Data[colIndex].Set(old); err != nil {
+			return err
+		}
 	}
-	copy(updatedResource.Data, resources[0].Data)
-	_ = updatedResource.Data[1].Set(secondSyncTime)
 
 	// write second time
 	if err := p.writeOne(ctx, sourceSpec, tables, secondSyncTime, updatedResource); err != nil {

--- a/plugins/destination/plugin_testing_overwrite.go
+++ b/plugins/destination/plugin_testing_overwrite.go
@@ -59,7 +59,8 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Context,
 	secondSyncTime := time.Now().UTC().Round(1 * time.Second).Add(time.Hour).UTC()
 
 	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
-	for _, colIndex := range []int{2, 3, 7} {
+	for _, colName := range []string{schema.CqIDColumn.Name, schema.CqParentIDColumn.Name, "uuid"} {
+		colIndex := table.Columns.Index(colName)
 		old := resources[0].Data[colIndex].Get()
 		if err := updatedResource.Data[colIndex].Set(old); err != nil {
 			return err

--- a/plugins/destination/plugin_testing_overwrite_delete_stale.go
+++ b/plugins/destination/plugin_testing_overwrite_delete_stale.go
@@ -75,7 +75,7 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
 	for _, colIndex := range []int{2, 3, 7} {
 		old := resources[0].Data[colIndex].Get()
-		updatedResource.Data[colIndex].Set(old)
+		return updatedResource.Data[colIndex].Set(old)
 	}
 
 	// write second time

--- a/plugins/destination/plugin_testing_overwrite_delete_stale.go
+++ b/plugins/destination/plugin_testing_overwrite_delete_stale.go
@@ -72,13 +72,11 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 
 	secondSyncTime := syncTime.Add(time.Second).UTC()
 
-	// copy first resource but update the sync time
-	updatedResource := schema.DestinationResource{
-		TableName: table.Name,
-		Data:      make(schema.CQTypes, len(resources[0].Data)),
+	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
+	for _, colIndex := range []int{2, 3, 7} {
+		old := resources[0].Data[colIndex].Get()
+		updatedResource.Data[colIndex].Set(old)
 	}
-	copy(updatedResource.Data, resources[0].Data)
-	_ = updatedResource.Data[1].Set(secondSyncTime)
 
 	// write second time
 	if err := p.writeOne(ctx, sourceSpec, tables, secondSyncTime, updatedResource); err != nil {
@@ -94,7 +92,7 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 		return fmt.Errorf("after overwrite expected 1 resource, got %d", len(resourcesRead))
 	}
 
-	if diff := resources[0].Data.Diff(resourcesRead[0]); diff != "" {
+	if diff := resources[0].Data.Diff(resourcesRead[0]); diff == "" {
 		return fmt.Errorf("after overwrite expected first resource diff: %s", diff)
 	}
 

--- a/plugins/destination/plugin_testing_overwrite_delete_stale.go
+++ b/plugins/destination/plugin_testing_overwrite_delete_stale.go
@@ -73,7 +73,8 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 	secondSyncTime := syncTime.Add(time.Second).UTC()
 
 	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
-	for _, colIndex := range []int{2, 3, 7} {
+	for _, colName := range []string{schema.CqIDColumn.Name, schema.CqParentIDColumn.Name, "uuid"} {
+		colIndex := table.Columns.Index(colName)
 		old := resources[0].Data[colIndex].Get()
 		if err := updatedResource.Data[colIndex].Set(old); err != nil {
 			return err

--- a/plugins/destination/plugin_testing_overwrite_delete_stale.go
+++ b/plugins/destination/plugin_testing_overwrite_delete_stale.go
@@ -75,7 +75,9 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwriteDeleteStale(ctx conte
 	updatedResource := createTestResources(table, sourceName, secondSyncTime, 1)[0]
 	for _, colIndex := range []int{2, 3, 7} {
 		old := resources[0].Data[colIndex].Get()
-		return updatedResource.Data[colIndex].Set(old)
+		if err := updatedResource.Data[colIndex].Set(old); err != nil {
+			return err
+		}
 	}
 
 	// write second time


### PR DESCRIPTION
#### Summary

when we use `copy()` to copy the resources it does a shallow copy so the timestamp that is stored in the `memdb` gets updated as well, which is not what should be happening here. This was discovered as part of #740 
