### PR TITLE
feat: Revert "feat(test): Test writing to a child table"

### DIFF
--- a/internal/memdb/memdb.go
+++ b/internal/memdb/memdb.go
@@ -95,7 +95,7 @@ func (c *client) overwrite(table *schema.Table, data arrow.Record) {
 }
 
 func (c *client) Migrate(_ context.Context, tables schema.Tables) error {
-	for _, table := range tables.FlattenTables() {
+	for _, table := range tables {
 		tableName := table.Name
 		memTable := c.memoryDB[tableName]
 		if memTable == nil {

--- a/plugins/destination/plugin_testing_overwrite.go
+++ b/plugins/destination/plugin_testing_overwrite.go
@@ -20,10 +20,11 @@ func (*PluginTestSuite) destinationPluginTestWriteOverwrite(ctx context.Context,
 	}
 	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
 	table := schema.TestTable(tableName, testSourceOptions...)
-	parent := schema.TestTable(tableName+"_parent", testSourceOptions...)
-	parent.Relations = schema.Tables{table}
 	syncTime := time.Now().UTC().Round(1 * time.Second)
-	if err := p.Migrate(ctx, schema.Tables{parent}); err != nil {
+	tables := schema.Tables{
+		table,
+	}
+	if err := p.Migrate(ctx, tables); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 

--- a/plugins/destination/plugin_testing_write_append.go
+++ b/plugins/destination/plugin_testing_write_append.go
@@ -19,10 +19,11 @@ func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, 
 	}
 	tableName := fmt.Sprintf("cq_%s_%d", spec.Name, time.Now().Unix())
 	table := schema.TestTable(tableName, testSourceOptions...)
-	parent := schema.TestTable(tableName+"_parent", testSourceOptions...)
-	parent.Relations = schema.Tables{table}
 	syncTime := time.Now().UTC().Round(1 * time.Second)
-	if err := p.Migrate(ctx, schema.Tables{parent}); err != nil {
+	tables := schema.Tables{
+		table,
+	}
+	if err := p.Migrate(ctx, tables); err != nil {
 		return fmt.Errorf("failed to migrate tables: %w", err)
 	}
 
@@ -52,7 +53,7 @@ func (s *PluginTestSuite) destinationPluginTestWriteAppend(ctx context.Context, 
 		}
 	}
 
-	resourcesRead, err := p.readAll(ctx, table, sourceName)
+	resourcesRead, err := p.readAll(ctx, tables[0], sourceName)
 	if err != nil {
 		return fmt.Errorf("failed to read all second time: %w", err)
 	}


### PR DESCRIPTION
Reverts cloudquery/plugin-sdk#878

As far as I can see there is no need for this because over the wire it is always flattened anyway and in general I think we should move to always flatten structure as it causes more harm then good. 