### PR TITLE
fix: Fix nil pointer dereference when remaining rows not set

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -227,7 +227,8 @@ func (u *BatchUpdater) HasQuota(ctx context.Context) (bool, error) {
 	if usage.StatusCode() != http.StatusOK {
 		return false, fmt.Errorf("failed to get usage: %s", usage.Status())
 	}
-	return *usage.JSON200.RemainingRows > 0, nil
+	hasQuota := usage.JSON200.RemainingRows == nil || *usage.JSON200.RemainingRows > 0
+	return hasQuota, nil
 }
 
 func (u *BatchUpdater) Close() error {


### PR DESCRIPTION
If remaining rows is not set, it indicates an infinite number of remaining rows (ie. the plugin is free)