### PR TITLE
fix(writers): StreamingBatchWriter hangs with non-append mode

### DIFF
--- a/writers/streamingbatchwriter/streamingbatchwriter.go
+++ b/writers/streamingbatchwriter/streamingbatchwriter.go
@@ -159,6 +159,7 @@ func (w *StreamingBatchWriter) Close(context.Context) error {
 	w.insertWorkers = make(map[string]*streamingWorkerManager[*message.WriteInsert])
 	w.migrateWorker = nil
 	w.deleteWorker = nil
+	w.lastMsgType = writers.MsgTypeUnset
 
 	return nil
 }

--- a/writers/streamingbatchwriter/streamingbatchwriter_test.go
+++ b/writers/streamingbatchwriter/streamingbatchwriter_test.go
@@ -227,7 +227,7 @@ func TestStreamingBatchTimeout(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	tickerFn, expire := newMockTicker()
+	tickerFn, tickFn := newMockTicker()
 
 	wr, err := New(testClient, withTickerFn(tickerFn))
 	if err != nil {
@@ -258,7 +258,7 @@ func TestStreamingBatchTimeout(t *testing.T) {
 	}
 
 	// flush
-	close(expire)
+	tickFn()
 	waitForLength(t, testClient.MessageLen, messageTypeInsert, 1)
 
 	close(ch)
@@ -332,7 +332,7 @@ func TestStreamingBatchUpserts(t *testing.T) {
 	ch := make(chan message.WriteMessage)
 
 	testClient := newClient()
-	tickerFn, expire := newMockTicker()
+	tickerFn, tickFn := newMockTicker()
 	wr, err := New(testClient, WithBatchSizeRows(2), withTickerFn(tickerFn))
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +363,7 @@ func TestStreamingBatchUpserts(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// flush the batch
-	close(expire)
+	tickFn()
 	waitForLength(t, testClient.MessageLen, messageTypeInsert, 2)
 
 	close(ch)

--- a/writers/streamingbatchwriter/unimplemented.go
+++ b/writers/streamingbatchwriter/unimplemented.go
@@ -18,9 +18,12 @@ func (IgnoreMigrateTable) MigrateTable(_ context.Context, ch <-chan *message.Wri
 	return nil
 }
 
-// UnimplementedDeleteStale is a dummy handler to error on DeleteStale messages
+// UnimplementedDeleteStale is a dummy handler to consume and error on DeleteStale messages
 type UnimplementedDeleteStale struct{}
 
-func (UnimplementedDeleteStale) DeleteStale(_ context.Context, _ <-chan *message.WriteDeleteStale) error {
+func (UnimplementedDeleteStale) DeleteStale(_ context.Context, ch <-chan *message.WriteDeleteStale) error {
+	// nolint:revive
+	for range ch {
+	}
 	return fmt.Errorf("DeleteStale: %w", plugin.ErrNotImplemented)
 }


### PR DESCRIPTION
Fixes the hang [issue](https://github.com/cloudquery/cloudquery/issues/12793) with non-append mode when a dest is using `UnimplementedDeleteStale`.

- This also makes it so that it closes things when Write is done: Otherwise our testing framework confuses things (by invoking Write multiple times for multiple tests in the same plugin, I think).
We're noticing this now because of https://github.com/cloudquery/cloudquery/pull/12765, as other plugins using this writer (file based plugins) don't support migration operations.

Also makes it so that you don't need to call Close() on plugin deinit (but it could still be a good idea if Write was interrupted)
