### PR TITLE
fix(scalar): Use `appendTime` instead of `UnixMicro`

### DIFF
--- a/scalar/scalar.go
+++ b/scalar/scalar.go
@@ -176,7 +176,8 @@ func AppendToBuilder(bldr array.Builder, s Scalar) {
 	case arrow.BOOL:
 		bldr.(*array.BooleanBuilder).Append(s.(*Bool).Value)
 	case arrow.TIMESTAMP:
-		bldr.(*array.TimestampBuilder).Append(arrow.Timestamp(s.(*Timestamp).Value.UnixMicro()))
+		asTime := s.(*Timestamp).Value
+		bldr.(*array.TimestampBuilder).AppendTime(asTime)
 	case arrow.DURATION:
 		bldr.(*array.DurationBuilder).Append(arrow.Duration(s.(*Duration).Value))
 	case arrow.DATE32:


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Discovered while working on https://github.com/cloudquery/cloudquery/pull/11719. Using `UnixMicro()` is incorrect as it doesn't account for the internal time unit of the arrow timestamp type. 

`AppendTime` does https://github.com/cloudquery/arrow/blob/0d1f7234124e67b98b3aa0aa3e521d42c2f3165d/go/arrow/array/timestamp.go#L156 and does the correct conversion https://github.com/cloudquery/arrow/blob/8366a2241e66a53ee05ab4a832927e33e5f9c5a2/go/arrow/datatype_fixedwidth.go#L202

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
