### PR TITLE
fix: Fix test assertions for records

### DIFF
--- a/plugin/testing_write_migrate.go
+++ b/plugin/testing_write_migrate.go
@@ -53,6 +53,9 @@ func (s *WriterTestSuite) migrate(ctx context.Context, target *schema.Table, sou
 	if totalItems != 1 {
 		return fmt.Errorf("expected 1 item, got %d", totalItems)
 	}
+	if diff := RecordDiff(records[0], resource1); diff != "" {
+		return fmt.Errorf("first record differs from expectation: %s", diff)
+	}
 
 	if err := s.plugin.writeOne(ctx, &message.WriteMigrateTable{
 		Table:        target,
@@ -78,11 +81,8 @@ func (s *WriterTestSuite) migrate(ctx context.Context, target *schema.Table, sou
 		if totalItems != 2 {
 			return fmt.Errorf("expected 2 items, got %d", totalItems)
 		}
-		if diff := RecordDiff(records[0], resource1); diff != "" {
-			return fmt.Errorf("records[0] differs: %s", diff)
-		}
 		if diff := RecordDiff(records[1], resource2); diff != "" {
-			return fmt.Errorf("records[1] differs: %s", diff)
+			return fmt.Errorf("second record differs from expectation: %s", diff)
 		}
 	} else {
 		totalItems = TotalRows(records)
@@ -90,7 +90,7 @@ func (s *WriterTestSuite) migrate(ctx context.Context, target *schema.Table, sou
 			return fmt.Errorf("expected 1 item, got %d", totalItems)
 		}
 		if diff := RecordDiff(records[0], resource2); diff != "" {
-			return fmt.Errorf("records[0] differs: %s", diff)
+			return fmt.Errorf("record differs from expectation: %s", diff)
 		}
 	}
 


### PR DESCRIPTION
We should check the first record higher up, because after the migration it will have an additional column and is therefore bound to differ from the original record.