### PR TITLE
feat: Added a CQ ID Salt to the CQ ID generation to support overlapping sync

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -140,6 +140,12 @@ func WithStrategy(strategy Strategy) Option {
 
 type SyncOption func(*syncClient)
 
+func WithSyncCQIDSalt(salt string) SyncOption {
+	return func(s *syncClient) {
+		s.cqIDSalt = salt
+	}
+}
+
 func WithSyncDeterministicCQID(deterministicCQID bool) SyncOption {
 	return func(s *syncClient) {
 		s.deterministicCQID = deterministicCQID
@@ -168,6 +174,7 @@ type syncClient struct {
 	client            schema.ClientMeta
 	scheduler         *Scheduler
 	deterministicCQID bool
+	cqIDSalt          string
 	// status sync metrics
 	metrics *Metrics
 	logger  zerolog.Logger

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -148,7 +148,7 @@ func (s *syncClient) resolveResourcesDfs(ctx context.Context, table *schema.Tabl
 					return
 				}
 
-				if err := resolvedResource.CalculateCQID(s.deterministicCQID); err != nil {
+				if err := resolvedResource.CalculateCQID(s.deterministicCQID, s.cqIDSalt); err != nil {
 					tableMetrics := s.metrics.TableClient[table.Name][client.ID()]
 					s.logger.Error().Err(err).Str("table", table.Name).Str("client", client.ID()).Msg("resource resolver finished with primary key calculation error")
 					if _, found := sentValidationErrors.LoadOrStore(table.Name, struct{}{}); !found {

--- a/schema/resource.go
+++ b/schema/resource.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const CQIDSalt = "_cq_id_salt"
+
 type Resources []*Resource
 
 // Resource represents a row in it's associated table, it carries a reference to the original item, and automatically
@@ -78,7 +80,7 @@ func (r *Resource) GetValues() scalar.Vector {
 }
 
 //nolint:revive
-func (r *Resource) CalculateCQID(deterministicCQID bool) error {
+func (r *Resource) CalculateCQID(deterministicCQID bool, cqIDSalt string) error {
 	if !deterministicCQID {
 		return r.storeCQID(uuid.New())
 	}
@@ -88,6 +90,10 @@ func (r *Resource) CalculateCQID(deterministicCQID bool) error {
 	}
 	slices.Sort(names)
 	h := sha256.New()
+	if cqIDSalt != "" {
+		h.Write([]byte(CQIDSalt))
+		h.Write([]byte(cqIDSalt))
+	}
 	for _, name := range names {
 		// We need to include the column name in the hash because the same value can be present in multiple columns and therefore lead to the same hash
 		h.Write([]byte(name))


### PR DESCRIPTION
## ISSUE
https://github.com/cloudquery/cloudquery/issues/14590
Right now the behaviour of overlapping syncs of same resource is undefined as they always refer to the same primary keys while writing

## PROPOSAL
Accept a custom hash salt as a source spec which can be used as a custom salt while generating deterministic cq_ids.
This way we can get different cq_ids across different syncs even for the same resource.

This holds true when we use **deterministic_cq_id: true && pk_mode: _cq_id_only**

## TODO
Need to update source spec and other parts of Plugin SDKs to support this