### PR TITLE
feat: Add Unflatten tables method

### DIFF
--- a/schema/table_test.go
+++ b/schema/table_test.go
@@ -16,6 +16,7 @@ var testTable = &Table{
 		{
 			Name:    "test2",
 			Columns: []Column{},
+			Parent:  &Table{Name: "test"},
 		},
 	},
 }
@@ -43,6 +44,15 @@ func TestTablesFlatten(t *testing.T) {
 	if len(tables) != 2 {
 		t.Fatal("expected 2 tables")
 	}
+}
+
+func TestTablesUnflatten(t *testing.T) {
+	srcTables := Tables{testTable}
+	tables, err := srcTables.FlattenTables().UnflattenTables()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(srcTables)) // verify that the source Tables were left untouched
+	require.Equal(t, 1, len(tables))    // verify that the tables are equal to what we started with
+	require.Equal(t, 1, len(tables[0].Relations))
 }
 
 func TestTablesFilterDFS(t *testing.T) {


### PR DESCRIPTION
This adds an `UnflattenTables` method to the `Tables` type, the opposite operation of `FlattenTables`.

### Why?
Until now, destination plugins were the only part of the code that needed to decode Arrow schemas to tables, and destinations don't need relational information. Now that docs generation is moving to the CLI, however, we need to be able to reconstruct the original relational structure in order to accurately reflect it in the docs.

Rather than modifying `FlattenTables`, which would not be backwards-compatible, I have opted to add a new method that the CLI can use. With this change in place, I am able to fully generate the docs for the AWS plugin from the CLI, with zero changes.