### PR TITLE
feat(test): Add double migration test

### DIFF
--- a/plugins/destination/plugin_testing_migrate.go
+++ b/plugins/destination/plugin_testing_migrate.go
@@ -245,14 +245,7 @@ func (*PluginTestSuite) destinationPluginTestMigrate(
 
 	t.Run("double_migration", func(t *testing.T) {
 		tableName := "double_migration_" + tableUUIDSuffix()
-		md := arrow.NewMetadata([]string{schema.MetadataTableName}, []string{tableName})
-		table := arrow.NewSchema([]arrow.Field{
-			schema.CqSourceNameField,
-			schema.CqSyncTimeField,
-			schema.CqIDField,
-			{Name: "id", Type: types.ExtensionTypes.UUID, Nullable: true},
-			{Name: "bool", Type: arrow.FixedWidthTypes.Boolean},
-		}, &md)
+		table := schema.CQSchemaToArrow(testdata.TestTable(tableName))
 
 		p := newPlugin()
 		require.NoError(t, p.Init(ctx, logger, spec))


### PR DESCRIPTION
We saw some bugs when the migration code wasn't reliable and, if we ran safe migration after forced one, there would be conflicts reported (where they shouldn't have been).
This extra test ensures that the destination is in sync what it scans from database and what is taken from spec.