### PR TITLE
feat: Update transformer for v3

### DIFF
--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -2,6 +2,7 @@ package transformers
 
 import (
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ type (
 		StringCol string  `json:"string_col,omitempty"`
 		FloatCol  float64 `json:"float_col,omitempty"`
 		BoolCol   bool    `json:"bool_col,omitempty"`
-		JSONCol   struct {
+		StructCol struct {
 			IntCol    int    `json:"int_col,omitempty"`
 			StringCol string `json:"string_col,omitempty"`
 		}
@@ -99,8 +100,12 @@ var (
 			Type: arrow.FixedWidthTypes.Boolean,
 		},
 		{
-			Name: "json_col",
-			Type: types.ExtensionTypes.JSON,
+			Name: "struct_col",
+			Type: arrow.StructOf(
+				[]arrow.Field{
+					{Name: "int_col", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+					{Name: "string_col", Type: arrow.BinaryTypes.String, Nullable: true},
+				}...),
 		},
 		{
 			Name: "int_array_col",
@@ -177,12 +182,35 @@ var (
 				PrimaryKey: true,
 			}),
 	}
+	expectedStructType = arrow.StructOf([]arrow.Field{
+		{Name: "int_col", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "int64_col", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "string_col", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "float_col", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "bool_col", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		{Name: "struct_col", Type: arrow.StructOf([]arrow.Field{
+			{Name: "int_col", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "string_col", Type: arrow.BinaryTypes.String, Nullable: true},
+		}...), Nullable: true},
+		{Name: "int_array_col", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true},
+		{Name: "int_pointer_array_col", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64), Nullable: true},
+		{Name: "string_array_col", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		{Name: "string_pointer_array_col", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		{Name: "inet_col", Type: types.ExtensionTypes.Inet, Nullable: true},
+		{Name: "inet_pointer_col", Type: types.ExtensionTypes.Inet, Nullable: true},
+		{Name: "byte_array_col", Type: arrow.BinaryTypes.Binary, Nullable: true},
+		{Name: "any_array_col", Type: types.ExtensionTypes.JSON, Nullable: true},
+		{Name: "time_col", Type: arrow.FixedWidthTypes.Timestamp_us, Nullable: true},
+		{Name: "time_pointer_col", Type: arrow.FixedWidthTypes.Timestamp_us, Nullable: true},
+		{Name: "json_tag", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "no_json_tag", Type: arrow.BinaryTypes.String, Nullable: true},
+	}...)
 	expectedTestTableNonEmbeddedStruct = schema.Table{
 		Name: "test_struct",
 		Columns: schema.ColumnList{
 			schema.Column{Name: "int_col", Type: arrow.PrimitiveTypes.Int64},
 			// Should not be unwrapped
-			schema.Column{Name: "test_struct", Type: types.ExtensionTypes.JSON},
+			schema.Column{Name: "test_struct", Type: expectedStructType},
 			// Should be unwrapped
 			schema.Column{Name: "non_embedded_embedded_string", Type: arrow.BinaryTypes.String},
 			schema.Column{Name: "non_embedded_int_col", Type: arrow.PrimitiveTypes.Int64},
@@ -197,7 +225,7 @@ var (
 				PrimaryKey: true,
 			},
 			// Should not be unwrapped
-			schema.Column{Name: "test_struct", Type: types.ExtensionTypes.JSON},
+			schema.Column{Name: "test_struct", Type: expectedStructType},
 			// Should be unwrapped
 			schema.Column{
 				Name: "non_embedded_embedded_string",
@@ -212,7 +240,7 @@ var (
 			// shouldn't be PK
 			schema.Column{Name: "int_col", Type: arrow.PrimitiveTypes.Int64},
 			// Should not be unwrapped
-			schema.Column{Name: "test_struct", Type: types.ExtensionTypes.JSON},
+			schema.Column{Name: "test_struct", Type: expectedStructType},
 			// Should be unwrapped
 			schema.Column{
 				Name: "non_embedded_embedded_string",
@@ -414,5 +442,52 @@ func TestTableFromGoStruct(t *testing.T) {
 				t.Fatalf("table does not match expected. diff (-got, +want): %v", diff)
 			}
 		})
+	}
+}
+
+func TestGoStructToArrowStruct(t *testing.T) {
+	type Inner struct {
+		String     string `json:"string"`
+		InnerInner struct {
+			String string `json:"string"`
+		}
+	}
+	type Self struct {
+		Self *Self `json:"self"`
+	}
+	type TestStruct struct {
+		String      string   `json:"string"`
+		Int         int      `json:"int"`
+		Float       float64  `json:"float"`
+		Bool        bool     `json:"bool"`
+		Bytes       []byte   `json:"bytes"`
+		StringSlice []string `json:"string_slice"`
+		Inner       Inner    `json:"inner"`
+		Self        Self     `json:"self"`
+		Interface   any      `json:"interface"`
+	}
+	s := TestStruct{}
+	got, err := goStructToArrowStruct(reflect.TypeOf(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := arrow.StructOf(
+		arrow.Field{Name: "string", Type: arrow.BinaryTypes.String, Nullable: true},
+		arrow.Field{Name: "int", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		arrow.Field{Name: "float", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		arrow.Field{Name: "bool", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		arrow.Field{Name: "bytes", Type: arrow.BinaryTypes.Binary, Nullable: true},
+		arrow.Field{Name: "string_slice", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		arrow.Field{Name: "inner", Type: arrow.StructOf(
+			arrow.Field{Name: "string", Type: arrow.BinaryTypes.String, Nullable: true},
+			arrow.Field{Name: "inner_inner", Type: arrow.StructOf(
+				arrow.Field{Name: "string", Type: arrow.BinaryTypes.String, Nullable: true},
+			), Nullable: true},
+		), Nullable: true},
+		arrow.Field{Name: "self", Type: arrow.StructOf(arrow.Field{Name: "self", Type: types.ExtensionTypes.JSON, Nullable: true}), Nullable: true},
+		arrow.Field{Name: "interface", Type: types.ExtensionTypes.JSON, Nullable: true},
+	)
+	if !arrow.TypeEqual(got, want) {
+		t.Fatalf("type does not match expected. got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This updates the struct transformer to use Arrow types that better reflect the underlying Go types. Were it not for the `type_support` option being added in https://github.com/cloudquery/plugin-sdk/pull/917, this would be a big breaking change for all plugins. As such, this depends on https://github.com/cloudquery/plugin-sdk/pull/917 being merged first (or these should at least be merged together)



Note on the ordering of PRs: I've split this out from https://github.com/cloudquery/plugin-sdk/pull/917 because without this, the other PR is smaller and less risky. Currently this one, when used in a plugin, will cause all types to change (updating the docs) and can lead to some resolvers to panic if the underlying scalar type isn't implemented yet. This is true even if running in limited type support mode.