### PR TITLE
fix(testdata): Exclude only the correct type

### DIFF
--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -172,7 +172,7 @@ func TestTable(name string, opts TestSourceOptions) *Table {
 func excludeType(columns ColumnList, typ arrow.DataType) ColumnList {
 	var cols ColumnList
 	for _, c := range columns {
-		if c.Type.ID() != typ.ID() {
+		if !arrow.TypeEqual(c.Type, typ) {
 			cols = append(cols, c)
 		}
 	}


### PR DESCRIPTION
`c.Type.ID()` is same for all Arrow extension types so instead of excluding the JSON type from list testdata, it excludes all extensions.