### PR TITLE
fix(destinations): Populate managed writer metrics

### DIFF
--- a/plugins/destination/managed_writer.go
+++ b/plugins/destination/managed_writer.go
@@ -100,11 +100,12 @@ func (*Plugin) removeDuplicatesByPK(table *schema.Table, resources []arrow.Recor
 
 func (p *Plugin) writeManagedTableBatch(ctx context.Context, _ specs.Source, tables schema.Tables, _ time.Time, res <-chan arrow.Record) error {
 	workers := make(map[string]*worker, len(tables))
-	metrics := &Metrics{}
 
 	p.workersLock.Lock()
 	for _, table := range tables {
 		table := table
+		metrics := &Metrics{}
+		p.metrics[table.Name] = metrics
 		if p.workers[table.Name] == nil {
 			ch := make(chan arrow.Record)
 			flush := make(chan chan bool)

--- a/plugins/destination/plugin.go
+++ b/plugins/destination/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow/go/v13/arrow"
@@ -164,8 +165,8 @@ func (p *Plugin) Metrics() Metrics {
 		metrics := Metrics{}
 		p.metricsLock.RLock()
 		for _, m := range p.metrics {
-			metrics.Errors += m.Errors
-			metrics.Writes += m.Writes
+			metrics.Errors += atomic.LoadUint64(&m.Errors)
+			metrics.Writes += atomic.LoadUint64(&m.Writes)
 		}
 		p.metricsLock.RUnlock()
 		return metrics


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

When a destination write fails we log an error but the sync seems successful.
One of the reasons for it is that we don't populate the destination plugin `p.metrics`.
Another reason is that we never call `GetMetrics` nor handle any destination errors from the CLI (another PR for that is coming in a bit).

![image](https://github.com/cloudquery/plugin-sdk/assets/26760571/21dfe78a-b2dc-4833-bbca-5d6383674829)
![image](https://github.com/cloudquery/plugin-sdk/assets/26760571/eb619169-5ce3-4216-bd48-db4af10e9dfd)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
