### PR TITLE
feat(transformers): Add `Apply` to apply extra transformations

### DIFF
--- a/transformers/tables.go
+++ b/transformers/tables.go
@@ -15,7 +15,7 @@ func SetParents(tables schema.Tables, parent *schema.Table) {
 }
 
 // TransformTables runs given Tables' transformers as defined in the table definitions, and recursively on the relations.
-// To apply additional transformers, use ApplyTransformers.
+// To apply additional transformers, use Apply.
 func TransformTables(tables schema.Tables) error {
 	for _, table := range tables {
 		if table.Transform != nil {

--- a/transformers/tables.go
+++ b/transformers/tables.go
@@ -14,20 +14,30 @@ func SetParents(tables schema.Tables, parent *schema.Table) {
 	}
 }
 
-// Apply transformations to tables
-func TransformTables(tables schema.Tables, extraTransformers ...schema.Transform) error {
+// TransformTables runs given Tables' transformers as defined in the table definitions, and recursively on the relations
+func TransformTables(tables schema.Tables) error {
 	for _, table := range tables {
 		if table.Transform != nil {
 			if err := table.Transform(table); err != nil {
 				return fmt.Errorf("failed to transform table %s: %w", table.Name, err)
 			}
 		}
+		if err := TransformTables(table.Relations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ApplyTransformers applies the given transformers to the given Tables, and recursively on the relations
+func ApplyTransformers(tables schema.Tables, extraTransformers ...schema.Transform) error {
+	for _, table := range tables {
 		for _, tf := range extraTransformers {
 			if err := tf(table); err != nil {
 				return fmt.Errorf("failed to transform table %s: %w", table.Name, err)
 			}
 		}
-		if err := TransformTables(table.Relations, extraTransformers...); err != nil {
+		if err := ApplyTransformers(table.Relations, extraTransformers...); err != nil {
 			return err
 		}
 	}

--- a/transformers/tables.go
+++ b/transformers/tables.go
@@ -14,7 +14,8 @@ func SetParents(tables schema.Tables, parent *schema.Table) {
 	}
 }
 
-// TransformTables runs given Tables' transformers as defined in the table definitions, and recursively on the relations
+// TransformTables runs given Tables' transformers as defined in the table definitions, and recursively on the relations.
+// To apply additional transformers, use ApplyTransformers.
 func TransformTables(tables schema.Tables) error {
 	for _, table := range tables {
 		if table.Transform != nil {
@@ -29,7 +30,8 @@ func TransformTables(tables schema.Tables) error {
 	return nil
 }
 
-// ApplyTransformers applies the given transformers to the given Tables, and recursively on the relations
+// ApplyTransformers applies the given transformers to the given Tables, and recursively on the relations.
+// This is useful for applying transformers that are not defined in the table definitions. To apply the table-definition transformers, use TransformTables.
 func ApplyTransformers(tables schema.Tables, extraTransformers ...schema.Transform) error {
 	for _, table := range tables {
 		for _, tf := range extraTransformers {

--- a/transformers/tables.go
+++ b/transformers/tables.go
@@ -30,16 +30,16 @@ func TransformTables(tables schema.Tables) error {
 	return nil
 }
 
-// ApplyTransformers applies the given transformers to the given Tables, and recursively on the relations.
+// Apply applies the given transformers to the given Tables, and recursively on the relations.
 // This is useful for applying transformers that are not defined in the table definitions. To apply the table-definition transformers, use TransformTables.
-func ApplyTransformers(tables schema.Tables, extraTransformers ...schema.Transform) error {
+func Apply(tables schema.Tables, extraTransformers ...schema.Transform) error {
 	for _, table := range tables {
 		for _, tf := range extraTransformers {
 			if err := tf(table); err != nil {
 				return fmt.Errorf("failed to transform table %s: %w", table.Name, err)
 			}
 		}
-		if err := ApplyTransformers(table.Relations, extraTransformers...); err != nil {
+		if err := Apply(table.Relations, extraTransformers...); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
// Apply applies the given transformers to the given Tables, and recursively on the relations.
// This is useful for applying transformers that are not defined in the table definitions. To apply the table-definition transformers, use TransformTables.
