### PR TITLE
fix: TransformWithStruct/DefaultNameTransformer change for invalid column names

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -360,8 +360,7 @@ func (t *Table) ValidateDuplicateColumns() error {
 
 func (t *Table) ValidateColumnNames() error {
 	for _, c := range t.Columns {
-		ok := reValidColumnName.MatchString(c.Name)
-		if !ok {
+		if !ValidColumnName(c.Name) {
 			return fmt.Errorf("column name %q on table %q is not valid: column names must contain only lower-case letters, numbers and underscores, and must start with a lower-case letter or underscore", c.Name, t.Name)
 		}
 	}
@@ -429,4 +428,8 @@ func (t *Table) Copy(parent *Table) *Table {
 		c.Relations[i] = t.Relations[i].Copy(&c)
 	}
 	return &c
+}
+
+func ValidColumnName(name string) bool {
+	return reValidColumnName.MatchString(name)
 }

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -363,7 +363,9 @@ func DefaultNameTransformer(field reflect.StructField) (string, error) {
 		if jsonTag == "-" {
 			return "", nil
 		}
-		name = jsonTag
+		if schema.ValidColumnName(jsonTag) {
+			name = jsonTag
+		}
 	}
 	return defaultCaser.ToSnake(name), nil
 }

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -66,6 +66,10 @@ type (
 		Name    string `json:"name"`
 		Version int    `json:"version"`
 	}
+
+	testFunnyStruct struct {
+		AFunnyLookingField string `json:"OS-EXT:a-funny-looking-field"`
+	}
 )
 
 var (
@@ -243,6 +247,16 @@ var (
 			},
 		},
 	}
+
+	expectedFunnyTable = schema.Table{
+		Name: "test_funny_struct",
+		Columns: schema.ColumnList{
+			{
+				Name: "a_funny_looking_field",
+				Type: schema.TypeString,
+			},
+		},
+	}
 )
 
 func TestTableFromGoStruct(t *testing.T) {
@@ -355,6 +369,13 @@ func TestTableFromGoStruct(t *testing.T) {
 			},
 			want:    expectedTableWithPKs,
 			wantErr: true,
+		},
+		{
+			name: "Should properly transform structs with funny looking fields",
+			args: args{
+				testStruct: testFunnyStruct{},
+			},
+			want: expectedFunnyTable,
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/cloudquery/cloudquery/issues/10274

I went for the simple approach of not accepting the json tag value if it's going to result in an invalid column name.
