### PR TITLE
fix(scalar): Handle nil pointer to []byte in uuid and binary

### DIFF
--- a/scalar/binary.go
+++ b/scalar/binary.go
@@ -52,6 +52,12 @@ func (s *Binary) Set(val any) error {
 	}
 
 	switch value := val.(type) {
+	case *[]byte:
+		if value == nil {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(*value)
 	case []byte:
 		if value == nil {
 			s.Valid = false

--- a/scalar/binary_test.go
+++ b/scalar/binary_test.go
@@ -3,6 +3,9 @@ package scalar
 import "testing"
 
 func TestBinarySet(t *testing.T) {
+	var nilPointerByteArray *[]byte
+	var nilPointerString *string
+
 	successfulTests := []struct {
 		source any
 		result Binary
@@ -12,6 +15,8 @@ func TestBinarySet(t *testing.T) {
 		{source: []byte(nil), result: Binary{}},
 		{source: _byteSlice{1, 2, 3}, result: Binary{Value: []byte{1, 2, 3}, Valid: true}},
 		{source: _byteSlice(nil), result: Binary{}},
+		{source: nilPointerByteArray, result: Binary{}},
+		{source: nilPointerString, result: Binary{}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/bool_test.go
+++ b/scalar/bool_test.go
@@ -5,6 +5,9 @@ import (
 )
 
 func TestBoolSet(t *testing.T) {
+	var nilPointerBool *bool
+	var nilPointerString *string
+
 	successfulTests := []struct {
 		source any
 		result Bool
@@ -19,6 +22,8 @@ func TestBoolSet(t *testing.T) {
 		{source: _bool(false), result: Bool{Value: false, Valid: true}},
 		{source: &Bool{Value: true, Valid: true}, result: Bool{Value: true, Valid: true}},
 		{source: nil, result: Bool{}},
+		{source: nilPointerBool, result: Bool{}},
+		{source: nilPointerString, result: Bool{}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/float_test.go
+++ b/scalar/float_test.go
@@ -8,7 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFloat32Set(t *testing.T) {
+var nilPointerInt8 *int8
+var nilPointerInt16 *int16
+var nilPointerInt32 *int32
+var nilPointerInt64 *int64
+var nilPointerUint8 *uint8
+var nilPointerUint16 *uint16
+var nilPointerUint32 *uint32
+var nilPointerUint64 *uint64
+var nilPointerFloat32 *float32
+var nilPointerFloat64 *float64
+
+func TestFloatAllWidthsSet(t *testing.T) {
 	successfulTests := []struct {
 		source any
 		expect Float
@@ -30,6 +41,16 @@ func TestFloat32Set(t *testing.T) {
 		{source: "1", expect: Float{Value: 1, Valid: true}},
 		{source: _int8(1), expect: Float{Value: 1, Valid: true}},
 		{source: &Float{Value: 1, Valid: true, BitWidth: 32}, expect: Float{Value: 1, Valid: true}},
+		{source: nilPointerInt8, expect: Float{Valid: false}},
+		{source: nilPointerInt16, expect: Float{Valid: false}},
+		{source: nilPointerInt32, expect: Float{Valid: false}},
+		{source: nilPointerInt64, expect: Float{Valid: false}},
+		{source: nilPointerUint8, expect: Float{Valid: false}},
+		{source: nilPointerUint16, expect: Float{Valid: false}},
+		{source: nilPointerUint32, expect: Float{Valid: false}},
+		{source: nilPointerUint64, expect: Float{Valid: false}},
+		{source: nilPointerFloat32, expect: Float{Valid: false}},
+		{source: nilPointerFloat64, expect: Float{Valid: false}},
 	}
 
 	for _, bitWidth := range []uint8{8, 16, 32, 64} {
@@ -74,6 +95,16 @@ func TestFloat64Set(t *testing.T) {
 		{source: "1", result: Float{Value: 1, Valid: true}},
 		{source: _int8(1), result: Float{Value: 1, Valid: true}},
 		{source: &Float{Value: 1, Valid: true}, result: Float{Value: 1, Valid: true}},
+		{source: nilPointerInt8, result: Float{Valid: false}},
+		{source: nilPointerInt16, result: Float{Valid: false}},
+		{source: nilPointerInt32, result: Float{Valid: false}},
+		{source: nilPointerInt64, result: Float{Valid: false}},
+		{source: nilPointerUint8, result: Float{Valid: false}},
+		{source: nilPointerUint16, result: Float{Valid: false}},
+		{source: nilPointerUint32, result: Float{Valid: false}},
+		{source: nilPointerUint64, result: Float{Valid: false}},
+		{source: nilPointerFloat32, result: Float{Valid: false}},
+		{source: nilPointerFloat64, result: Float{Valid: false}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/uuid.go
+++ b/scalar/uuid.go
@@ -63,8 +63,15 @@ func (s *UUID) Set(src any) error {
 		return s.Set(value2)
 	case [16]byte:
 		s.Value = uuid.UUID(value)
+	case *[]byte:
+		if value == nil {
+			s.Valid = false
+			return nil
+		}
+		return s.Set(*value)
 	case []byte:
 		if value == nil {
+			s.Valid = false
 			return nil
 		}
 		if len(value) != 16 {
@@ -79,6 +86,7 @@ func (s *UUID) Set(src any) error {
 		s.Value = uuidVal
 	case *string:
 		if value == nil {
+			s.Valid = false
 			return nil
 		}
 		return s.Set(*value)

--- a/scalar/uuid_test.go
+++ b/scalar/uuid_test.go
@@ -14,6 +14,9 @@ func (s StringUUIDType) String() string {
 }
 
 func TestUUIDSet(t *testing.T) {
+	var nilPointerByteArray *[]byte
+	var nilPointerString *string
+
 	successfulTests := []struct {
 		source any
 		result UUID
@@ -54,6 +57,8 @@ func TestUUIDSet(t *testing.T) {
 			source: &UUID{Value: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Valid: true},
 			result: UUID{Value: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Valid: true},
 		},
+		{source: nilPointerByteArray, result: UUID{}},
+		{source: nilPointerString, result: UUID{}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Follow up to https://github.com/cloudquery/plugin-sdk/pull/922 to handle nil `*[]byte]` in `uuid` and `binary`.
Also added some tests to floats I can extract to another PR.

This is required for supporting `nil` values in https://github.com/cloudquery/cloudquery/pull/11115.
Discovered by generating test data with the [2 rows option](https://github.com/cloudquery/cloudquery/pull/11115#discussion_r1211284293) cc @candiduslynx.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
