### PR TITLE
fix(arrow): Allow empty and `nil` valid param in `AppendValues`

### DIFF
--- a/types/inet.go
+++ b/types/inet.go
@@ -33,9 +33,13 @@ func (b *InetBuilder) UnsafeAppend(v *net.IPNet) {
 }
 
 func (b *InetBuilder) AppendValues(v []*net.IPNet, valid []bool) {
+	if len(v) != len(valid) && len(valid) != 0 {
+		panic("len(v) != len(valid) && len(valid) != 0")
+	}
+
 	data := make([]string, len(v))
 	for i, v := range v {
-		if !valid[i] {
+		if len(valid) > 0 && !valid[i] {
 			continue
 		}
 		data[i] = v.String()

--- a/types/inet_test.go
+++ b/types/inet_test.go
@@ -35,7 +35,7 @@ func TestInetBuilder(t *testing.T) {
 		mustParseInet("192.168.0.0/26"),
 		mustParseInet("192.168.0.0/27"),
 	}
-	b.AppendValues(values, []bool{true, true})
+	b.AppendValues(values, nil)
 
 	require.Equal(t, 6, b.Len(), "unexpected Len()")
 

--- a/types/json.go
+++ b/types/json.go
@@ -54,10 +54,14 @@ func (b *JSONBuilder) AppendValueFromString(s string) error {
 }
 
 func (b *JSONBuilder) AppendValues(v []any, valid []bool) {
+	if len(v) != len(valid) && len(valid) != 0 {
+		panic("len(v) != len(valid) && len(valid) != 0")
+	}
+
 	data := make([][]byte, len(v))
 	var err error
 	for i := range v {
-		if !valid[i] {
+		if len(valid) > 0 && !valid[i] {
 			continue
 		}
 		// per https://github.com/cloudquery/plugin-sdk/issues/622

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -28,7 +28,7 @@ func TestJSONBuilder(t *testing.T) {
 		map[string]any{"e": 5, "f": 6},
 		map[string]any{"g": 7, "h": 8},
 	}
-	b.AppendValues(values, []bool{true, true})
+	b.AppendValues(values, nil)
 
 	require.Equal(t, 6, b.Len(), "unexpected Len()")
 

--- a/types/mac.go
+++ b/types/mac.go
@@ -29,9 +29,13 @@ func (b *MacBuilder) UnsafeAppend(v net.HardwareAddr) {
 }
 
 func (b *MacBuilder) AppendValues(v []net.HardwareAddr, valid []bool) {
+	if len(v) != len(valid) && len(valid) != 0 {
+		panic("len(v) != len(valid) && len(valid) != 0")
+	}
+
 	data := make([][]byte, len(v))
 	for i, v := range v {
-		if !valid[i] {
+		if len(valid) > 0 && !valid[i] {
 			continue
 		}
 		data[i] = v

--- a/types/mac_test.go
+++ b/types/mac_test.go
@@ -35,7 +35,7 @@ func TestMacBuilder(t *testing.T) {
 		mustParseMac("00:00:00:00:00:03"),
 		mustParseMac("00:00:00:00:00:04"),
 	}
-	b.AppendValues(values, []bool{true, true})
+	b.AppendValues(values, nil)
 
 	require.Equal(t, 6, b.Len(), "unexpected Len()")
 

--- a/types/uuid.go
+++ b/types/uuid.go
@@ -42,9 +42,13 @@ func (b *UUIDBuilder) AppendValueFromString(s string) error {
 }
 
 func (b *UUIDBuilder) AppendValues(v []uuid.UUID, valid []bool) {
+	if len(v) != len(valid) && len(valid) != 0 {
+		panic("len(v) != len(valid) && len(valid) != 0")
+	}
+
 	data := make([][]byte, len(v))
 	for i := range v {
-		if !valid[i] {
+		if len(valid) > 0 && !valid[i] {
 			continue
 		}
 		data[i] = v[i][:]

--- a/types/uuid_test.go
+++ b/types/uuid_test.go
@@ -27,7 +27,7 @@ func TestUUIDBuilder(t *testing.T) {
 		uuid.MustParse("00000000-0000-0000-0000-000000000003"),
 		uuid.MustParse("00000000-0000-0000-0000-000000000004"),
 	}
-	b.AppendValues(values, []bool{true, true})
+	b.AppendValues(values, nil)
 
 	require.Equal(t, 6, b.Len(), "unexpected Len()")
 


### PR DESCRIPTION
Follow-up for #823 