### PR TITLE
fix(package): Normalize tables when writing tables.json

### DIFF
--- a/internal/memdb/memdb.go
+++ b/internal/memdb/memdb.go
@@ -43,7 +43,9 @@ func GetNewClient(options ...Option) plugin.NewClientFunc {
 	c := &client{
 		memoryDB:     make(map[string][]arrow.Record),
 		memoryDBLock: sync.RWMutex{},
-		tables:       make(map[string]*schema.Table),
+		tables: map[string]*schema.Table{
+			"table1": {Name: "table1", Relations: schema.Tables{{Name: "table2"}}},
+		},
 	}
 	for _, opt := range options {
 		opt(c)

--- a/serve/package.go
+++ b/serve/package.go
@@ -63,8 +63,9 @@ func (s *PluginServe) writeTablesJSON(ctx context.Context, dir string) error {
 	if err != nil {
 		return err
 	}
-	tablesToEncode := make([]pluginTable, 0, len(tables))
-	for _, t := range tables.FlattenTables() {
+	flattenedTables := tables.FlattenTables()
+	tablesToEncode := make([]pluginTable, 0, len(flattenedTables))
+	for _, t := range flattenedTables {
 		table := tables.Get(t.Name)
 		var parent *string
 		if table.Parent != nil {

--- a/serve/package_test.go
+++ b/serve/package_test.go
@@ -97,6 +97,7 @@ with multiple lines and **markdown**`
 				"overview.md",
 			}
 			checkDocs(t, filepath.Join(distDir, "docs"), expectDocs)
+			checkTables(t, distDir)
 		})
 	}
 }
@@ -121,6 +122,18 @@ func checkDocs(t *testing.T, dir string, expect []string) {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(expect, fileNames(files)); diff != "" {
+		t.Fatalf("unexpected files in docs directory (-want +got):\n%s", diff)
+	}
+}
+
+func checkTables(t *testing.T, distDir string) {
+	content, err := os.ReadFile(filepath.Join(distDir, "tables.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tablesString := string(content)
+
+	if diff := cmp.Diff(tablesString, "[{\"name\":\"table1\",\"relations\":[\"table2\"]},{\"name\":\"table2\"}]\n"); diff != "" {
 		t.Fatalf("unexpected files in docs directory (-want +got):\n%s", diff)
 	}
 }

--- a/serve/plugin_test.go
+++ b/serve/plugin_test.go
@@ -80,7 +80,7 @@ func TestPluginServe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(tables) != 0 {
+	if len(tables) != 2 {
 		t.Fatalf("Expected 0 tables but got %d", len(tables))
 	}
 	testTable := schema.Table{


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

We might want to refactor this to no (ab)use the MemDB plugin but I think this is ok for now. Also we should call `FlattenTables` otherwise we only output the top level ones

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
