### PR TITLE
fix(package): Don't init destinations during package

### DIFF
--- a/serve/package.go
+++ b/serve/package.go
@@ -305,12 +305,13 @@ func (s *PluginServe) newCmdPluginPackage() *cobra.Command {
 			if err := os.MkdirAll(distPath, 0755); err != nil {
 				return err
 			}
-			if err := s.plugin.Init(cmd.Context(), nil, plugin.NewClientOptions{
-				NoConnection: true,
-			}); err != nil {
-				return err
-			}
+
 			if pluginKind == plugin.KindSource {
+				if err := s.plugin.Init(cmd.Context(), nil, plugin.NewClientOptions{
+					NoConnection: true,
+				}); err != nil {
+					return err
+				}
 				if err := s.writeTablesJSON(cmd.Context(), distPath); err != nil {
 					return err
 				}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/plugin-sdk/issues/1248

Another option that we could do (or do both) is handle `NoConnection` in all destinations.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
