### PR TITLE
fix: Use backtick around types

### DIFF
--- a/plugins/source/templates/table.md.go.tpl
+++ b/plugins/source/templates/table.md.go.tpl
@@ -40,5 +40,5 @@ The following tables depend on {{.Name}}:
 | Name          | Type          |
 | ------------- | ------------- |
 {{- range $column := $.Columns }}
-|{{$column.Name}}{{if $column.PrimaryKey}} (PK){{end}}{{if $column.IncrementalKey}} (Incremental Key){{end}}|{{$column.Type}}|
+|{{$column.Name}}{{if $column.PrimaryKey}} (PK){{end}}{{if $column.IncrementalKey}} (Incremental Key){{end}}|`{{$column.Type}}`|
 {{- end }}

--- a/plugins/source/testdata/TestGeneratePluginDocs-Markdown-incremental_table.md
+++ b/plugins/source/testdata/TestGeneratePluginDocs-Markdown-incremental_table.md
@@ -11,10 +11,10 @@ It supports incremental syncs based on the (**id_col**, **id_col2**) columns.
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|utf8|
-|_cq_sync_time|timestamp[us, tz=UTC]|
-|_cq_id|uuid|
-|_cq_parent_id|uuid|
-|int_col|int64|
-|id_col (PK) (Incremental Key)|int64|
-|id_col2 (Incremental Key)|int64|
+|_cq_source_name|`utf8`|
+|_cq_sync_time|`timestamp[us, tz=UTC]`|
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|int_col|`int64`|
+|id_col (PK) (Incremental Key)|`int64`|
+|id_col2 (Incremental Key)|`int64`|

--- a/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_relation_table_a.md
+++ b/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_relation_table_a.md
@@ -14,8 +14,8 @@ This table depends on [relation_table](relation_table.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|utf8|
-|_cq_sync_time|timestamp[us, tz=UTC]|
-|_cq_id (PK)|uuid|
-|_cq_parent_id|uuid|
-|string_col|utf8|
+|_cq_source_name|`utf8`|
+|_cq_sync_time|`timestamp[us, tz=UTC]`|
+|_cq_id (PK)|`uuid`|
+|_cq_parent_id|`uuid`|
+|string_col|`utf8`|

--- a/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_relation_table_b.md
+++ b/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_relation_table_b.md
@@ -14,8 +14,8 @@ This table depends on [relation_table](relation_table.md).
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|utf8|
-|_cq_sync_time|timestamp[us, tz=UTC]|
-|_cq_id (PK)|uuid|
-|_cq_parent_id|uuid|
-|string_col|utf8|
+|_cq_source_name|`utf8`|
+|_cq_sync_time|`timestamp[us, tz=UTC]`|
+|_cq_id (PK)|`uuid`|
+|_cq_parent_id|`uuid`|
+|string_col|`utf8`|

--- a/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_table.md
+++ b/plugins/source/testdata/TestGeneratePluginDocs-Markdown-relation_table.md
@@ -18,8 +18,8 @@ The following tables depend on relation_table:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|utf8|
-|_cq_sync_time|timestamp[us, tz=UTC]|
-|_cq_id (PK)|uuid|
-|_cq_parent_id|uuid|
-|string_col|utf8|
+|_cq_source_name|`utf8`|
+|_cq_sync_time|`timestamp[us, tz=UTC]`|
+|_cq_id (PK)|`uuid`|
+|_cq_parent_id|`uuid`|
+|string_col|`utf8`|

--- a/plugins/source/testdata/TestGeneratePluginDocs-Markdown-test_table.md
+++ b/plugins/source/testdata/TestGeneratePluginDocs-Markdown-test_table.md
@@ -16,14 +16,14 @@ The following tables depend on test_table:
 
 | Name          | Type          |
 | ------------- | ------------- |
-|_cq_source_name|utf8|
-|_cq_sync_time|timestamp[us, tz=UTC]|
-|_cq_id|uuid|
-|_cq_parent_id|uuid|
-|int_col|int64|
-|id_col (PK)|int64|
-|id_col2 (PK)|int64|
-|json_col|json|
-|list_col|list<item: int64, nullable>|
-|map_col|map<utf8, int64, items_nullable>|
-|struct_col|struct<string_field: utf8, int_field: int64>|
+|_cq_source_name|`utf8`|
+|_cq_sync_time|`timestamp[us, tz=UTC]`|
+|_cq_id|`uuid`|
+|_cq_parent_id|`uuid`|
+|int_col|`int64`|
+|id_col (PK)|`int64`|
+|id_col2 (PK)|`int64`|
+|json_col|`json`|
+|list_col|`list<item: int64, nullable>`|
+|map_col|`map<utf8, int64, items_nullable>`|
+|struct_col|`struct<string_field: utf8, int_field: int64>`|


### PR DESCRIPTION
Nextra isn't happy about us including `<` and `>` inside the types column now, it thinks it's HTML. This is causing errors on the website, so we need to escape these strings with backticks to avoid this issue.