### PR TITLE
fix: Add schema version to package.json

### DIFF
--- a/serve/package.go
+++ b/serve/package.go
@@ -29,6 +29,7 @@ This creates a directory with the plugin binaries, package.json and documentatio
 // PackageJSON is the package.json file inside the dist directory. It is used by the CloudQuery package command
 // to be able to package the plugin with all the needed metadata.
 type PackageJSON struct {
+	SchemaVersion    int                `json:"schema_version"`
 	Name             string             `json:"name"`
 	Version          string             `json:"version"`
 	Protocols        []int              `json:"protocols"`
@@ -141,6 +142,7 @@ func (s *PluginServe) writePackageJSON(dir, pluginVersion string) error {
 		})
 	}
 	packageJSON := PackageJSON{
+		SchemaVersion:    1,
 		Name:             s.plugin.Name(),
 		Version:          pluginVersion,
 		Protocols:        s.versions,

--- a/serve/package_test.go
+++ b/serve/package_test.go
@@ -55,9 +55,10 @@ func TestPluginPackage(t *testing.T) {
 	}
 
 	expectPackage := PackageJSON{
-		Name:      "testPlugin",
-		Version:   "v1.2.3",
-		Protocols: []int{3},
+		SchemaVersion: 1,
+		Name:          "testPlugin",
+		Version:       "v1.2.3",
+		Protocols:     []int{3},
 		SupportedTargets: []TargetBuild{
 			{OS: plugin.GoOSLinux, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-linux-amd64.zip"},
 			{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-windows-amd64.zip"},


### PR DESCRIPTION
We should have a version in the package.json file so that we can check compatibility with the CLI.