### PR TITLE
fix: Bring back null handling for destination testing

### DIFF
--- a/plugin/nulls.go
+++ b/plugin/nulls.go
@@ -6,73 +6,63 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/memory"
 )
 
-// TODO(v4): use in v4
-//
-// nolint:unused
-func stripNullsFromLists(records []arrow.Record) {
-	for i := range records {
-		cols := records[i].Columns()
-		for c, col := range cols {
-			if col.DataType().ID() != arrow.LIST {
+func stripNullsFromLists(record arrow.Record) arrow.Record {
+	cols := record.Columns()
+	for c, col := range cols {
+		if col.DataType().ID() != arrow.LIST {
+			continue
+		}
+
+		list := col.(*array.List)
+		bldr := array.NewListBuilder(memory.DefaultAllocator, list.DataType().(*arrow.ListType).Elem())
+		for j := 0; j < list.Len(); j++ {
+			if list.IsNull(j) {
+				bldr.AppendNull()
 				continue
 			}
-
-			list := col.(*array.List)
-			bldr := array.NewListBuilder(memory.DefaultAllocator, list.DataType().(*arrow.ListType).Elem())
-			for j := 0; j < list.Len(); j++ {
-				if list.IsNull(j) {
-					bldr.AppendNull()
+			bldr.Append(true)
+			vBldr := bldr.ValueBuilder()
+			from, to := list.ValueOffsets(j)
+			slc := array.NewSlice(list.ListValues(), from, to)
+			for k := 0; k < int(to-from); k++ {
+				if slc.IsNull(k) {
 					continue
 				}
-				bldr.Append(true)
-				vBldr := bldr.ValueBuilder()
-				from, to := list.ValueOffsets(j)
-				slc := array.NewSlice(list.ListValues(), from, to)
-				for k := 0; k < int(to-from); k++ {
-					if slc.IsNull(k) {
-						continue
-					}
-					err := vBldr.AppendValueFromString(slc.ValueStr(k))
-					if err != nil {
-						panic(err)
-					}
+				err := vBldr.AppendValueFromString(slc.ValueStr(k))
+				if err != nil {
+					panic(err)
 				}
 			}
-			cols[c] = bldr.NewArray()
 		}
-		records[i] = array.NewRecord(records[i].Schema(), cols, records[i].NumRows())
+		cols[c] = bldr.NewArray()
 	}
+	return array.NewRecord(record.Schema(), cols, record.NumRows())
 }
 
 type AllowNullFunc func(arrow.DataType) bool
 
-// TODO(v4): use in v4
-//
-// nolint:unused
-func (f AllowNullFunc) replaceNullsByEmpty(records []arrow.Record) {
+func (f AllowNullFunc) replaceNullsWithEmpty(record arrow.Record) arrow.Record {
 	if f == nil {
-		return
+		return record
 	}
-	for i := range records {
-		cols := records[i].Columns()
-		for c, col := range records[i].Columns() {
-			if col.NullN() == 0 || f(col.DataType()) {
+	cols := record.Columns()
+	for c, col := range record.Columns() {
+		if col.NullN() == 0 || f(col.DataType()) {
+			continue
+		}
+
+		builder := array.NewBuilder(memory.DefaultAllocator, record.Column(c).DataType())
+		for j := 0; j < col.Len(); j++ {
+			if col.IsNull(j) {
+				builder.AppendEmptyValue()
 				continue
 			}
 
-			builder := array.NewBuilder(memory.DefaultAllocator, records[i].Column(c).DataType())
-			for j := 0; j < col.Len(); j++ {
-				if col.IsNull(j) {
-					builder.AppendEmptyValue()
-					continue
-				}
-
-				if err := builder.AppendValueFromString(col.ValueStr(j)); err != nil {
-					panic(err)
-				}
+			if err := builder.AppendValueFromString(col.ValueStr(j)); err != nil {
+				panic(err)
 			}
-			cols[c] = builder.NewArray()
 		}
-		records[i] = array.NewRecord(records[i].Schema(), cols, records[i].NumRows())
+		cols[c] = builder.NewArray()
 	}
+	return array.NewRecord(record.Schema(), cols, record.NumRows())
 }

--- a/plugin/testing_write_insert.go
+++ b/plugin/testing_write_insert.go
@@ -129,10 +129,22 @@ func (s *WriterTestSuite) testInsertAll(ctx context.Context) error {
 	if totalItems != 2 {
 		return fmt.Errorf("expected 2 items, got %d", totalItems)
 	}
-	if diff := RecordDiff(readRecords[0], normalRecord); diff != "" {
+
+	wantNormalRecord := s.allowNull.replaceNullsWithEmpty(normalRecord)
+	if s.ignoreNullsInLists {
+		wantNormalRecord = stripNullsFromLists(wantNormalRecord)
+	}
+
+	if diff := RecordDiff(readRecords[0], wantNormalRecord); diff != "" {
 		return fmt.Errorf("record[0] differs: %s", diff)
 	}
-	if diff := RecordDiff(readRecords[1], nullRecord); diff != "" {
+
+	wantNullRecord := s.allowNull.replaceNullsWithEmpty(nullRecord)
+	if s.ignoreNullsInLists {
+		wantNullRecord = stripNullsFromLists(wantNullRecord)
+	}
+
+	if diff := RecordDiff(readRecords[1], wantNullRecord); diff != "" {
 		return fmt.Errorf("record[1] differs: %s", diff)
 	}
 	return nil


### PR DESCRIPTION
This brings back the optional removal of nulls when doing test comparisons for destinations that need it.