### PR TITLE
fix: Transform `[]any` as `JSON`

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -331,9 +331,13 @@ func defaultGoTypeToSchemaType(v reflect.Type) (arrow.DataType, error) {
 		}
 		return types.ExtensionTypes.JSON, nil
 	case reflect.Slice:
-		if v.Elem().Kind() == reflect.Uint8 {
+		switch v.Elem().Kind() {
+		case reflect.Uint8:
 			return arrow.BinaryTypes.Binary, nil
+		case reflect.Interface:
+			return types.ExtensionTypes.JSON, nil
 		}
+
 		elemValueType, err := defaultGoTypeToSchemaType(v.Elem())
 		if err != nil {
 			return nil, err

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -40,6 +40,8 @@ type (
 
 		ByteArrayCol []byte `json:"byte_array_col,omitempty"`
 
+		AnyArrayCol []any `json:"any_array_col,omitempty"`
+
 		TimeCol        time.Time  `json:"time_col,omitempty"`
 		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
 		JSONTag        *string    `json:"json_tag"`
@@ -127,6 +129,10 @@ var (
 		{
 			Name: "byte_array_col",
 			Type: arrow.BinaryTypes.Binary,
+		},
+		{
+			Name: "any_array_col",
+			Type: types.ExtensionTypes.JSON,
 		},
 		{
 			Name: "time_col",


### PR DESCRIPTION
Without this, attempting to transform an `[]any` column results in panic:
> panic: failed to transform table vercel_teams: failed to add column for field Profiles: failed to transform type for field Profiles: unsupported type: interface

Which is different from v2 behavior.
