### PR TITLE
feat: Add Duration configtype

### DIFF
--- a/configtype/duration.go
+++ b/configtype/duration.go
@@ -1,0 +1,35 @@
+package configtype
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration is a wrapper around time.Duration that should be used in config
+// when a duration type is required. We wrap the time.Duration type so that
+// the spec can be extended in the future to support other types of durations
+// (e.g. a duration that is specified in days).
+type Duration struct {
+	duration time.Duration
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	duration, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration{duration: duration}
+	return nil
+}
+
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.duration.String())
+}
+
+func (d *Duration) Duration() time.Duration {
+	return d.duration
+}

--- a/configtype/duration_test.go
+++ b/configtype/duration_test.go
@@ -1,0 +1,28 @@
+package configtype
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDuration(t *testing.T) {
+	cases := []struct {
+		give string
+		want time.Duration
+	}{
+		{"1ns", 1 * time.Nanosecond},
+		{"20s", 20 * time.Second},
+		{"-50m30s", -50*time.Minute - 30*time.Second},
+	}
+	for _, tc := range cases {
+		var d Duration
+		err := json.Unmarshal([]byte(`"`+tc.give+`"`), &d)
+		if err != nil {
+			t.Fatalf("error calling Unmarshal(%q): %v", tc.give, err)
+		}
+		if d.Duration() != tc.want {
+			t.Errorf("Unmarshal(%q) = %v, want %v", tc.give, d.Duration(), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
This adds a wrapper to `time.Duration` that can be used in plugin configs that require some sort of time duration. We wrap `time.Duration` so that we can control the spec and possibly extend it in the future. 