### PR TITLE
fix: Reverse order of records in memdb

### DIFF
--- a/internal/memdb/memdb.go
+++ b/internal/memdb/memdb.go
@@ -3,7 +3,6 @@ package memdb
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
 
 	"github.com/apache/arrow/go/v13/arrow"
@@ -101,15 +100,12 @@ func (c *client) Read(_ context.Context, table *schema.Table, res chan<- arrow.R
 	defer c.memoryDBLock.RUnlock()
 
 	tableName := table.Name
-	// we randomize the order of the records here because we don't set an expectation
+	// we iterate over records in reverse here because we don't set an expectation
 	// of ordering on plugins, and we want to make sure that the tests are not
-	// dependent on the order of the records either.
+	// dependent on the order of insertion either.
 	rows := c.memoryDB[tableName]
-	rand.Shuffle(len(rows), func(i, j int) {
-		rows[i], rows[j] = rows[j], rows[i]
-	})
-	for _, row := range rows {
-		res <- row
+	for i := len(rows) - 1; i >= 0; i-- {
+		res <- rows[i]
 	}
 	return nil
 }

--- a/plugin/testing_write_insert.go
+++ b/plugin/testing_write_insert.go
@@ -124,6 +124,7 @@ func (s *WriterTestSuite) testInsertAll(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to sync: %w", err)
 	}
+	sortRecords(table, readRecords, "id")
 
 	totalItems = TotalRows(readRecords)
 	if totalItems != 2 {


### PR DESCRIPTION
Shuffling missed a case (I think) because we were using the same seed every time. Iterating over the items in reverse should have the same effect and is still deterministic.

Same fix as in https://github.com/cloudquery/plugin-sdk/pull/1074 but also adds a test for it.