### PR TITLE
fix: Skip tables.json when packaging destinations

### DIFF
--- a/examples/simple_plugin/plugin/client.go
+++ b/examples/simple_plugin/plugin/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/cloudquery/plugin-sdk/examples/simple_plugin/client"
 	"github.com/cloudquery/plugin-sdk/examples/simple_plugin/services"
 	"github.com/cloudquery/plugin-sdk/v4/message"
@@ -20,8 +21,6 @@ type Client struct {
 	config    client.Spec
 	tables    schema.Tables
 	scheduler *scheduler.Scheduler
-
-	plugin.UnimplementedDestination
 }
 
 func (c *Client) Logger() *zerolog.Logger {
@@ -52,6 +51,16 @@ func (c *Client) Tables(_ context.Context, options plugin.TableOptions) (schema.
 }
 
 func (*Client) Close(_ context.Context) error {
+	return nil
+}
+
+func (*Client) Write(context.Context, <-chan message.WriteMessage) error {
+	// Not implemented, just used for testing destination packaging
+	return nil
+}
+
+func (*Client) Read(context.Context, *schema.Table, chan<- arrow.Record) error {
+	// Not implemented, just used for testing destination packaging
 	return nil
 }
 

--- a/plugin/plugin_package.go
+++ b/plugin/plugin_package.go
@@ -1,5 +1,7 @@
 package plugin
 
+import "errors"
+
 const (
 	GoOSLinux   = "linux"
 	GoOSWindows = "windows"
@@ -8,6 +10,22 @@ const (
 	GoArchAmd64 = "amd64"
 	GoArchArm64 = "arm64"
 )
+
+type Type string
+
+const (
+	TypeSource      Type = "source"
+	TypeDestination Type = "destination"
+)
+
+func (t Type) Validate() error {
+	switch t {
+	case TypeSource, TypeDestination:
+		return nil
+	default:
+		return errors.New("invalid type: must be one of source, destination")
+	}
+}
 
 type PackageType string
 

--- a/serve/package.go
+++ b/serve/package.go
@@ -310,7 +310,7 @@ func (s *PluginServe) newCmdPluginPackage() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			if pluginType == "source" {
+			if pluginType == plugin.TypeSource {
 				if err := s.writeTablesJSON(cmd.Context(), distPath); err != nil {
 					return err
 				}

--- a/serve/package_test.go
+++ b/serve/package_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestPluginPackage(t *testing.T) {
+func TestPluginPackage_Source(t *testing.T) {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("failed to get current file path")
@@ -29,6 +29,90 @@ func TestPluginPackage(t *testing.T) {
 		memdb.NewMemDBClient,
 		plugin.WithBuildTargets([]plugin.BuildTarget{
 			{OS: plugin.GoOSLinux, Arch: plugin.GoArchAmd64},
+			{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64},
+		}),
+	)
+	msg := `Test message
+with multiple lines and **markdown**`
+	testCases := []struct {
+		name    string
+		message string
+		wantErr bool
+	}{
+		{
+			name:    "inline message",
+			message: msg,
+		},
+		{
+			name:    "message from file",
+			message: "@testdata/message.txt",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := Plugin(p)
+			cmd := srv.newCmdPluginRoot()
+			distDir := t.TempDir()
+			cmd.SetArgs([]string{"package", "--dist-dir", distDir, "-m", tc.message, "source", packageVersion, simplePluginPath})
+			err := cmd.Execute()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			files, err := os.ReadDir(distDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect := []string{
+				"docs",
+				"package.json",
+				"plugin-testPlugin-v1.2.3-linux-amd64.zip",
+				"plugin-testPlugin-v1.2.3-windows-amd64.zip",
+				"tables.json",
+			}
+			if diff := cmp.Diff(expect, fileNames(files)); diff != "" {
+				t.Fatalf("unexpected files in dist directory (-want +got):\n%s", diff)
+			}
+
+			expectPackage := PackageJSON{
+				SchemaVersion: 1,
+				Name:          "testPlugin",
+				Type:          "source",
+				Message:       msg,
+				Version:       "v1.2.3",
+				Protocols:     []int{3},
+				SupportedTargets: []TargetBuild{
+					{OS: plugin.GoOSLinux, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-linux-amd64.zip", Checksum: "sha256:" + sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-linux-amd64.zip"))},
+					{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-windows-amd64.zip", Checksum: "sha256:" + sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-windows-amd64.zip"))},
+				},
+				PackageType: plugin.PackageTypeNative,
+			}
+			checkPackageJSONContents(t, filepath.Join(distDir, "package.json"), expectPackage)
+
+			expectDocs := []string{
+				"configuration.md",
+				"overview.md",
+			}
+			checkDocs(t, filepath.Join(distDir, "docs"), expectDocs)
+			checkTables(t, distDir)
+		})
+	}
+}
+
+func TestPluginPackage_Destination(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to get current file path")
+	}
+	dir := filepath.Dir(filepath.Dir(filename))
+	simplePluginPath := filepath.Join(dir, "examples/simple_plugin")
+	packageVersion := "v1.2.3"
+	p := plugin.NewPlugin(
+		"testPlugin",
+		"development",
+		memdb.NewMemDBClient,
+		plugin.WithBuildTargets([]plugin.BuildTarget{
 			{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64},
 			{OS: plugin.GoOSDarwin, Arch: plugin.GoArchAmd64},
 		}),
@@ -54,7 +138,7 @@ with multiple lines and **markdown**`
 			srv := Plugin(p)
 			cmd := srv.newCmdPluginRoot()
 			distDir := t.TempDir()
-			cmd.SetArgs([]string{"package", "--dist-dir", distDir, "-m", tc.message, simplePluginPath, packageVersion})
+			cmd.SetArgs([]string{"package", "--dist-dir", distDir, "-m", tc.message, "destination", packageVersion, simplePluginPath})
 			err := cmd.Execute()
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")
@@ -69,9 +153,7 @@ with multiple lines and **markdown**`
 				"docs",
 				"package.json",
 				"plugin-testPlugin-v1.2.3-darwin-amd64.zip",
-				"plugin-testPlugin-v1.2.3-linux-amd64.zip",
 				"plugin-testPlugin-v1.2.3-windows-amd64.zip",
-				"tables.json",
 			}
 			if diff := cmp.Diff(expect, fileNames(files)); diff != "" {
 				t.Fatalf("unexpected files in dist directory (-want +got):\n%s", diff)
@@ -80,11 +162,11 @@ with multiple lines and **markdown**`
 			expectPackage := PackageJSON{
 				SchemaVersion: 1,
 				Name:          "testPlugin",
+				Type:          "destination",
 				Message:       msg,
 				Version:       "v1.2.3",
 				Protocols:     []int{3},
 				SupportedTargets: []TargetBuild{
-					{OS: plugin.GoOSLinux, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-linux-amd64.zip", Checksum: "sha256:" + sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-linux-amd64.zip"))},
 					{OS: plugin.GoOSWindows, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-windows-amd64.zip", Checksum: "sha256:" + sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-windows-amd64.zip"))},
 					{OS: plugin.GoOSDarwin, Arch: plugin.GoArchAmd64, Path: "plugin-testPlugin-v1.2.3-darwin-amd64.zip", Checksum: "sha256:" + sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-darwin-amd64.zip"))},
 				},
@@ -97,7 +179,6 @@ with multiple lines and **markdown**`
 				"overview.md",
 			}
 			checkDocs(t, filepath.Join(distDir, "docs"), expectDocs)
-			checkTables(t, distDir)
 		})
 	}
 }


### PR DESCRIPTION
This adds a new `type` (`source` or `destination`) argument to the `package` command, and switches the ordering of arguments bit (since we're making a breaking change to it anyway). The `type` is written to package.json as well, and if it is `destination`, we don't create a `tables.json`.