### PR TITLE
fix: Fix timer logic in batch writers

### DIFF
--- a/writers/streamingbatchwriter/streamingbatchwriter.go
+++ b/writers/streamingbatchwriter/streamingbatchwriter.go
@@ -345,6 +345,7 @@ func (s *streamingWorkerManager[T]) run(ctx context.Context, wg *sync.WaitGroup,
 	}
 	defer closeFlush()
 
+	tick := s.timerFn(s.batchTimeout)
 	for {
 		select {
 		case r, ok := <-s.ch:
@@ -365,10 +366,11 @@ func (s *streamingWorkerManager[T]) run(ctx context.Context, wg *sync.WaitGroup,
 			clientCh <- r
 			sizeRows++
 			sizeBytes += recSize
-		case <-s.timerFn(s.batchTimeout):
+		case <-tick:
 			if sizeRows > 0 {
 				closeFlush()
 			}
+			tick = s.timerFn(s.batchTimeout)
 		case done := <-s.flush:
 			if sizeRows > 0 {
 				closeFlush()


### PR DESCRIPTION
I believe that the batch timeout should be a guarantee of a message being delayed by no longer than X amount of time. This means that we shouldn't reset the ticker every time a message is received, because then a message could be delayed for a very long time if a slow trickle of messages is coming in. This change fixes this issue and guarantees a message to be flushed within at most X duration.

For more context, see this PR and message https://github.com/cloudquery/plugin-sdk/pull/1055#discussion_r1251726213