### PR TITLE
fix: Validate spec only when connection is established

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -141,7 +141,7 @@ func (p *Plugin) Init(ctx context.Context, spec []byte, options NewClientOptions
 	defer p.mu.Unlock()
 	var err error
 
-	if len(spec) > 0 && p.schemaValidator != nil {
+	if !options.NoConnection && p.schemaValidator != nil {
 		var v any
 		if err := json.Unmarshal(spec, &v); err != nil {
 			return fmt.Errorf("failed to unmarshal plugin spec: %w", err)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -141,7 +141,7 @@ func (p *Plugin) Init(ctx context.Context, spec []byte, options NewClientOptions
 	defer p.mu.Unlock()
 	var err error
 
-	if p.schemaValidator != nil {
+	if len(spec) > 0 && p.schemaValidator != nil {
 		var v any
 		if err := json.Unmarshal(spec, &v); err != nil {
 			return fmt.Errorf("failed to unmarshal plugin spec: %w", err)


### PR DESCRIPTION
Documentation generation will fail otherwise.
Follow-up for #1214