### PR TITLE
fix: Fix test column generation

### DIFF
--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -228,11 +228,16 @@ func removeDuplicates(columns []Column) []Column {
 
 func removeColumnsByType(columns []Column, t ...arrow.Type) []Column {
 	var newColumns []Column
-	for _, d := range t {
-		for _, c := range columns {
+	for _, c := range columns {
+		shouldRemove := false
+		for _, d := range t {
 			if c.Type.ID() == d {
-				newColumns = append(newColumns, c)
+				shouldRemove = true
+				break
 			}
+		}
+		if !shouldRemove {
+			newColumns = append(newColumns, c)
 		}
 	}
 	return newColumns
@@ -240,11 +245,16 @@ func removeColumnsByType(columns []Column, t ...arrow.Type) []Column {
 
 func removeColumnsByDataType(columns []Column, dt ...arrow.DataType) []Column {
 	var newColumns []Column
-	for _, d := range dt {
-		for _, c := range columns {
+	for _, c := range columns {
+		shouldRemove := false
+		for _, d := range dt {
 			if arrow.TypeEqual(c.Type, d) {
-				newColumns = append(newColumns, c)
+				shouldRemove = true
+				break
 			}
+		}
+		if !shouldRemove {
+			newColumns = append(newColumns, c)
 		}
 	}
 	return newColumns

--- a/schema/testdata_test.go
+++ b/schema/testdata_test.go
@@ -31,7 +31,7 @@ func TestTestSourceColumns(t *testing.T) {
 		t.Fatal("expected no times when WithTestSourceSkipTimes is used")
 	}
 	if skipAll.Get("timestamp_us") == nil {
-		t.Fatal("expected no microsecond timestamps even when WithTestSourceSkipTimestamps is used")
+		t.Fatal("expected microsecond timestamps even when WithTestSourceSkipTimestamps is used (microsecond timestamps must always be supported)")
 	}
 	if skipAll.Get("timestamp_ns") != nil {
 		t.Fatal("expected no nansecond timestamps when WithTestSourceSkipTimestamps is used")

--- a/schema/testdata_test.go
+++ b/schema/testdata_test.go
@@ -1,0 +1,42 @@
+package schema
+
+import "testing"
+
+func TestTestSourceColumns(t *testing.T) {
+	// basic sanity check for tested columns
+	defaults := TestSourceColumns()
+	if len(defaults) < 100 {
+		t.Fatal("expected at least 100 columns by default")
+	}
+	skipAll := ColumnList(TestSourceColumns(
+		WithTestSourceSkipStructs(),
+		WithTestSourceSkipMaps(),
+		WithTestSourceSkipDates(),
+		WithTestSourceSkipTimes(),
+		WithTestSourceSkipTimestamps(),
+		WithTestSourceSkipDurations(),
+		WithTestSourceSkipIntervals(),
+		WithTestSourceSkipLargeTypes(),
+	))
+	if skipAll.Get("struct") != nil {
+		t.Fatal("expected no structs when WithTestSourceSkipStructs is used")
+	}
+	if skipAll.Get("map") != nil {
+		t.Fatal("expected no maps when WithTestSourceSkipMaps is used")
+	}
+	if skipAll.Get("date32") != nil {
+		t.Fatal("expected no date32 when WithTestSourceSkipDates is used")
+	}
+	if skipAll.Get("time32") != nil {
+		t.Fatal("expected no times when WithTestSourceSkipTimes is used")
+	}
+	if skipAll.Get("timestamp_us") == nil {
+		t.Fatal("expected no microsecond timestamps even when WithTestSourceSkipTimestamps is used")
+	}
+	if skipAll.Get("timestamp_ns") != nil {
+		t.Fatal("expected no nansecond timestamps when WithTestSourceSkipTimestamps is used")
+	}
+	if skipAll.Get("monthinterval") != nil {
+		t.Fatal("expected no interval when WithTestSourceSkipIntervals is used")
+	}
+}

--- a/schema/testdata_test.go
+++ b/schema/testdata_test.go
@@ -2,12 +2,17 @@ package schema
 
 import "testing"
 
-func TestTestSourceColumns(t *testing.T) {
+func TestTestSourceColumns_Default(t *testing.T) {
 	// basic sanity check for tested columns
 	defaults := TestSourceColumns()
 	if len(defaults) < 100 {
 		t.Fatal("expected at least 100 columns by default")
 	}
+	// test some specific columns
+	checkColumnsExist(t, defaults, []string{"int64", "date32", "timestamp_us", "string", "struct", "string_map", "string_list"})
+}
+
+func TestTestSourceColumns_SkipAll(t *testing.T) {
 	skipAll := ColumnList(TestSourceColumns(
 		WithTestSourceSkipStructs(),
 		WithTestSourceSkipMaps(),
@@ -18,25 +23,22 @@ func TestTestSourceColumns(t *testing.T) {
 		WithTestSourceSkipIntervals(),
 		WithTestSourceSkipLargeTypes(),
 	))
-	if skipAll.Get("struct") != nil {
-		t.Fatal("expected no structs when WithTestSourceSkipStructs is used")
+	// test some specific columns
+	checkColumnsDontExist(t, skipAll, []string{"int64", "date32", "timestamp_us", "string", "struct", "string_map", "string_list"})
+}
+
+func checkColumnsExist(t *testing.T, list ColumnList, cols []string) {
+	for _, col := range cols {
+		if list.Get(col) == nil {
+			t.Errorf("expected column %s to be present", col)
+		}
 	}
-	if skipAll.Get("map") != nil {
-		t.Fatal("expected no maps when WithTestSourceSkipMaps is used")
-	}
-	if skipAll.Get("date32") != nil {
-		t.Fatal("expected no date32 when WithTestSourceSkipDates is used")
-	}
-	if skipAll.Get("time32") != nil {
-		t.Fatal("expected no times when WithTestSourceSkipTimes is used")
-	}
-	if skipAll.Get("timestamp_us") == nil {
-		t.Fatal("expected microsecond timestamps even when WithTestSourceSkipTimestamps is used (microsecond timestamps must always be supported)")
-	}
-	if skipAll.Get("timestamp_ns") != nil {
-		t.Fatal("expected no nansecond timestamps when WithTestSourceSkipTimestamps is used")
-	}
-	if skipAll.Get("monthinterval") != nil {
-		t.Fatal("expected no interval when WithTestSourceSkipIntervals is used")
+}
+
+func checkColumnsDontExist(t *testing.T, list ColumnList, cols []string) {
+	for _, col := range cols {
+		if list.Get(col) == nil {
+			t.Errorf("expected no %s column", col)
+		}
 	}
 }

--- a/schema/testdata_test.go
+++ b/schema/testdata_test.go
@@ -24,7 +24,8 @@ func TestTestSourceColumns_SkipAll(t *testing.T) {
 		WithTestSourceSkipLargeTypes(),
 	))
 	// test some specific columns
-	checkColumnsDontExist(t, skipAll, []string{"int64", "date32", "timestamp_us", "string", "struct", "string_map", "string_list"})
+	checkColumnsExist(t, skipAll, []string{"int64", "timestamp_us", "string", "string_list"})
+	checkColumnsDontExist(t, skipAll, []string{"date32", "struct", "string_map"})
 }
 
 func checkColumnsExist(t *testing.T, list ColumnList, cols []string) {
@@ -37,7 +38,7 @@ func checkColumnsExist(t *testing.T, list ColumnList, cols []string) {
 
 func checkColumnsDontExist(t *testing.T, list ColumnList, cols []string) {
 	for _, col := range cols {
-		if list.Get(col) == nil {
+		if list.Get(col) != nil {
 			t.Errorf("expected no %s column", col)
 		}
 	}


### PR DESCRIPTION
There was a bug in the last implementation causing many types to be missing; it's always that final refactor you do 😄 

This time I added a sanity check for the testdata generation to make sure it can't be catastrophically broken without us knowing about it.