### PR TITLE
fix: Update scheduler for JSON marshal / unmarshal

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -22,29 +23,75 @@ import (
 )
 
 const (
+	DefaultConcurrency     = 50000
+	DefaultMaxDepth        = 4
 	minTableConcurrency    = 1
 	minResourceConcurrency = 100
-	defaultConcurrency     = 200000
-	defaultMaxDepth        = 4
 )
-
-type Strategy int
 
 const (
 	StrategyDFS Strategy = iota
 	StrategyRoundRobin
 )
 
-var AllSchedulers = Strategies{StrategyDFS, StrategyRoundRobin}
-var AllSchedulerNames = [...]string{
+type Strategy int
+
+func (s *Strategy) String() string {
+	if s == nil {
+		return ""
+	}
+	return AllStrategyNames[*s]
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s *Strategy) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+	if s == nil {
+		b.Write([]byte("null"))
+		return b.Bytes(), nil
+	}
+	b.Write([]byte{'"'})
+	b.Write([]byte(s.String()))
+	b.Write([]byte{'"'})
+	return b.Bytes(), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *Strategy) UnmarshalJSON(b []byte) error {
+	var name string
+	if err := json.Unmarshal(b, &name); err != nil {
+		return err
+	}
+	strategy, err := StrategyForName(name)
+	if err != nil {
+		return err
+	}
+	*s = strategy
+	return nil
+}
+
+func (s *Strategy) Validate() error {
+	if s == nil {
+		return errors.New("scheduler strategy is nil")
+	}
+	for _, strategy := range AllStrategies {
+		if strategy == *s {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown scheduler strategy: %d", s)
+}
+
+var AllStrategies = Strategies{StrategyDFS, StrategyRoundRobin}
+var AllStrategyNames = [...]string{
 	StrategyDFS:        "dfs",
 	StrategyRoundRobin: "round-robin",
 }
 
 func StrategyForName(s string) (Strategy, error) {
-	for i, name := range AllSchedulerNames {
+	for i, name := range AllStrategyNames {
 		if name == s {
-			return AllSchedulers[i], nil
+			return AllStrategies[i], nil
 		}
 	}
 	return StrategyDFS, fmt.Errorf("unknown scheduler strategy: %s", s)
@@ -61,10 +108,6 @@ func (s Strategies) String() string {
 		buffer.WriteString(strategy.String())
 	}
 	return buffer.String()
-}
-
-func (s Strategy) String() string {
-	return AllSchedulerNames[s]
 }
 
 type Option func(*Scheduler)
@@ -87,7 +130,7 @@ func WithMaxDepth(maxDepth uint64) Option {
 	}
 }
 
-func WithSchedulerStrategy(strategy Strategy) Option {
+func WithStrategy(strategy Strategy) Option {
 	return func(s *Scheduler) {
 		s.strategy = strategy
 	}
@@ -131,8 +174,8 @@ func NewScheduler(client schema.ClientMeta, opts ...Option) *Scheduler {
 		client:      client,
 		metrics:     &Metrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
 		caser:       caser.New(),
-		concurrency: defaultConcurrency,
-		maxDepth:    defaultMaxDepth,
+		concurrency: DefaultConcurrency,
+		maxDepth:    DefaultMaxDepth,
 	}
 	for _, opt := range opts {
 		opt(&s)
@@ -188,7 +231,7 @@ func (s *Scheduler) Sync(ctx context.Context, tables schema.Tables, res chan<- m
 		case StrategyRoundRobin:
 			s.syncRoundRobin(ctx, resources, syncOpts)
 		default:
-			panic(fmt.Errorf("unknown scheduler %s", s.strategy))
+			panic(fmt.Errorf("unknown scheduler %s", s.strategy.String()))
 		}
 	}()
 	for resource := range resources {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -207,12 +207,12 @@ var syncTestCases = []syncTestCase{
 
 func TestScheduler(t *testing.T) {
 	// uuid.SetRand(testRand{})
-	for _, scheduler := range AllSchedulers {
+	for _, strategy := range AllStrategies {
 		for _, tc := range syncTestCases {
 			tc := tc
 			tc.table = tc.table.Copy(nil)
-			t.Run(tc.table.Name+"_"+scheduler.String(), func(t *testing.T) {
-				testSyncTable(t, tc, scheduler, tc.deterministicCQID)
+			t.Run(tc.table.Name+"_"+strategy.String(), func(t *testing.T) {
+				testSyncTable(t, tc, strategy, tc.deterministicCQID)
 			})
 		}
 	}
@@ -226,7 +226,7 @@ func testSyncTable(t *testing.T, tc syncTestCase, strategy Strategy, determinist
 	c := testExecutionClient{}
 	opts := []Option{
 		WithLogger(zerolog.New(zerolog.NewTestWriter(t))),
-		WithSchedulerStrategy(strategy),
+		WithStrategy(strategy),
 	}
 	sc := NewScheduler(&c, opts...)
 	msgs := make(chan message.Message, 10)

--- a/writers/batch.go
+++ b/writers/batch.go
@@ -18,9 +18,9 @@ type Writer interface {
 }
 
 const (
-	defaultBatchTimeoutSeconds = 20
-	defaultBatchSize           = 10000
-	defaultBatchSizeBytes      = 5 * 1024 * 1024 // 5 MiB
+	DefaultBatchTimeoutSeconds = 20
+	DefaultBatchSize           = 10000
+	DefaultBatchSizeBytes      = 5 * 1024 * 1024 // 5 MiB
 )
 
 type BatchWriterClient interface {
@@ -83,9 +83,9 @@ func NewBatchWriter(client BatchWriterClient, opts ...Option) (*BatchWriter, err
 		client:         client,
 		workers:        make(map[string]*worker),
 		logger:         zerolog.Nop(),
-		batchTimeout:   defaultBatchTimeoutSeconds * time.Second,
-		batchSize:      defaultBatchSize,
-		batchSizeBytes: defaultBatchSizeBytes,
+		batchTimeout:   DefaultBatchTimeoutSeconds * time.Second,
+		batchSize:      DefaultBatchSize,
+		batchSizeBytes: DefaultBatchSizeBytes,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/writers/mixed_batch.go
+++ b/writers/mixed_batch.go
@@ -55,7 +55,7 @@ func WithMixedBatchWriterBatchSize(size int) MixedBatchWriterOption {
 	}
 }
 
-func WithMixedBatchWriterSizeBytes(size int) MixedBatchWriterOption {
+func WithMixedBatchWriterBatchSizeBytes(size int) MixedBatchWriterOption {
 	return func(p *MixedBatchWriter) {
 		p.batchSizeBytes = size
 	}
@@ -65,9 +65,9 @@ func NewMixedBatchWriter(client MixedBatchClient, opts ...MixedBatchWriterOption
 	c := &MixedBatchWriter{
 		client:         client,
 		logger:         zerolog.Nop(),
-		batchTimeout:   defaultBatchTimeoutSeconds * time.Second,
-		batchSize:      defaultBatchSize,
-		batchSizeBytes: defaultBatchSizeBytes,
+		batchTimeout:   DefaultBatchTimeoutSeconds * time.Second,
+		batchSize:      DefaultBatchSize,
+		batchSizeBytes: DefaultBatchSizeBytes,
 	}
 	for _, opt := range opts {
 		opt(c)


### PR DESCRIPTION
This add JSON marshaling / unmarshaling to the scheduler options, as well as some validation so that it can be used in source plugins that wish to use this option in their spec.

Other changes:
 - lowering the default concurrency to 50000 in preparation for the v4 SDK release
 - updating some names to be more consistent with Go naming conventions
 - make default writer values public for use by plugins