### PR TITLE
fix: Don't send migrate messages in destination v1 write

### DIFF
--- a/internal/servers/destination/v1/destinations.go
+++ b/internal/servers/destination/v1/destinations.go
@@ -137,13 +137,6 @@ func (s *Server) Write(msg pb.Destination_WriteServer) error {
 		return s.Plugin.Write(ctx, msgs)
 	})
 
-	for _, table := range tables {
-		msgs <- &message.WriteMigrateTable{
-			Table:        table,
-			MigrateForce: s.spec.MigrateMode == specs.MigrateModeForced,
-		}
-	}
-
 	for {
 		r, err := msg.Recv()
 		if err == io.EOF {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Migrate messages are already sent in the CLI here https://github.com/cloudquery/cloudquery/blob/eab200d6944c54db5ef6d9a81b290ed6b8ddd06f/cli/cmd/sync_v2.go#L145 (during sync) and here https://github.com/cloudquery/cloudquery/blob/eab200d6944c54db5ef6d9a81b290ed6b8ddd06f/cli/cmd/migrate_v2.go#L66 (during migrate).

Without this fix, if you have a v2 source and a v3 destination `sync` will run migration twice, and `sync --no-migrate` will run migration once

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
