### PR TITLE
feat: Null rows should go second

### DIFF
--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -130,7 +130,7 @@ func GenTestData(mem memory.Allocator, sc *arrow.Schema, opts GenTestDataOptions
 		if opts.StableUUID != uuid.Nil {
 			u = opts.StableUUID
 		}
-		nullRow := j%2 == 0
+		nullRow := j%2 == 1
 		bldr := array.NewRecordBuilder(mem, sc)
 		for i, c := range sc.Fields() {
 			if nullRow && c.Nullable {


### PR DESCRIPTION
Made a small mistake in the GenTestData function :) 

(Note: this PR is to the `feat/arrow_update` branch)