### PR TITLE
fix(writers): Require explicit batch options, remove defaults

### DIFF
--- a/writers/batchwriter/batchwriter.go
+++ b/writers/batchwriter/batchwriter.go
@@ -47,38 +47,20 @@ func WithLogger(logger zerolog.Logger) Option {
 	}
 }
 
-func WithBatchTimeout(timeout time.Duration) Option {
-	return func(p *BatchWriter) {
-		p.batchTimeout = timeout
-	}
-}
-
-func WithBatchSize(size int) Option {
-	return func(p *BatchWriter) {
-		p.batchSize = size
-	}
-}
-
-func WithBatchSizeBytes(size int) Option {
-	return func(p *BatchWriter) {
-		p.batchSizeBytes = size
-	}
-}
-
 type worker struct {
 	count int
 	ch    chan *message.WriteInsert
 	flush chan chan bool
 }
 
-func New(client Client, opts ...Option) (*BatchWriter, error) {
+func New(client Client, batchSize, batchSizeBytes int, batchTimeout time.Duration, opts ...Option) (*BatchWriter, error) {
 	c := &BatchWriter{
 		client:         client,
 		workers:        make(map[string]*worker),
 		logger:         zerolog.Nop(),
-		batchTimeout:   writers.DefaultBatchTimeoutSeconds * time.Second,
-		batchSize:      writers.DefaultBatchSize,
-		batchSizeBytes: writers.DefaultBatchSizeBytes,
+		batchSize:      batchSize,
+		batchSizeBytes: batchSizeBytes,
+		batchTimeout:   batchTimeout,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/writers/batchwriter/batchwriter_test.go
+++ b/writers/batchwriter/batchwriter_test.go
@@ -76,7 +76,7 @@ func TestBatchFlushDifferentMessages(t *testing.T) {
 	ctx := context.Background()
 
 	testClient := &testBatchClient{}
-	wr, err := New(testClient)
+	wr, err := New(testClient, 100, 0, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestBatchSize(t *testing.T) {
 	ctx := context.Background()
 
 	testClient := &testBatchClient{}
-	wr, err := New(testClient, WithBatchSize(2))
+	wr, err := New(testClient, 2, 0, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestBatchTimeout(t *testing.T) {
 	ctx := context.Background()
 
 	testClient := &testBatchClient{}
-	wr, err := New(testClient, WithBatchTimeout(time.Second))
+	wr, err := New(testClient, 0, 0, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestBatchUpserts(t *testing.T) {
 	ctx := context.Background()
 
 	testClient := &testBatchClient{}
-	wr, err := New(testClient, WithBatchSize(2), WithBatchTimeout(time.Second))
+	wr, err := New(testClient, 2, 0, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/writers/mixedbatchwriter/mixedbatchwriter.go
+++ b/writers/mixedbatchwriter/mixedbatchwriter.go
@@ -36,31 +36,13 @@ func WithLogger(logger zerolog.Logger) Option {
 	}
 }
 
-func WithBatchTimeout(timeout time.Duration) Option {
-	return func(p *MixedBatchWriter) {
-		p.batchTimeout = timeout
-	}
-}
-
-func WithBatchSize(size int) Option {
-	return func(p *MixedBatchWriter) {
-		p.batchSize = size
-	}
-}
-
-func WithBatchSizeBytes(size int) Option {
-	return func(p *MixedBatchWriter) {
-		p.batchSizeBytes = size
-	}
-}
-
-func New(client Client, opts ...Option) (*MixedBatchWriter, error) {
+func New(client Client, batchSize, batchSizeBytes int, batchTimeout time.Duration, opts ...Option) (*MixedBatchWriter, error) {
 	c := &MixedBatchWriter{
 		client:         client,
 		logger:         zerolog.Nop(),
-		batchTimeout:   writers.DefaultBatchTimeoutSeconds * time.Second,
-		batchSize:      writers.DefaultBatchSize,
-		batchSizeBytes: writers.DefaultBatchSizeBytes,
+		batchSize:      batchSize,
+		batchSizeBytes: batchSizeBytes,
+		batchTimeout:   batchTimeout,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/writers/mixedbatchwriter/mixedbatchwriter_test.go
+++ b/writers/mixedbatchwriter/mixedbatchwriter_test.go
@@ -170,7 +170,7 @@ func TestMixedBatchWriter(t *testing.T) {
 			client := &testMixedBatchClient{
 				receivedBatches: make([][]message.WriteMessage, 0),
 			}
-			wr, err := mixedbatchwriter.New(client)
+			wr, err := mixedbatchwriter.New(client, 100, 10000, time.Hour)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/writers/streamingbatchwriter/streamingbatchwriter.go
+++ b/writers/streamingbatchwriter/streamingbatchwriter.go
@@ -79,26 +79,14 @@ func WithBatchTimeout(timeout time.Duration) Option {
 	}
 }
 
-func WithBatchSizeRows(size int64) Option {
-	return func(p *StreamingBatchWriter) {
-		p.batchSizeRows = size
-	}
-}
-
-func WithBatchSizeBytes(size int64) Option {
-	return func(p *StreamingBatchWriter) {
-		p.batchSizeBytes = size
-	}
-}
-
-func New(client Client, opts ...Option) (*StreamingBatchWriter, error) {
+func New(client Client, batchSizeRows, batchSizeBytes int64, batchTimeout time.Duration, opts ...Option) (*StreamingBatchWriter, error) {
 	c := &StreamingBatchWriter{
 		client:         client,
 		insertWorkers:  make(map[string]*streamingWorkerManager[*message.WriteInsert]),
 		logger:         zerolog.Nop(),
-		batchTimeout:   writers.DefaultBatchTimeoutSeconds * time.Second,
-		batchSizeRows:  writers.DefaultBatchSize,
-		batchSizeBytes: writers.DefaultBatchSizeBytes,
+		batchSizeRows:  batchSizeRows,
+		batchSizeBytes: batchSizeBytes,
+		batchTimeout:   batchTimeout,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/writers/streamingbatchwriter/streamingbatchwriter_test.go
+++ b/writers/streamingbatchwriter/streamingbatchwriter_test.go
@@ -129,7 +129,7 @@ func TestBatchStreamFlushDifferentMessages(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	wr, err := streamingbatchwriter.New(testClient)
+	wr, err := streamingbatchwriter.New(testClient, 0, 0, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestStreamingBatchSizeRows(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	wr, err := streamingbatchwriter.New(testClient, streamingbatchwriter.WithBatchSizeRows(2))
+	wr, err := streamingbatchwriter.New(testClient, 2, 0, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestStreamingBatchTimeout(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	wr, err := streamingbatchwriter.New(testClient, streamingbatchwriter.WithBatchTimeout(time.Second))
+	wr, err := streamingbatchwriter.New(testClient, 0, 0, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestStreamingBatchUpserts(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	wr, err := streamingbatchwriter.New(testClient, streamingbatchwriter.WithBatchSizeRows(2), streamingbatchwriter.WithBatchTimeout(time.Second))
+	wr, err := streamingbatchwriter.New(testClient, 2, 0, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/writers/writers.go
+++ b/writers/writers.go
@@ -9,9 +9,3 @@ import (
 type Writer interface {
 	Write(ctx context.Context, res <-chan message.WriteMessage) error
 }
-
-const (
-	DefaultBatchTimeoutSeconds = 20
-	DefaultBatchSize           = 10000
-	DefaultBatchSizeBytes      = 5 * 1024 * 1024 // 5 MiB
-)


### PR DESCRIPTION
If we want to make _absolutely sure_ that each dest sets its own sensible batch settings, this could be the only way.

Zero as batch timeout isn't supported (it just means it will flush all the time with `<-time.After(0)`). There's no 'clean' way to prevent that as long as we're in that `select`.