### PR TITLE
fix: Force migrate mode should expect 1 row

### DIFF
--- a/plugin/testing_write_migrate.go
+++ b/plugin/testing_write_migrate.go
@@ -79,7 +79,7 @@ func (s *WriterTestSuite) migrate(ctx context.Context, target *schema.Table, sou
 	sortRecords(target, records, "id")
 
 	// if force migration is not required, we don't expect any items to be dropped (so there should be 2 items)
-	if !writeOptionMigrateForce || supportsSafeMigrate {
+	if !writeOptionMigrateForce && supportsSafeMigrate {
 		totalItems = TotalRows(records)
 		if totalItems != 2 {
 			return fmt.Errorf("expected 2 items, got %d", totalItems)


### PR DESCRIPTION
Force migrate should expect 1 row (the previous data to be dropped) not 2.

In plugin's migration handling code, there's no easy way to decide if we should drop the table or not. If `force` flag is set it should always drop the previous data. This is an issue with the ElasticSearch plugin where `change column` doesn't work without force (but add/remove works).

**CAVEAT** This breaks migration code where it detects if a change is necessary by comparing state of the current schema (by rebuilding a `schema.Table` from underlying data-storage) instead of always forcing a drop on force-migrate. Some destinations can't build the schema.Table back because of metadata loss (either can't read it back, or type mapping isn't 1-to-1) where this approach helps.