### PR TITLE
fix: Scalar set now accepts scalar type

### DIFF
--- a/scalar/binary.go
+++ b/scalar/binary.go
@@ -33,10 +33,22 @@ func (s *Binary) String() string {
 	return string(s.Value)
 }
 
+func (s *Binary) Get() any {
+	return s.Value
+}
+
 func (s *Binary) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/bool.go
+++ b/scalar/bool.go
@@ -37,11 +37,24 @@ func (s *Bool) String() string {
 	return strconv.FormatBool(s.Value)
 }
 
+func (s *Bool) Get() any {
+	return s.Value
+}
+
 func (s *Bool) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
 	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
+	}
+
 	switch value := val.(type) {
 	case bool:
 		s.Value = value

--- a/scalar/bool_test.go
+++ b/scalar/bool_test.go
@@ -17,6 +17,7 @@ func TestBoolSet(t *testing.T) {
 		{source: "f", result: Bool{Value: false, Valid: true}},
 		{source: _bool(true), result: Bool{Value: true, Valid: true}},
 		{source: _bool(false), result: Bool{Value: false, Valid: true}},
+		{source: &Bool{Value: true, Valid: true}, result: Bool{Value: true, Valid: true}},
 		{source: nil, result: Bool{}},
 	}
 

--- a/scalar/float.go
+++ b/scalar/float.go
@@ -38,10 +38,22 @@ func (s *Float32) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value == r.Value
 }
 
+func (s *Float32) Get() any {
+	return s.Value
+}
+
 func (s *Float32) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {
@@ -126,6 +138,10 @@ func (*Float64) DataType() arrow.DataType {
 	return arrow.PrimitiveTypes.Float64
 }
 
+func (s *Float64) Get() any {
+	return s.Value
+}
+
 func (s *Float64) Equal(rhs Scalar) bool {
 	if rhs == nil {
 		return false
@@ -148,6 +164,14 @@ func (s *Float64) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/float_test.go
+++ b/scalar/float_test.go
@@ -23,6 +23,7 @@ func TestFloat32Set(t *testing.T) {
 		{source: uint64(1), result: Float32{Value: 1, Valid: true}},
 		{source: "1", result: Float32{Value: 1, Valid: true}},
 		{source: _int8(1), result: Float32{Value: 1, Valid: true}},
+		{source: &Float32{Value: 1, Valid: true}, result: Float32{Value: 1, Valid: true}},
 	}
 
 	for i, tt := range successfulTests {
@@ -59,6 +60,7 @@ func TestFloat64Set(t *testing.T) {
 		{source: uint64(1), result: Float64{Value: 1, Valid: true}},
 		{source: "1", result: Float64{Value: 1, Valid: true}},
 		{source: _int8(1), result: Float64{Value: 1, Valid: true}},
+		{source: &Float64{Value: 1, Valid: true}, result: Float64{Value: 1, Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/inet.go
+++ b/scalar/inet.go
@@ -41,9 +41,21 @@ func (s *Inet) String() string {
 	return s.Value.String()
 }
 
+func (s *Inet) Get() any {
+	return s.Value
+}
+
 func (s *Inet) Set(val any) error {
 	if val == nil {
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/inet_test.go
+++ b/scalar/inet_test.go
@@ -71,6 +71,7 @@ func TestInetSet(t *testing.T) {
 			b.WriteString(s)
 			return &b
 		}("127.0.0.1"), result: Inet{Value: mustParseInet(t, "127.0.0.1"), Valid: true}},
+		{source: &Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}, result: Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/int.go
+++ b/scalar/int.go
@@ -38,10 +38,22 @@ func (s *Int64) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value == r.Value
 }
 
+func (s *Int64) Get() any {
+	return s.Value
+}
+
 func (s *Int64) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/int_test.go
+++ b/scalar/int_test.go
@@ -23,6 +23,7 @@ func TestInt8Set(t *testing.T) {
 		{source: float64(1), result: Int64{Value: 1, Valid: true}},
 		{source: "1", result: Int64{Value: 1, Valid: true}},
 		{source: _int8(1), result: Int64{Value: 1, Valid: true}},
+		{source: &Int64{Value: 1, Valid: true}, result: Int64{Value: 1, Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/json.go
+++ b/scalar/json.go
@@ -22,6 +22,10 @@ func (*JSON) DataType() arrow.DataType {
 	return types.ExtensionTypes.JSON
 }
 
+func (s *JSON) Get() any {
+	return s.Value
+}
+
 func (s *JSON) Equal(rhs Scalar) bool {
 	if rhs == nil {
 		return false
@@ -55,6 +59,14 @@ func (s *JSON) String() string {
 func (s *JSON) Set(val any) error {
 	if val == nil {
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/json_test.go
+++ b/scalar/json_test.go
@@ -43,6 +43,7 @@ func TestJSONSet(t *testing.T) {
 		{source: nil, result: JSON{}},
 
 		{source: map[string]any{"test1": "a&b", "test2": "😀"}, result: JSON{Value: []byte(`{"test1": "a&b", "test2": "😀"}`), Valid: true}},
+		{source: &JSON{Value: []byte(`{"test1": "a&b", "test2": "😀"}`), Valid: true}, result: JSON{Value: []byte(`{"test1": "a&b", "test2": "😀"}`), Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/list.go
+++ b/scalar/list.go
@@ -59,6 +59,10 @@ func (s *List) Equal(rhs Scalar) bool {
 	return true
 }
 
+func (s *List) Get() any {
+	return s.Value
+}
+
 func (s *List) Set(val any) error {
 	if val == nil {
 		s.Valid = false
@@ -66,6 +70,14 @@ func (s *List) Set(val any) error {
 	}
 	if s.Type == nil {
 		panic("List type is nil")
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	reflectedValue := reflect.ValueOf(val)

--- a/scalar/list_test.go
+++ b/scalar/list_test.go
@@ -15,6 +15,14 @@ func TestListSet(t *testing.T) {
 			&Int64{Value: 1, Valid: true},
 			&Int64{Value: 2, Valid: true},
 		}, Valid: true, Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)}},
+		{source: &List{Value: []Scalar{
+			&Int64{Value: 1, Valid: true},
+			&Int64{Value: 2, Valid: true},
+		}, Valid: true, Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)},
+			result: List{Value: []Scalar{
+				&Int64{Value: 1, Valid: true},
+				&Int64{Value: 2, Valid: true},
+			}, Valid: true, Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/mac.go
+++ b/scalar/mac.go
@@ -38,9 +38,21 @@ func (s *Mac) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value.String() == r.Value.String()
 }
 
+func (s *Mac) Get() any {
+	return s.Value
+}
+
 func (s *Mac) Set(val any) error {
 	if val == nil {
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/mac_test.go
+++ b/scalar/mac_test.go
@@ -18,6 +18,10 @@ func TestMacaddrSet(t *testing.T) {
 			source: "01:23:45:67:89:ab",
 			result: Mac{Value: mustParseMacaddr(t, "01:23:45:67:89:ab"), Valid: true},
 		},
+		{
+			source: &Mac{Value: mustParseMacaddr(t, "01:23:45:67:89:ab"), Valid: true},
+			result: Mac{Value: mustParseMacaddr(t, "01:23:45:67:89:ab"), Valid: true},
+		},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/scalar.go
+++ b/scalar/scalar.go
@@ -24,6 +24,8 @@ type Scalar interface {
 	// Validate() error
 	// tries to set the value of the scalar to the given value
 	Set(val any) error
+
+	Get() any
 	Equal(other Scalar) bool
 }
 

--- a/scalar/string.go
+++ b/scalar/string.go
@@ -37,10 +37,22 @@ func (s *String) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value == r.Value
 }
 
+func (s *String) Get() any {
+	return s.Value
+}
+
 func (s *String) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/timestamp.go
+++ b/scalar/timestamp.go
@@ -57,9 +57,21 @@ func (s *Timestamp) String() string {
 	return s.Value.Format(time.RFC3339)
 }
 
+func (s *Timestamp) Get() any {
+	return s.Value
+}
+
 func (s *Timestamp) Set(val any) error {
 	if val == nil {
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/timestamp_test.go
+++ b/scalar/timestamp_test.go
@@ -34,6 +34,7 @@ func TestTimestampSet(t *testing.T) {
 		{source: timeInstance.String(), result: Timestamp{Value: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Valid: true}},
 		{source: TimestampSt{timeInstance}, result: Timestamp{Value: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Valid: true}},
 		{source: "", result: Timestamp{}},
+		{source: &Timestamp{Value: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Valid: true}, result: Timestamp{Value: time.Date(2105, 7, 23, 22, 23, 37, 750076110, time.UTC), Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/uint.go
+++ b/scalar/uint.go
@@ -37,10 +37,22 @@ func (s *Uint64) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value == r.Value
 }
 
+func (s *Uint64) Get() any {
+	return s.Value
+}
+
 func (s *Uint64) Set(val any) error {
 	if val == nil {
 		s.Valid = false
 		return nil
+	}
+
+	if sc, ok := val.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := val.(type) {

--- a/scalar/uint_test.go
+++ b/scalar/uint_test.go
@@ -19,6 +19,7 @@ func TestUint64Set(t *testing.T) {
 		{source: float64(1), result: Uint64{Value: 1, Valid: true}},
 		{source: "1", result: Uint64{Value: 1, Valid: true}},
 		{source: _int8(1), result: Uint64{Value: 1, Valid: true}},
+		{source: &Uint64{Value: 1, Valid: true}, result: Uint64{Value: 1, Valid: true}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/uuid.go
+++ b/scalar/uuid.go
@@ -40,9 +40,21 @@ func (s *UUID) Equal(rhs Scalar) bool {
 	return s.Valid == r.Valid && s.Value == r.Value
 }
 
+func (s *UUID) Get() any {
+	return s.Value
+}
+
 func (s *UUID) Set(src any) error {
 	if src == nil {
 		return nil
+	}
+
+	if sc, ok := src.(Scalar); ok {
+		if !sc.IsValid() {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(sc.Get())
 	}
 
 	switch value := src.(type) {

--- a/scalar/uuid_test.go
+++ b/scalar/uuid_test.go
@@ -50,6 +50,10 @@ func TestUUIDSet(t *testing.T) {
 			source: StringUUIDType("00010203-0405-0607-0809-0a0b0c0d0e0f"),
 			result: UUID{Value: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Valid: true},
 		},
+		{
+			source: &UUID{Value: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Valid: true},
+			result: UUID{Value: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Valid: true},
+		},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
This brings back functionally that we had in cqtypes which needs to keep all our resolver working (specifically the ParentColumnResolver) 