### PR TITLE
feat(pk): Move PK duplicate report to source side

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
+	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/rs/zerolog v1.29.0
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3 h1:o95KDiV/b1xdkumY5
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3/go.mod h1:hTxjzRcX49ogbTGVJ1sM5mz5s+SSgiGIyL3jjPxl32E=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
+github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/pk/cache.go
+++ b/internal/pk/cache.go
@@ -1,0 +1,30 @@
+package pk
+
+import (
+	lru "github.com/hashicorp/golang-lru/v2"
+	"sync"
+)
+
+const CacheWindow = 10000 // 10k is sufficient
+
+type (
+	Cache struct {
+		pks sync.Map // implies usage by pointer, but allows init via new(Cache)
+	}
+	TableCache = *lru.Cache[string, struct{}]
+)
+
+func (c *Cache) For(tableName string) TableCache {
+	v, ok := c.pks.Load(tableName)
+	if ok {
+		return v.(TableCache)
+	}
+
+	cache, _ := lru.New[string, struct{}](CacheWindow)
+	v, _ = c.pks.LoadOrStore(tableName, cache)
+	return v.(TableCache)
+}
+
+func (c *Cache) Done(tableName string) {
+	c.pks.Delete(tableName)
+}

--- a/plugins/source/plugin.go
+++ b/plugins/source/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudquery/plugin-sdk/v2/caser"
 	"github.com/cloudquery/plugin-sdk/v2/internal/backends/local"
 	"github.com/cloudquery/plugin-sdk/v2/internal/backends/nop"
+	"github.com/cloudquery/plugin-sdk/v2/internal/pk"
 	"github.com/cloudquery/plugin-sdk/v2/schema"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
 	"github.com/rs/zerolog"
@@ -70,6 +71,8 @@ type Plugin struct {
 	unmanaged bool
 	// titleTransformer allows the plugin to control how table names get turned into titles for generated documentation
 	titleTransformer func(*schema.Table) string
+
+	pkCache *pk.Cache // reinitialized every Sync
 }
 
 const (
@@ -297,6 +300,8 @@ func (p *Plugin) Sync(ctx context.Context, res chan<- *schema.Resource) error {
 			return fmt.Errorf("failed to create execution client for source plugin %s: %w", p.name, err)
 		}
 	}
+
+	p.pkCache = new(pk.Cache)
 
 	startTime := time.Now()
 	if p.unmanaged {

--- a/schema/resource.go
+++ b/schema/resource.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"crypto/sha256"
 	"fmt"
-
 	"github.com/google/uuid"
 	"golang.org/x/exp/slices"
 )
@@ -136,6 +135,16 @@ func (r *Resource) Validate() error {
 		return fmt.Errorf("missing primary key on columns: %v", missingPks)
 	}
 	return nil
+}
+
+func (r *Resource) PrimaryKeyValue() (values CQTypes) {
+	for i, col := range r.Table.Columns {
+		if col.CreationOptions.PrimaryKey {
+			values = append(values, r.data[i])
+		}
+	}
+
+	return values
 }
 
 func (rr Resources) TableName() string {

--- a/schema/resource_test.go
+++ b/schema/resource_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"net/netip"
 	"testing"
 	"time"
@@ -525,5 +526,38 @@ func TestCalculateCQIDNoPrimaryKeys(t *testing.T) {
 			}
 			assert.NotEqual(t, initialCQID, resource.Get(CqIDColumn.Name).String())
 		})
+	}
+}
+
+func TestResource_PrimaryKeyValue(t *testing.T) {
+	type testCase struct {
+		r   *Resource
+		val string
+	}
+
+	for _, tc := range []testCase{
+		{r: &Resource{Table: &Table{}}, val: "[]"},
+		{r: &Resource{
+			Table: &Table{
+				Columns: ColumnList{
+					{Name: "a", CreationOptions: ColumnCreationOptions{PrimaryKey: true}},
+					{Name: "b"},
+					{Name: "c", CreationOptions: ColumnCreationOptions{PrimaryKey: true}},
+					{Name: "d"},
+					{Name: "e"},
+					{Name: "f", CreationOptions: ColumnCreationOptions{PrimaryKey: true}},
+				},
+			},
+			data: CQTypes{
+				&Text{Str: "aVal", Status: Present},
+				nil,
+				&Int8{Int: -1, Status: Present},
+				nil,
+				nil,
+				&Bool{Bool: true, Status: Present},
+			},
+		}, val: "[aVal,-1,true]"},
+	} {
+		require.Equal(t, tc.val, tc.r.PrimaryKeyValue().String())
 	}
 }

--- a/schema/types.go
+++ b/schema/types.go
@@ -272,6 +272,23 @@ func (c CQTypes) Len() int {
 	return len(c)
 }
 
+func (c CQTypes) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		if v == nil {
+			sb.WriteString("nil")
+		} else {
+			sb.WriteString(v.String())
+		}
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
 // Used in testing only.
 func (c CQTypes) Diff(other CQTypes) string {
 	var diff strings.Builder
@@ -318,23 +335,6 @@ func (c CQTypes) Equal(other CQTypes) bool {
 		}
 	}
 	return true
-}
-
-func (c CQTypes) String() string {
-	var sb strings.Builder
-	sb.WriteString("[")
-	for i, v := range c {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		if v == nil {
-			sb.WriteString("nil")
-		} else {
-			sb.WriteString(v.String())
-		}
-	}
-	sb.WriteString("]")
-	return sb.String()
 }
 
 func NewCqTypeFromValueType(typ ValueType) CQType {


### PR DESCRIPTION
Move PK duplicates check & reporting to Sentry from destination plugins to source ones.

This allows us to achieve the following:

1. Only the plugins we develop & maintain would be reporting the issues
2. We would be able to clearly tie the issue with the source plugin version
3. We will be able to utilize versioning & releases inSentry, too