### PR TITLE
fix: Fail early on usage client init if token is not set

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -170,6 +170,11 @@ func NewUsageClient(pluginTeam cqapi.PluginTeam, pluginKind cqapi.PluginKind, pl
 
 	tokenClient := auth.NewTokenClient()
 
+	// Fail early if the token is not set
+	if _, err := tokenClient.GetToken(); err != nil {
+		return nil, err
+	}
+
 	// Create a default api client if none was provided
 	if u.apiClient == nil {
 		ac, err := cqapi.NewClientWithResponses(u.url, cqapi.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -11,11 +11,23 @@ import (
 	"time"
 
 	cqapi "github.com/cloudquery/cloudquery-api-go"
+	"github.com/cloudquery/cloudquery-api-go/auth"
 	"github.com/cloudquery/cloudquery-api-go/config"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type MockTokenClient struct {
+}
+
+func (m *MockTokenClient) GetToken() (auth.Token, error) {
+	return auth.Token{}, nil
+}
+
+func (m *MockTokenClient) GetTokenType() auth.TokenType {
+	return auth.BearerToken
+}
 
 func TestUsageService_NewUsageClient_Defaults(t *testing.T) {
 	err := config.SetConfigHome(t.TempDir())
@@ -28,6 +40,7 @@ func TestUsageService_NewUsageClient_Defaults(t *testing.T) {
 		WithPluginTeam("plugin-team"),
 		WithPluginKind("source"),
 		WithPluginName("vault"),
+		withTokenClient(&MockTokenClient{}),
 	)
 	require.NoError(t, err)
 
@@ -55,6 +68,7 @@ func TestUsageService_NewUsageClient_Override(t *testing.T) {
 		WithMaxRetries(10),
 		WithMaxWaitTime(120*time.Second),
 		WithMaxTimeBetweenFlushes(10*time.Second),
+		withTokenClient(&MockTokenClient{}),
 	)
 	require.NoError(t, err)
 
@@ -356,7 +370,7 @@ func newClient(t *testing.T, apiClient *cqapi.ClientWithResponses, ops ...UsageC
 		WithPluginTeam("plugin-team"),
 		WithPluginKind("source"),
 		WithPluginName("vault"),
-		append(ops, withTeamName("team-name"), WithAPIClient(apiClient))...)
+		append(ops, withTeamName("team-name"), WithAPIClient(apiClient), withTokenClient(&MockTokenClient{}))...)
 	require.NoError(t, err)
 
 	return client

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -21,11 +21,11 @@ import (
 type MockTokenClient struct {
 }
 
-func (m *MockTokenClient) GetToken() (auth.Token, error) {
+func (*MockTokenClient) GetToken() (auth.Token, error) {
 	return auth.Token{}, nil
 }
 
-func (m *MockTokenClient) GetTokenType() auth.TokenType {
+func (*MockTokenClient) GetTokenType() auth.TokenType {
 	return auth.BearerToken
 }
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Related to https://github.com/cloudquery/cloudquery-issues/issues/990 (internal issue). Currently if the user is not logged in and you try to initialize the usage client it fails with an error the team is not set and tells the user to run `cloudquery switch` (since `getTeamNameByTokenType` fails).

This PR adds logic to try and get the token during initialization to show a more relevant error message with a hint for the user  to run `cloudquery login`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
