### PR TITLE
fix: Check record data in tests

### DIFF
--- a/plugin/testing_upsert.go
+++ b/plugin/testing_upsert.go
@@ -60,7 +60,9 @@ func (s *WriterTestSuite) testUpsertBasic(ctx context.Context) error {
 	if totalItems != 1 {
 		return fmt.Errorf("expected 1 item, got %d", totalItems)
 	}
-
+	if diff := RecordDiff(records[0], record); diff != "" {
+		return fmt.Errorf("record differs: %s", diff)
+	}
 	return nil
 }
 
@@ -106,6 +108,10 @@ func (s *WriterTestSuite) testUpsertAll(ctx context.Context) error {
 	totalItems = TotalRows(records)
 	if totalItems != 1 {
 		return fmt.Errorf("expected 1 item, got %d", totalItems)
+	}
+
+	if diff := RecordDiff(records[0], record); diff != "" {
+		return fmt.Errorf("record differs: %s", diff)
 	}
 
 	return nil

--- a/plugin/testing_write_delete.go
+++ b/plugin/testing_write_delete.go
@@ -69,6 +69,8 @@ func (s *WriterTestSuite) testDeleteStale(ctx context.Context) error {
 	if totalItems != 1 {
 		return fmt.Errorf("expected 1 item, got %d", totalItems)
 	}
-
+	if diff := RecordDiff(records[0], record); diff != "" {
+		return fmt.Errorf("record differs: %s", diff)
+	}
 	return nil
 }

--- a/plugin/testing_write_insert.go
+++ b/plugin/testing_write_insert.go
@@ -69,6 +69,13 @@ func (s *WriterTestSuite) testInsertBasic(ctx context.Context) error {
 		return fmt.Errorf("expected 2 items, got %d", totalItems)
 	}
 
+	if diff := RecordDiff(readRecords[0], record); diff != "" {
+		return fmt.Errorf("record[0] differs: %s", diff)
+	}
+	if diff := RecordDiff(readRecords[1], record); diff != "" {
+		return fmt.Errorf("record[1] differs: %s", diff)
+	}
+
 	return nil
 }
 
@@ -115,6 +122,11 @@ func (s *WriterTestSuite) testInsertAll(ctx context.Context) error {
 	if totalItems != 2 {
 		return fmt.Errorf("expected 2 items, got %d", totalItems)
 	}
-
+	if diff := RecordDiff(readRecords[0], record); diff != "" {
+		return fmt.Errorf("record[0] differs: %s", diff)
+	}
+	if diff := RecordDiff(readRecords[1], record); diff != "" {
+		return fmt.Errorf("record[1] differs: %s", diff)
+	}
 	return nil
 }

--- a/plugin/testing_write_migrate.go
+++ b/plugin/testing_write_migrate.go
@@ -78,10 +78,19 @@ func (s *WriterTestSuite) migrate(ctx context.Context, target *schema.Table, sou
 		if totalItems != 2 {
 			return fmt.Errorf("expected 2 items, got %d", totalItems)
 		}
+		if diff := RecordDiff(records[0], resource1); diff != "" {
+			return fmt.Errorf("records[0] differs: %s", diff)
+		}
+		if diff := RecordDiff(records[1], resource2); diff != "" {
+			return fmt.Errorf("records[1] differs: %s", diff)
+		}
 	} else {
 		totalItems = TotalRows(records)
 		if totalItems != 1 {
 			return fmt.Errorf("expected 1 item, got %d", totalItems)
+		}
+		if diff := RecordDiff(records[0], resource2); diff != "" {
+			return fmt.Errorf("records[0] differs: %s", diff)
 		}
 	}
 


### PR DESCRIPTION
This adds back assertions on the record data in destination writer tests. I'm not sure if we also need to handle ordering somehow here, but I think we can follow up with a fix for that if necessary.