### PR TITLE
fix(types-inet): Align logic with scalar package, set `net.IPNet` `IP` field after parsing `ParseCIDR`

### DIFF
--- a/types/inet.go
+++ b/types/inet.go
@@ -67,17 +67,20 @@ func (b *InetBuilder) UnmarshalOne(dec *json.Decoder) error {
 	}
 
 	var val *net.IPNet
+	var ip net.IP
 	switch v := t.(type) {
 	case string:
-		_, val, err = net.ParseCIDR(v)
+		ip, val, err = net.ParseCIDR(v)
 		if err != nil {
 			return err
 		}
+		val.IP = ip
 	case []byte:
-		_, val, err = net.ParseCIDR(string(v))
+		ip, val, err = net.ParseCIDR(string(v))
 		if err != nil {
 			return err
 		}
+		val.IP = ip
 	case nil:
 		b.AppendNull()
 		return nil
@@ -156,10 +159,11 @@ func (a *InetArray) Value(i int) *net.IPNet {
 			Mask: make(net.IPMask, len(net.IPv4zero)),
 		}
 	}
-	_, ipnet, err := net.ParseCIDR(cidr)
+	ip, ipnet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		panic(fmt.Errorf("invalid ip+net: %w", err))
 	}
+	ipnet.IP = ip
 
 	return ipnet
 }

--- a/types/inet_test.go
+++ b/types/inet_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func mustParseInet(s string) *net.IPNet {
-	_, ipnet, err := net.ParseCIDR(s)
+	ip, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
 		panic(err)
 	}
+	ipnet.IP = ip
 	return ipnet
 }
 
@@ -36,8 +37,9 @@ func TestInetBuilder(t *testing.T) {
 		mustParseInet("192.168.0.0/27"),
 	}
 	b.AppendValues(values, nil)
+	b.Append(mustParseInet("192.168.0.1/24"))
 
-	require.Equal(t, 6, b.Len(), "unexpected Len()")
+	require.Equal(t, 7, b.Len(), "unexpected Len()")
 
 	a := b.NewArray()
 
@@ -46,7 +48,7 @@ func TestInetBuilder(t *testing.T) {
 	require.Zero(t, b.Cap(), "unexpected ArrayBuilder.Cap(), did not reset state")
 	require.Zero(t, b.NullN(), "unexpected ArrayBuilder.NullN(), did not reset state")
 
-	require.Equal(t, `["192.168.0.0/24" (null) "192.168.0.0/25" (null) "192.168.0.0/26" "192.168.0.0/27"]`, a.String())
+	require.Equal(t, `["192.168.0.0/24" (null) "192.168.0.0/25" (null) "192.168.0.0/26" "192.168.0.0/27" "192.168.0.1/24"]`, a.String())
 	st, err := a.MarshalJSON()
 	require.NoError(t, err)
 
@@ -58,7 +60,8 @@ func TestInetBuilder(t *testing.T) {
 	require.NoError(t, err)
 
 	a = b.NewArray()
-	require.Equal(t, `["192.168.0.0/24" (null) "192.168.0.0/25" (null) "192.168.0.0/26" "192.168.0.0/27"]`, a.String())
+	require.Equal(t, `["192.168.0.0/24" (null) "192.168.0.0/25" (null) "192.168.0.0/26" "192.168.0.0/27" "192.168.0.1/24"]`, a.String())
 	b.Release()
 	a.Release()
+
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Discovered this while working on the PostgreSQL source v4 migration.
When we set string values to the `inet` scalar we set the `IP` field on the resulting `net.IPNet`:
https://github.com/cloudquery/plugin-sdk/blob/097621f02e4fe1258290c3bfdd744a8fc3ab1c15/scalar/inet.go#L85

However the `inet` arrow type loses that information when returning the value:
https://github.com/cloudquery/plugin-sdk/blob/097621f02e4fe1258290c3bfdd744a8fc3ab1c15/types/inet.go#L159

This means that if you create an arrow `inet` type from the string `192.168.0.1/24`, then call `ValueStr` you get back `192.168.0.0/24`


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
