### PR TITLE
feat(scalar): Support pointer dereferencing in decimal

### DIFF
--- a/scalar/decimal.go
+++ b/scalar/decimal.go
@@ -166,6 +166,9 @@ func (s *Decimal256) Set(val any) error {
 		}
 		return s.Set(*value)
 	default:
+		if originalSrc, ok := underlyingPtrType(val); ok {
+			return s.Set(originalSrc)
+		}
 		return &ValidationError{Type: s.DataType(), Msg: noConversion, Value: value}
 	}
 	s.Valid = true
@@ -324,6 +327,9 @@ func (s *Decimal128) Set(val any) error {
 		}
 		return s.Set(*value)
 	default:
+		if originalSrc, ok := underlyingPtrType(val); ok {
+			return s.Set(originalSrc)
+		}
 		return &ValidationError{Type: s.DataType(), Msg: noConversion, Value: value}
 	}
 	s.Valid = true

--- a/scalar/decimal_test.go
+++ b/scalar/decimal_test.go
@@ -26,6 +26,8 @@ func TestDecimal128Set(t *testing.T) {
 	uint32Val := uint32(1)
 	uint64Val := uint64(1)
 
+	intValPointer := &intVal
+
 	successfulTests := []struct {
 		source      any
 		decimalType *arrow.Decimal128Type
@@ -53,6 +55,7 @@ func TestDecimal128Set(t *testing.T) {
 		{source: &uint16Val, expect: Decimal128{Value: decimal128.FromU64(1), Valid: true}},
 		{source: &uint32Val, expect: Decimal128{Value: decimal128.FromU64(1), Valid: true}},
 		{source: &uint64Val, expect: Decimal128{Value: decimal128.FromU64(1), Valid: true}},
+		{source: &intValPointer, expect: Decimal128{Value: decimal128.FromI64(1), Valid: true}},
 	}
 
 	for i, tt := range successfulTests {
@@ -81,6 +84,8 @@ func TestDecimal256Set(t *testing.T) {
 	uint32Val := uint32(1)
 	uint64Val := uint64(1)
 
+	intValPointer := &intVal
+
 	successfulTests := []struct {
 		source      any
 		decimalType *arrow.Decimal256Type
@@ -108,6 +113,7 @@ func TestDecimal256Set(t *testing.T) {
 		{source: &uint16Val, expect: Decimal256{Value: decimal256.FromU64(1), Valid: true}},
 		{source: &uint32Val, expect: Decimal256{Value: decimal256.FromU64(1), Valid: true}},
 		{source: &uint64Val, expect: Decimal256{Value: decimal256.FromU64(1), Valid: true}},
+		{source: &intValPointer, expect: Decimal256{Value: decimal256.FromI64(1), Valid: true}},
 	}
 
 	for i, tt := range successfulTests {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Follow up to https://github.com/cloudquery/plugin-sdk/pull/937, also needed for https://github.com/cloudquery/cloudquery/pull/11115

When reading data from a database it is common to pass a pointer to a value to support reading `nil` values, so the type of the value read is a pointer to a pointer.

Without this PR, if someone uses the decimal scalar they need to dereferences the pointer manually before setting the scalar value.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
