### PR TITLE
chore(ci): Add timeout to CI jobs

### DIFF
--- a/.github/workflows/add_tags.yml
+++ b/.github/workflows/add_tags.yml
@@ -9,6 +9,7 @@ name: conventional-release-labels
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: bcoe/conventional-release-labels@v1
         with:

--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -11,6 +11,7 @@ jobs:
   golangci:
     name: Lint with GolangCI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/lint_markdown.yml
+++ b/.github/workflows/lint_markdown.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint-grammar:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -21,6 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   lint-structure:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -29,4 +31,4 @@ jobs:
         with:
           files: .
           config_file: .markdownlint.yaml
-          ignore_files: '{plugins/source/testdata/*,CHANGELOG.md}'
+          ignore_files: "{plugins/source/testdata/*,CHANGELOG.md}"

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -11,6 +11,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release

--- a/.github/workflows/unittest-post.yml
+++ b/.github/workflows/unittest-post.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   post-unitests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # This posts the status to the PR/commit
       - uses: haya14busa/action-workflow_run-status@v1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

The default GitHub Actions timeout is 6 hours. This PR sets all jobs timeouts to 10m to avoid things like:
https://github.com/cloudquery/plugin-sdk/actions/runs/4753306214/jobs/8444724190 (This Windows job timed out after 6 hours)

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
