### PR TITLE
fix: Set GOOS and GOARCH in package command

### DIFF
--- a/serve/package.go
+++ b/serve/package.go
@@ -115,6 +115,7 @@ func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersi
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOOS=%s", goos))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOARCH=%s", goarch))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_ENABLED=%v", getEnvOrDefault("CGO_ENABLED", "0"))) // default to CGO_ENABLED=0
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("failed to build plugin with `go %v`: %w", args, err)
 	}

--- a/serve/package.go
+++ b/serve/package.go
@@ -113,6 +113,8 @@ func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersi
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOOS=%s", goos))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOARCH=%s", goarch))
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("failed to build plugin with `go %v`: %w", args, err)
 	}

--- a/serve/package_test.go
+++ b/serve/package_test.go
@@ -50,6 +50,7 @@ with multiple lines and **markdown**`
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CGO_ENABLED", "0") // disable CGO to ensure we environmental differences don't interfere with the test
 			srv := Plugin(p)
 			cmd := srv.newCmdPluginRoot()
 			distDir := t.TempDir()
@@ -73,6 +74,12 @@ with multiple lines and **markdown**`
 			}
 			if diff := cmp.Diff(expect, fileNames(files)); diff != "" {
 				t.Fatalf("unexpected files in dist directory (-want +got):\n%s", diff)
+			}
+			// expect SHA-256 for the zip files to differ
+			sha1 := sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-linux-amd64.zip"))
+			sha2 := sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-windows-amd64.zip"))
+			if sha1 == sha2 {
+				t.Fatalf("expected SHA-256 for linux and windows zip files to differ, but they are the same: %s", sha1)
 			}
 
 			expectPackage := PackageJSON{
@@ -135,6 +142,7 @@ with multiple lines and **markdown**`
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CGO_ENABLED", "0") // disable CGO to ensure we environmental differences don't interfere with the test
 			srv := Plugin(p)
 			cmd := srv.newCmdPluginRoot()
 			distDir := t.TempDir()
@@ -157,6 +165,12 @@ with multiple lines and **markdown**`
 			}
 			if diff := cmp.Diff(expect, fileNames(files)); diff != "" {
 				t.Fatalf("unexpected files in dist directory (-want +got):\n%s", diff)
+			}
+			// expect SHA-256 for the zip files to differ
+			sha1 := sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-windows-amd64.zip"))
+			sha2 := sha256sum(filepath.Join(distDir, "plugin-testPlugin-v1.2.3-darwin-amd64.zip"))
+			if sha1 == sha2 {
+				t.Fatalf("expected SHA-256 for windows and darwin zip files to differ, but they are the same: %s", sha1)
 			}
 
 			expectPackage := PackageJSON{


### PR DESCRIPTION
This ensures that different binaries are actually built as expected. I also added a test assertion to check that the SHA256 of the resulting binaries are at least different. 