### PR TITLE
fix: Reset timers on flush

### DIFF
--- a/writers/mixedbatchwriter/mixedbatchwriter_test.go
+++ b/writers/mixedbatchwriter/mixedbatchwriter_test.go
@@ -232,7 +232,7 @@ func (m *mockTicker) Stop() {
 	close(m.C)
 }
 
-func (m *mockTicker) Reset(d time.Duration) {}
+func (*mockTicker) Reset(_ time.Duration) {}
 
 func newMockTicker(trigger chan struct{}) *mockTicker {
 	c := make(chan time.Time)

--- a/writers/streamingbatchwriter/mocktimer_test.go
+++ b/writers/streamingbatchwriter/mocktimer_test.go
@@ -6,22 +6,26 @@ import (
 	"github.com/cloudquery/plugin-sdk/v4/writers"
 )
 
-type mockTimer struct {
+type mockTicker struct {
 	expire chan time.Time
 }
 
-func (t *mockTimer) timer(time.Duration) (<-chan time.Time, func()) {
-	return t.expire, t.close
-}
-
-func (t *mockTimer) close() {
+func (t *mockTicker) Stop() {
 	close(t.expire)
 }
 
-func newMockTimer() (writers.TickerFunc, chan time.Time) {
+func (t *mockTicker) Reset(time.Duration) {}
+
+func (t *mockTicker) Chan() <-chan time.Time {
+	return t.expire
+}
+
+func newMockTicker() (writers.TickerFunc, chan<- time.Time) {
 	expire := make(chan time.Time)
-	t := &mockTimer{
+	t := &mockTicker{
 		expire: expire,
 	}
-	return t.timer, expire
+	return func(time.Duration) writers.Ticker {
+		return t
+	}, expire
 }

--- a/writers/streamingbatchwriter/mocktimer_test.go
+++ b/writers/streamingbatchwriter/mocktimer_test.go
@@ -14,7 +14,7 @@ func (t *mockTicker) Stop() {
 	close(t.expire)
 }
 
-func (t *mockTicker) Reset(time.Duration) {}
+func (*mockTicker) Reset(time.Duration) {}
 
 func (t *mockTicker) Chan() <-chan time.Time {
 	return t.expire

--- a/writers/ticker.go
+++ b/writers/ticker.go
@@ -31,7 +31,7 @@ type nopTicker struct{}
 
 func (nopTicker) Stop() {}
 
-func (nopTicker) Reset(d time.Duration) {}
+func (nopTicker) Reset(_ time.Duration) {}
 
 func (nopTicker) Chan() <-chan time.Time {
 	return nil

--- a/writers/ticker.go
+++ b/writers/ticker.go
@@ -4,14 +4,35 @@ import (
 	"time"
 )
 
-type TickerFunc func(interval time.Duration) (ch <-chan time.Time, done func())
+type TickerFunc func(time.Duration) Ticker
 
-func NewTicker(interval time.Duration) (<-chan time.Time, func()) {
-	if interval <= 0 {
-		return nil, nop
-	}
-	t := time.NewTicker(interval)
-	return t.C, t.Stop
+type Ticker interface {
+	Stop()
+	Reset(d time.Duration)
+	Chan() <-chan time.Time
 }
 
-func nop() {}
+func NewTicker(interval time.Duration) Ticker {
+	if interval <= 0 {
+		return nopTicker{}
+	}
+	return &ticker{time.NewTicker(interval)}
+}
+
+type ticker struct {
+	*time.Ticker
+}
+
+func (t *ticker) Chan() <-chan time.Time {
+	return t.C
+}
+
+type nopTicker struct{}
+
+func (nopTicker) Stop() {}
+
+func (nopTicker) Reset(d time.Duration) {}
+
+func (nopTicker) Chan() <-chan time.Time {
+	return nil
+}


### PR DESCRIPTION
This updates the ticker logic in the batch writers to reset the ticker when a flush happens. This is better, as it still guarantees that a message won't be delayed by more than batch_timeout, but we don't risk flushing a very small batch because we must flush at regular intervals either.

The choice of resetting _after_ the flush is deliberate: it means that the maximum amount of time between flushes is:

```
max_time = flush_time + batch_timeout
```

otherwise we could do:

```
max_time = batch_timeout
```

but if a flush were to then longer than the batch timeout, we can end up in a cycle of flushing again immediately after the previous flush finishes.