### PR TITLE
feat: Add support for conditional static linking of C lib to builds

### DIFF
--- a/plugin/options.go
+++ b/plugin/options.go
@@ -29,6 +29,12 @@ func WithJSONSchema(schema string) Option {
 	}
 }
 
+func WithStaticLinking() Option {
+	return func(p *Plugin) {
+		p.staticLinking = true
+	}
+}
+
 type TableOptions struct {
 	Tables              []string
 	SkipTables          []string

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -57,6 +57,8 @@ type Plugin struct {
 	targets []BuildTarget
 	// Called upon init call to validate and init configuration
 	newClient NewClientFunc
+	// staticLinking true if C libraries should be added to compiled executable
+	staticLinking bool
 	// Logger to call, this logger is passed to the serve.Serve Client, if not defined Serve will create one instead.
 	logger zerolog.Logger
 	// mu is a mutex that limits the number of concurrent init/syncs (can only be one at a time)
@@ -106,6 +108,11 @@ func (p *Plugin) Name() string {
 // Version returns the version of this plugin
 func (p *Plugin) Version() string {
 	return p.version
+}
+
+// IsStaticLinkingEnabled whether static linking is to be enabled
+func (p *Plugin) IsStaticLinkingEnabled() bool {
+	return p.staticLinking
 }
 
 func (p *Plugin) Targets() []BuildTarget {

--- a/serve/package.go
+++ b/serve/package.go
@@ -110,7 +110,7 @@ func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersi
 		return nil, err
 	}
 	ldFlags := fmt.Sprintf("-s -w -X %s/plugin.Version=%s", importPath, pluginVersion)
-	if getEnvOrDefault("STATIC_LINKING_ENABLED", "0") == "1" {
+	if s.plugin.IsStaticLinkingEnabled() {
 		ldFlags += " -linkmode external -extldflags=-static"
 	}
 	args := []string{"build", "-o", pluginPath}

--- a/serve/package.go
+++ b/serve/package.go
@@ -105,13 +105,17 @@ func (s *PluginServe) writeTablesJSON(ctx context.Context, dir string) error {
 func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersion string) (*TargetBuild, error) {
 	pluginName := fmt.Sprintf("plugin-%s-%s-%s-%s", s.plugin.Name(), pluginVersion, goos, goarch)
 	pluginPath := path.Join(distPath, pluginName)
-	args := []string{"build", "-o", pluginPath}
 	importPath, err := s.getModuleName(pluginDirectory)
 	if err != nil {
 		return nil, err
 	}
+	ldFlags := fmt.Sprintf("-s -w -X %s/plugin.Version=%s", importPath, pluginVersion)
+	if getEnvOrDefault("STATIC_LINKING_ENABLED", "0") == "1" {
+		ldFlags += " -linkmode external -extldflags=-static"
+	}
+	args := []string{"build", "-o", pluginPath}
 	args = append(args, "-buildmode=exe")
-	args = append(args, "-ldflags", fmt.Sprintf("-s -w -X %s/plugin.Version=%s", importPath, pluginVersion))
+	args = append(args, "-ldflags", ldFlags)
 	cmd := exec.Command("go", args...)
 	cmd.Dir = pluginDirectory
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This adds support for conditionally linking C libs when building plugin executables. CGO_ENABLED plugins (sqlite and duckdb) fail to run on Alpine Linux distributions because of missing C libraries needed to execute the code. See https://github.com/cloudquery/cloudquery/issues/14465.

The fix is to include those missing libraries into the executable that is created by `go build`:

`CGO_ENABLED=1 go build -ldflags="-linkmode external -extldflags=-static"`
