### PR TITLE
fix: Use Go memory allocator for arrow

### DIFF
--- a/internal/memdb/memdb_test.go
+++ b/internal/memdb/memdb_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v12/arrow"
-	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v2/plugins/destination"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
 	"github.com/cloudquery/plugin-sdk/v2/testdata"
@@ -122,8 +121,6 @@ func TestOnWriteError(t *testing.T) {
 	sourceSpec := specs.Source{
 		Name: sourceName,
 	}
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer mem.AssertSize(t, 0)
 	ch := make(chan arrow.Record, 1)
 	opts := testdata.GenTestDataOptions{
 		SourceName: "test",
@@ -131,8 +128,7 @@ func TestOnWriteError(t *testing.T) {
 		MaxRows:    1,
 		StableUUID: uuid.Nil,
 	}
-	record := testdata.GenTestData(mem, table.ToArrowSchema(), opts)[0]
-	defer record.Release()
+	record := testdata.GenTestData(table.ToArrowSchema(), opts)[0]
 	ch <- record
 	close(ch)
 	err := p.Write(ctx, sourceSpec, tables, syncTime, ch)
@@ -160,8 +156,6 @@ func TestOnWriteCtxCancelled(t *testing.T) {
 	sourceSpec := specs.Source{
 		Name: sourceName,
 	}
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer mem.AssertSize(t, 0)
 	ch := make(chan arrow.Record, 1)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	opts := testdata.GenTestDataOptions{
@@ -170,8 +164,7 @@ func TestOnWriteCtxCancelled(t *testing.T) {
 		MaxRows:    1,
 		StableUUID: uuid.Nil,
 	}
-	record := testdata.GenTestData(mem, table.ToArrowSchema(), opts)[0]
-	defer record.Release()
+	record := testdata.GenTestData(table.ToArrowSchema(), opts)[0]
 	ch <- record
 	defer cancel()
 	err := p.Write(ctx, sourceSpec, tables, syncTime, ch)

--- a/plugins/destination/plugin_testing.go
+++ b/plugins/destination/plugin_testing.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
-	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v2/schema"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
 	"github.com/cloudquery/plugin-sdk/v2/types"
@@ -116,11 +115,9 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipOverwrite {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.Name = "test_write_overwrite"
 		p := newPlugin()
-		if err := suite.destinationPluginTestWriteOverwrite(ctx, mem, p, logger, destSpec); err != nil {
+		if err := suite.destinationPluginTestWriteOverwrite(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -133,11 +130,9 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipOverwrite || suite.tests.SkipDeleteStale {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.Name = "test_write_overwrite_delete_stale"
 		p := newPlugin()
-		if err := suite.destinationPluginTestWriteOverwriteDeleteStale(ctx, mem, p, logger, destSpec); err != nil {
+		if err := suite.destinationPluginTestWriteOverwriteDeleteStale(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -150,11 +145,9 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipMigrateOverwrite {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.Name = "test_migrate_overwrite"
-		suite.destinationPluginTestMigrate(ctx, mem, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
 	})
 
 	t.Run("TestMigrateOverwriteForce", func(t *testing.T) {
@@ -162,12 +155,10 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipMigrateOverwriteForce {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.WriteMode = specs.WriteModeOverwrite
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_overwrite_force"
-		suite.destinationPluginTestMigrate(ctx, mem, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyOverwrite)
 	})
 
 	t.Run("TestWriteAppend", func(t *testing.T) {
@@ -175,11 +166,9 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipAppend {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.Name = "test_write_append"
 		p := newPlugin()
-		if err := suite.destinationPluginTestWriteAppend(ctx, mem, p, logger, destSpec); err != nil {
+		if err := suite.destinationPluginTestWriteAppend(ctx, p, logger, destSpec); err != nil {
 			t.Fatal(err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -189,14 +178,12 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 
 	t.Run("TestMigrateAppend", func(t *testing.T) {
 		t.Helper()
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		if suite.tests.SkipMigrateAppend {
 			t.Skip("skipping " + t.Name())
 		}
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.Name = "test_migrate_append"
-		suite.destinationPluginTestMigrate(ctx, mem, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
 	})
 
 	t.Run("TestMigrateAppendForce", func(t *testing.T) {
@@ -204,12 +191,10 @@ func PluginTestSuiteRunner(t *testing.T, newPlugin NewPluginFunc, destSpec specs
 		if suite.tests.SkipMigrateAppendForce {
 			t.Skip("skipping " + t.Name())
 		}
-		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		defer mem.AssertSize(t, 0)
 		destSpec.WriteMode = specs.WriteModeAppend
 		destSpec.MigrateMode = specs.MigrateModeForced
 		destSpec.Name = "test_migrate_append_force"
-		suite.destinationPluginTestMigrate(ctx, mem, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
+		suite.destinationPluginTestMigrate(ctx, t, newPlugin, logger, destSpec, tests.MigrateStrategyAppend)
 	})
 }
 

--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
-	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v2/schema"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
 	"github.com/cloudquery/plugin-sdk/v2/testdata"
@@ -22,7 +21,7 @@ func tableUUIDSuffix() string {
 	return strings.ReplaceAll(uuid.NewString(), "-", "_")
 }
 
-func testMigration(ctx context.Context, mem memory.Allocator, _ *testing.T, p *Plugin, logger zerolog.Logger, spec specs.Destination, target *arrow.Schema, source *arrow.Schema, mode specs.MigrateMode) error {
+func testMigration(ctx context.Context, _ *testing.T, p *Plugin, logger zerolog.Logger, spec specs.Destination, target *arrow.Schema, source *arrow.Schema, mode specs.MigrateMode) error {
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
 	}
@@ -41,9 +40,7 @@ func testMigration(ctx context.Context, mem memory.Allocator, _ *testing.T, p *P
 		SyncTime:   syncTime,
 		MaxRows:    1,
 	}
-	resource1 := testdata.GenTestData(mem, source, opts)[0]
-	resource1.Retain()
-	defer resource1.Release()
+	resource1 := testdata.GenTestData(source, opts)[0]
 	if err := p.writeOne(ctx, sourceSpec, syncTime, resource1); err != nil {
 		return fmt.Errorf("failed to write one: %w", err)
 	}
@@ -51,9 +48,7 @@ func testMigration(ctx context.Context, mem memory.Allocator, _ *testing.T, p *P
 	if err := p.Migrate(ctx, []*arrow.Schema{target}); err != nil {
 		return fmt.Errorf("failed to migrate existing table: %w", err)
 	}
-	resource2 := testdata.GenTestData(mem, target, opts)[0]
-	resource2.Retain()
-	defer resource2.Release()
+	resource2 := testdata.GenTestData(target, opts)[0]
 	if err := p.writeOne(ctx, sourceSpec, syncTime, resource2); err != nil {
 		return fmt.Errorf("failed to write one after migration: %w", err)
 	}
@@ -85,7 +80,6 @@ func testMigration(ctx context.Context, mem memory.Allocator, _ *testing.T, p *P
 
 func (*PluginTestSuite) destinationPluginTestMigrate(
 	ctx context.Context,
-	mem memory.Allocator,
 	t *testing.T,
 	newPlugin NewPluginFunc,
 	logger zerolog.Logger,
@@ -117,7 +111,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}, &md)
 
 		p := newPlugin()
-		if err := testMigration(ctx, mem, t, p, logger, spec, target, source, strategy.AddColumn); err != nil {
+		if err := testMigration(ctx, t, p, logger, spec, target, source, strategy.AddColumn); err != nil {
 			t.Fatalf("failed to migrate %s: %v", tableName, err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -147,7 +141,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 			{Name: "bool", Type: arrow.FixedWidthTypes.Boolean},
 		}, &md)
 		p := newPlugin()
-		if err := testMigration(ctx, mem, t, p, logger, spec, target, source, strategy.AddColumnNotNull); err != nil {
+		if err := testMigration(ctx, t, p, logger, spec, target, source, strategy.AddColumnNotNull); err != nil {
 			t.Fatalf("failed to migrate add_column_not_null: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -177,7 +171,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}, &md)
 
 		p := newPlugin()
-		if err := testMigration(ctx, mem, t, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
+		if err := testMigration(ctx, t, p, logger, spec, target, source, strategy.RemoveColumn); err != nil {
 			t.Fatalf("failed to migrate remove_column: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -207,7 +201,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}, &md)
 
 		p := newPlugin()
-		if err := testMigration(ctx, mem, t, p, logger, spec, target, source, strategy.RemoveColumnNotNull); err != nil {
+		if err := testMigration(ctx, t, p, logger, spec, target, source, strategy.RemoveColumnNotNull); err != nil {
 			t.Fatalf("failed to migrate remove_column_not_null: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {
@@ -238,7 +232,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 		}, &md)
 
 		p := newPlugin()
-		if err := testMigration(ctx, mem, t, p, logger, spec, target, source, strategy.ChangeColumn); err != nil {
+		if err := testMigration(ctx, t, p, logger, spec, target, source, strategy.ChangeColumn); err != nil {
 			t.Fatalf("failed to migrate change_column: %v", err)
 		}
 		if err := p.Close(ctx); err != nil {

--- a/plugins/destination/plugin_testing_write_append.go
+++ b/plugins/destination/plugin_testing_write_append.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
-	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v2/specs"
 	"github.com/cloudquery/plugin-sdk/v2/testdata"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
 
-func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, mem memory.Allocator, p *Plugin, logger zerolog.Logger, spec specs.Destination) error {
+func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, p *Plugin, logger zerolog.Logger, spec specs.Destination) error {
 	spec.WriteMode = specs.WriteModeAppend
 	if err := p.Init(ctx, logger, spec); err != nil {
 		return fmt.Errorf("failed to init plugin: %w", err)
@@ -39,26 +38,20 @@ func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, 
 		SyncTime:   syncTime,
 		MaxRows:    1,
 	}
-	record1 := testdata.GenTestData(mem, table.ToArrowSchema(), opts)[0]
-	record1.Retain()
-	defer record1.Release()
+	record1 := testdata.GenTestData(table.ToArrowSchema(), opts)[0]
 	if err := p.writeOne(ctx, specSource, syncTime, record1); err != nil {
 		return fmt.Errorf("failed to write one second time: %w", err)
 	}
 
 	secondSyncTime := syncTime.Add(10 * time.Second).UTC()
 	opts.SyncTime = secondSyncTime
-	record2 := testdata.GenTestData(mem, table.ToArrowSchema(), opts)[0]
-	record2.Retain()
-	defer record2.Release()
+	record2 := testdata.GenTestData(table.ToArrowSchema(), opts)[0]
 
 	if !s.tests.SkipSecondAppend {
 		// write second time
 		if err := p.writeOne(ctx, specSource, secondSyncTime, record2); err != nil {
 			return fmt.Errorf("failed to write one second time: %w", err)
 		}
-	} else {
-		record2.Release()
 	}
 
 	resourcesRead, err := p.readAll(ctx, tables[0], sourceName)

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -134,7 +134,7 @@ type GenTestDataOptions struct {
 	StableTime time.Time
 }
 
-func GenTestData(mem memory.Allocator, sc *arrow.Schema, opts GenTestDataOptions) []arrow.Record {
+func GenTestData(sc *arrow.Schema, opts GenTestDataOptions) []arrow.Record {
 	var records []arrow.Record
 	for j := 0; j < opts.MaxRows; j++ {
 		u := uuid.New()
@@ -142,7 +142,7 @@ func GenTestData(mem memory.Allocator, sc *arrow.Schema, opts GenTestDataOptions
 			u = opts.StableUUID
 		}
 		nullRow := j%2 == 1
-		bldr := array.NewRecordBuilder(mem, sc)
+		bldr := array.NewRecordBuilder(memory.DefaultAllocator, sc)
 		for i, c := range sc.Fields() {
 			if nullRow && c.Nullable && !schema.IsPk(c) &&
 				 c.Name != schema.CqSourceNameColumn.Name &&


### PR DESCRIPTION
Following this short discussion - https://github.com/apache/arrow/issues/35232

It seems we don't really need to use Retain/Release outside the arrow library. We can always bring this back in the future if we would like to experiment if this brings better memory performance then the default go allocator. 