### PR TITLE
feat: Adding a batch updater to allow usage updates to be batched

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/CloudyKit/jet/v6 v6.2.0 // indirect
 	github.com/Joker/jade v1.1.3 // indirect
 	github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/arrow/go/v13 v13.0.0-20230731205701-112f94971882 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06 h1:KkH3I3sJuOLP3TjA/dfr4NAY8bghDwnXiU7cTKxQqo0=
 github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06/go.mod h1:7erjKLwalezA0k99cWs5L11HWOAPNjdUZ6RxH1BXbbM=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
@@ -556,6 +558,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -227,7 +227,7 @@ func (u *BatchUpdater) updateUsageWithRetryAndBackoff(ctx context.Context, numbe
 		if err != nil {
 			return fmt.Errorf("failed to update usage: %w", err)
 		}
-		if resp.StatusCode() == http.StatusOK {
+		if resp.StatusCode() >= 200 && resp.StatusCode() < 300 {
 			u.lastUpdateTime = time.Now().UTC()
 			return nil
 		}

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -1,0 +1,193 @@
+package premium
+
+import (
+	"context"
+	"fmt"
+	cqapi "github.com/cloudquery/cloudquery-api-go"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultBatchLimit = 1000
+	defaultDurationMS = 10000
+)
+
+type UsageClient interface {
+	// Increase updates the usage by the given number of rows
+	Increase(context.Context, uint32)
+	// HasQuota returns true if the quota has not been exceeded
+	HasQuota(context.Context) (bool, error)
+	// Close flushes any remaining rows and closes the quota service
+	Close() error
+}
+
+type UpdaterOptions func(updater *BatchUpdater)
+
+func WithBatchLimit(batchLimit uint32) UpdaterOptions {
+	return func(updater *BatchUpdater) {
+		updater.batchLimit = batchLimit
+	}
+}
+
+func WithTickerDuration(durationms int) UpdaterOptions {
+	return func(updater *BatchUpdater) {
+		updater.tickerDuration = durationms
+	}
+}
+
+type BatchUpdater struct {
+	apiClient *cqapi.ClientWithResponses
+
+	teamName   string
+	pluginTeam string
+	pluginKind string
+	pluginName string
+
+	batchLimit     uint32
+	tickerDuration int
+	rowsToUpdate   atomic.Uint32
+	triggerUpdate  chan struct{}
+	done           chan struct{}
+	wg             *sync.WaitGroup
+	isClosed       bool
+}
+
+func NewUsageClient(ctx context.Context, apiClient *cqapi.ClientWithResponses, teamName, pluginTeam, pluginKind, pluginName string, ops ...UpdaterOptions) *BatchUpdater {
+	u := &BatchUpdater{
+		apiClient: apiClient,
+
+		teamName:   teamName,
+		pluginTeam: pluginTeam,
+		pluginKind: pluginKind,
+		pluginName: pluginName,
+
+		batchLimit:     defaultBatchLimit,
+		tickerDuration: defaultDurationMS,
+		triggerUpdate:  make(chan struct{}),
+		done:           make(chan struct{}),
+		wg:             &sync.WaitGroup{},
+	}
+	for _, op := range ops {
+		op(u)
+	}
+
+	u.backgroundUpdater(ctx)
+
+	return u
+}
+
+func (u *BatchUpdater) Increase(_ context.Context, rows uint32) error {
+	if rows <= 0 {
+		return fmt.Errorf("rows must be greater than zero got %d", rows)
+	}
+
+	if u.isClosed {
+		return fmt.Errorf("usage updater is closed")
+	}
+
+	u.rowsToUpdate.Add(rows)
+
+	// Trigger an update unless an update is already in process
+	select {
+	case u.triggerUpdate <- struct{}{}:
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+func (u *BatchUpdater) HasQuota(ctx context.Context) (bool, error) {
+	usage, err := u.apiClient.GetTeamPluginUsageWithResponse(ctx, u.teamName, u.pluginTeam, cqapi.PluginKind(u.pluginKind), u.pluginName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get usage: %w", err)
+	}
+	if usage.StatusCode() != http.StatusOK {
+		return false, fmt.Errorf("failed to get usage: %s", usage.Status())
+	}
+	return *usage.JSON200.RemainingRows > 0, nil
+}
+
+func (u *BatchUpdater) Close(_ context.Context) error {
+	u.isClosed = true
+
+	close(u.done)
+	u.wg.Wait()
+
+	return nil
+}
+
+func (u *BatchUpdater) backgroundUpdater(ctx context.Context) {
+	started := make(chan struct{})
+	u.wg.Add(1)
+
+	duration := time.Duration(u.tickerDuration) * time.Millisecond
+	ticker := time.NewTicker(duration)
+
+	go func() {
+		defer u.wg.Done()
+		started <- struct{}{}
+		for {
+			select {
+			case <-u.triggerUpdate:
+				rowsToUpdate := u.rowsToUpdate.Load()
+				if rowsToUpdate < u.batchLimit {
+					// Not enough rows to update
+					continue
+				}
+				log.Info().Msgf("updating usage: %d", rowsToUpdate)
+				if err := u.updateUsageWithRetryAndBackoff(ctx, rowsToUpdate); err != nil {
+					log.Error().Err(err).Msg("failed to update usage")
+					// TODO: what to do with an update error
+					continue
+				}
+				u.rowsToUpdate.Add(-rowsToUpdate)
+			case <-ticker.C:
+				rowsToUpdate := u.rowsToUpdate.Load()
+				if rowsToUpdate == 0 {
+					continue
+				}
+				if err := u.updateUsageWithRetryAndBackoff(ctx, rowsToUpdate); err != nil {
+					log.Error().Err(err).Msg("failed to update usage")
+					// TODO: what to do with an update error
+					continue
+				}
+				u.rowsToUpdate.Add(-rowsToUpdate)
+			case <-u.done:
+				remainingRows := u.rowsToUpdate.Load()
+				if remainingRows != 0 {
+					log.Info().Msgf("updating usage: %d", remainingRows)
+					if err := u.updateUsageWithRetryAndBackoff(ctx, remainingRows); err != nil {
+						log.Error().Err(err).Msg("failed to update usage")
+					}
+					u.rowsToUpdate.Add(-remainingRows)
+				}
+				log.Info().Msg("background updater exiting")
+				return
+			}
+		}
+	}()
+	<-started
+}
+
+func (u *BatchUpdater) updateUsageWithRetryAndBackoff(ctx context.Context, numberToUpdate uint32) error {
+	resp, err := u.apiClient.IncreaseTeamPluginUsageWithResponse(ctx, u.teamName, cqapi.IncreaseTeamPluginUsageJSONRequestBody{
+		RequestId:  uuid.New(),
+		PluginTeam: u.pluginTeam,
+		PluginKind: cqapi.PluginKind(u.pluginKind),
+		PluginName: u.pluginName,
+		Rows:       int(numberToUpdate),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update usage: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("failed to update usage: %s", resp.Status())
+	}
+	return nil
+}

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -252,9 +252,6 @@ func (u *BatchUpdater) calculateRetryDuration(statusCode int, headers http.Heade
 			if err != nil {
 				return 0, fmt.Errorf("failed to parse retry-after header: %w", err)
 			}
-			if retryDelay > u.maxWaitTime {
-				return 0, fmt.Errorf("retry-after header exceeds max wait time: %s > %s", retryDelay, u.maxWaitTime)
-			}
 			return retryDelay, nil
 		}
 	}

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -6,6 +6,7 @@ import (
 	cqapi "github.com/cloudquery/cloudquery-api-go"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"math/rand"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -256,8 +257,10 @@ func (u *BatchUpdater) calculateRetryDuration(statusCode int, headers http.Heade
 		}
 	}
 
-	retryDelay := time.Duration(1<<retry) * time.Second
-	return min(retryDelay, u.maxWaitTime) - time.Since(queryStartTime), nil
+	baseRetry := min(time.Duration(1<<retry)*time.Second, u.maxWaitTime)
+	jitter := time.Duration(rand.Intn(1000)) * time.Millisecond
+	retryDelay := baseRetry + jitter
+	return retryDelay - time.Since(queryStartTime), nil
 }
 
 func retryableStatusCode(statusCode int) bool {

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	defaultBatchLimit = 1000
-	defaultDurationMS = 10000
+	defaultBatchLimit  = 1000
+	defaultDurationMS  = 10000
+	defaultMaxRetries  = 5
+	defaultMaxWaitTime = 60 * time.Second
 )
 
 type UsageClient interface {
@@ -28,15 +30,31 @@ type UsageClient interface {
 
 type UpdaterOptions func(updater *BatchUpdater)
 
+// WithBatchLimit sets the maximum number of rows to update in a single request
 func WithBatchLimit(batchLimit uint32) UpdaterOptions {
 	return func(updater *BatchUpdater) {
 		updater.batchLimit = batchLimit
 	}
 }
 
+// WithTickerDuration sets the duration between updates if the number of rows to update have not reached the batch limit
 func WithTickerDuration(durationms int) UpdaterOptions {
 	return func(updater *BatchUpdater) {
 		updater.tickerDuration = durationms
+	}
+}
+
+// WithMaxRetries sets the maximum number of retries to update the usage in case of an API error
+func WithMaxRetries(maxRetries int) UpdaterOptions {
+	return func(updater *BatchUpdater) {
+		updater.maxRetries = maxRetries
+	}
+}
+
+// WithMaxWaitTime sets the maximum time to wait before retrying a failed update
+func WithMaxWaitTime(maxWaitTime time.Duration) UpdaterOptions {
+	return func(updater *BatchUpdater) {
+		updater.maxWaitTime = maxWaitTime
 	}
 }
 
@@ -50,6 +68,8 @@ type BatchUpdater struct {
 
 	batchLimit     uint32
 	tickerDuration int
+	maxRetries     int
+	maxWaitTime    time.Duration
 	rowsToUpdate   atomic.Uint32
 	triggerUpdate  chan struct{}
 	done           chan struct{}
@@ -68,6 +88,8 @@ func NewUsageClient(ctx context.Context, apiClient *cqapi.ClientWithResponses, t
 
 		batchLimit:     defaultBatchLimit,
 		tickerDuration: defaultDurationMS,
+		maxRetries:     defaultMaxRetries,
+		maxWaitTime:    defaultMaxWaitTime,
 		triggerUpdate:  make(chan struct{}),
 		done:           make(chan struct{}),
 		wg:             &sync.WaitGroup{},
@@ -176,18 +198,34 @@ func (u *BatchUpdater) backgroundUpdater(ctx context.Context) {
 }
 
 func (u *BatchUpdater) updateUsageWithRetryAndBackoff(ctx context.Context, numberToUpdate uint32) error {
-	resp, err := u.apiClient.IncreaseTeamPluginUsageWithResponse(ctx, u.teamName, cqapi.IncreaseTeamPluginUsageJSONRequestBody{
-		RequestId:  uuid.New(),
-		PluginTeam: u.pluginTeam,
-		PluginKind: cqapi.PluginKind(u.pluginKind),
-		PluginName: u.pluginName,
-		Rows:       int(numberToUpdate),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to update usage: %w", err)
+	var retryDelay time.Duration
+
+	for retry := 0; retry < u.maxRetries; retry++ {
+		startTime := time.Now()
+
+		resp, err := u.apiClient.IncreaseTeamPluginUsageWithResponse(ctx, u.teamName, cqapi.IncreaseTeamPluginUsageJSONRequestBody{
+			RequestId:  uuid.New(),
+			PluginTeam: u.pluginTeam,
+			PluginKind: cqapi.PluginKind(u.pluginKind),
+			PluginName: u.pluginName,
+			Rows:       int(numberToUpdate),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update usage: %w", err)
+		}
+		if resp.StatusCode() == http.StatusOK {
+			return nil
+		}
+
+		retryDelay = time.Duration(1<<retry) * time.Second
+		if retryDelay > u.maxWaitTime {
+			retryDelay = u.maxWaitTime
+		}
+
+		sleepDuration := retryDelay - time.Since(startTime)
+		if sleepDuration > 0 {
+			time.Sleep(sleepDuration)
+		}
 	}
-	if resp.StatusCode() != http.StatusOK {
-		return fmt.Errorf("failed to update usage: %s", resp.Status())
-	}
-	return nil
+	return fmt.Errorf("failed to update usage: max retries exceeded")
 }

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -94,7 +94,7 @@ func TestUsageService_WithBatchSize(t *testing.T) {
 	assert.True(t, true, s.minExcludingClose() > batchSize, "minimum should be greater than batch size")
 }
 
-func TestUsageService_WithTicker(t *testing.T) {
+func TestUsageService_WithFlushDuration(t *testing.T) {
 	ctx := context.Background()
 	batchSize := 2000
 
@@ -104,7 +104,7 @@ func TestUsageService_WithTicker(t *testing.T) {
 	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
 	require.NoError(t, err)
 
-	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(uint32(batchSize)), WithTickerDuration(1))
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(uint32(batchSize)), WithFlushEvery(1*time.Millisecond))
 
 	for i := 0; i < 10; i++ {
 		err = usageClient.Increase(ctx, 10)

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -1,0 +1,242 @@
+package premium
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	cqapi "github.com/cloudquery/cloudquery-api-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestUsageService_HasQuota_NoRowsRemaining(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServerWithRemainingRows(t, 0)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	hasQuota, err := usageClient.HasQuota(ctx)
+	require.NoError(t, err)
+
+	assert.False(t, hasQuota, "should not have quota")
+}
+
+func TestUsageService_HasQuota_WithRowsRemaining(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServerWithRemainingRows(t, 100)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	hasQuota, err := usageClient.HasQuota(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, hasQuota, "should have quota")
+}
+
+func TestUsageService_ZeroBatchSize(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	for i := 0; i < 10000; i++ {
+		err = usageClient.Increase(ctx, 1)
+		require.NoError(t, err)
+	}
+
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10000, s.sumOfUpdates(), "total should equal number of updated rows")
+}
+
+func TestUsageService_WithBatchSize(t *testing.T) {
+	ctx := context.Background()
+	batchSize := 2000
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(uint32(batchSize)))
+
+	for i := 0; i < 10000; i++ {
+		err = usageClient.Increase(ctx, 1)
+		require.NoError(t, err)
+	}
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10000, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.True(t, true, s.minExcludingClose() > batchSize, "minimum should be greater than batch size")
+}
+
+func TestUsageService_WithTicker(t *testing.T) {
+	ctx := context.Background()
+	batchSize := 2000
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(uint32(batchSize)), WithTickerDuration(1))
+
+	for i := 0; i < 10; i++ {
+		err = usageClient.Increase(ctx, 10)
+		require.NoError(t, err)
+		time.Sleep(5 * time.Millisecond)
+	}
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.True(t, s.minExcludingClose() < batchSize, "we should see updates less than batchsize if ticker is firing")
+}
+
+func TestUsageService_NoUpdates(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, s.numberOfUpdates(), "total number of updates should be zero")
+}
+
+func TestUsageService_UpdatesWithZeroRows(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	err = usageClient.Increase(ctx, 0)
+	require.Error(t, err, "should not be able to update with zero rows")
+
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, s.numberOfUpdates(), "total number of updates should be zero")
+}
+
+func TestUsageService_ShouldNotUpdateClosedService(t *testing.T) {
+	ctx := context.Background()
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := NewUsageClient(ctx, apiClient, "myteam", "mnorbury-team", "source", "vault", WithBatchLimit(0))
+
+	// Close the service first
+	err = usageClient.Close(ctx)
+	require.NoError(t, err)
+
+	err = usageClient.Increase(ctx, 10)
+	require.Error(t, err, "should not be able to update closed service")
+
+	assert.Equal(t, 0, s.numberOfUpdates(), "total number of updates should be zero")
+}
+
+func createTestServerWithRemainingRows(t *testing.T, remainingRows int) *testStage {
+	stage := testStage{
+		remainingRows: remainingRows,
+		update:        make([]int, 0),
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := fmt.Fprintf(w, `{"remaining_rows": %d}`, stage.remainingRows); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "POST" {
+			dec := json.NewDecoder(r.Body)
+			var req cqapi.IncreaseTeamPluginUsageJSONRequestBody
+			err := dec.Decode(&req)
+			require.NoError(t, err)
+
+			stage.update = append(stage.update, req.Rows)
+
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	})
+
+	stage.server = httptest.NewServer(handler)
+
+	return &stage
+}
+
+func createTestServer(t *testing.T) *testStage {
+	return createTestServerWithRemainingRows(t, 0)
+}
+
+type testStage struct {
+	server *httptest.Server
+
+	remainingRows int
+	update        []int
+}
+
+func (s *testStage) numberOfUpdates() int {
+	return len(s.update)
+}
+
+func (s *testStage) sumOfUpdates() int {
+	sum := 0
+	for _, val := range s.update {
+		sum += val
+	}
+	return sum
+}
+
+func (s *testStage) minExcludingClose() int {
+	m := math.MaxInt
+	for i := 0; i < len(s.update); i++ {
+		if s.update[i] < m {
+			m = s.update[i]
+		}
+	}
+	return m
+}

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -208,35 +208,35 @@ func TestUsageService_CalculateRetryDuration_Exp(t *testing.T) {
 	}{
 		{
 			name:            "first retry",
-			statusCode:      http.StatusOK,
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           0,
 			expectedSeconds: 1,
 		},
 		{
 			name:            "second retry",
-			statusCode:      http.StatusOK,
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           1,
 			expectedSeconds: 2,
 		},
 		{
 			name:            "third retry",
-			statusCode:      http.StatusOK,
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           2,
 			expectedSeconds: 4,
 		},
 		{
 			name:            "fourth retry",
-			statusCode:      http.StatusOK,
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           3,
 			expectedSeconds: 8,
 		},
 		{
 			name:            "should max out at max wait time",
-			statusCode:      http.StatusOK,
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           10,
 			expectedSeconds: 30,
@@ -271,8 +271,8 @@ func TestUsageService_CalculateRetryDuration_ServerBackPressure(t *testing.T) {
 		wantErr         error
 	}{
 		{
-			name:            "should use exponential backoff on 200",
-			statusCode:      http.StatusOK,
+			name:            "should use exponential backoff on 503 and no header",
+			statusCode:      http.StatusServiceUnavailable,
 			headers:         http.Header{},
 			retry:           0,
 			expectedSeconds: 1,

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -255,7 +255,7 @@ func TestUsageService_CalculateRetryDuration_Exp(t *testing.T) {
 			retryDuration, err := usageClient.calculateRetryDuration(tt.statusCode, tt.headers, time.Now(), tt.retry)
 			require.NoError(t, err)
 
-			assert.InDeltaf(t, tt.expectedSeconds, retryDuration.Seconds(), 0.1, "retry duration should be %d seconds", tt.expectedSeconds)
+			assert.InDeltaf(t, tt.expectedSeconds, retryDuration.Seconds(), 1, "retry duration should be %d seconds", tt.expectedSeconds)
 		})
 	}
 }
@@ -306,7 +306,7 @@ func TestUsageService_CalculateRetryDuration_ServerBackPressure(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr.Error())
 			}
 
-			assert.InDeltaf(t, tt.expectedSeconds, retryDuration.Seconds(), 0.1, "retry duration should be %d seconds", tt.expectedSeconds)
+			assert.InDeltaf(t, tt.expectedSeconds, retryDuration.Seconds(), 1, "retry duration should be %d seconds", tt.expectedSeconds)
 		})
 	}
 }

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -3,7 +3,6 @@ package premium
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	cqapi "github.com/cloudquery/cloudquery-api-go"
 	"github.com/stretchr/testify/assert"
@@ -291,16 +290,6 @@ func TestUsageService_CalculateRetryDuration_ServerBackPressure(t *testing.T) {
 			headers:         http.Header{"Retry-After": []string{"5"}},
 			retry:           0,
 			expectedSeconds: 5,
-		},
-		{
-			name:       "should raise an error if the server wants us to wait longer than max wait time",
-			statusCode: http.StatusTooManyRequests,
-			headers:    http.Header{"Retry-After": []string{"40"}},
-			retry:      0,
-			ops: func(client *BatchUpdater) {
-				client.maxWaitTime = 30 * time.Second
-			},
-			wantErr: errors.New("retry-after header exceeds max wait time: 40s > 30s"),
 		},
 	}
 

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -104,7 +104,7 @@ func TestUsageService_WithFlushDuration(t *testing.T) {
 	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
 	require.NoError(t, err)
 
-	usageClient := newClient(ctx, apiClient, WithBatchLimit(uint32(batchSize)), WithFlushEvery(1*time.Millisecond), WithMinimumUpdateDuration(0*time.Millisecond))
+	usageClient := newClient(ctx, apiClient, WithBatchLimit(uint32(batchSize)), WithMaxTimeBetweenFlushes(1*time.Millisecond), WithMinTimeBetweenFlushes(0*time.Millisecond))
 
 	for i := 0; i < 10; i++ {
 		err = usageClient.Increase(ctx, 10)
@@ -127,7 +127,7 @@ func TestUsageService_WithMinimumUpdateDuration(t *testing.T) {
 	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
 	require.NoError(t, err)
 
-	usageClient := newClient(ctx, apiClient, WithBatchLimit(0), WithMinimumUpdateDuration(30*time.Second))
+	usageClient := newClient(ctx, apiClient, WithBatchLimit(0), WithMinTimeBetweenFlushes(30*time.Second))
 
 	for i := 0; i < 10000; i++ {
 		err = usageClient.Increase(ctx, 1)


### PR DESCRIPTION
This will allows a client to update the usage asynchronously. The updater will only call the API when a configurable number of rows have been updated or a timeout is reached. In addition the updater will flush any remaining rows before closing.

If an error is encountered then an exponential backoff up to a max number of retries or a maximum wait time (relative to the start time of the last query) will be followed.

In addition, if the server replies with a status of `429` and includes a `Retry-After` header, then the client will wait that number of seconds before retrying.


It might be worth considering just using a retry library also e.g. https://github.com/avast/retry-go.