### PR TITLE
feat: Individual Table and Client rate limit

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -67,9 +67,9 @@ func WithStrategy(strategy Strategy) Option {
 	}
 }
 
-func WithSingleTableMaxConcurrency(concurrency int) Option {
+func WithSingleTableMaxConcurrency(concurrency int64) Option {
 	return func(s *Scheduler) {
-		s.singleTableMaxConcurrency = int64(concurrency)
+		s.singleTableMaxConcurrency = concurrency
 	}
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -65,6 +66,12 @@ func WithStrategy(strategy Strategy) Option {
 	}
 }
 
+func WithSingleTableMaxConcurrency(concurrency int) Option {
+	return func(s *Scheduler) {
+		s.singleTableMaxConcurrency = concurrency
+	}
+}
+
 type SyncOption func(*syncClient)
 
 func WithSyncDeterministicCQID(deterministicCQID bool) SyncOption {
@@ -86,8 +93,10 @@ type Scheduler struct {
 	// tableSem is a semaphore that limits the number of concurrent tables being fetched
 	tableSems []*semaphore.Weighted
 	// Logger to call, this logger is passed to the serve.Serve Client, if not defined Serve will create one instead.
-	logger      zerolog.Logger
-	concurrency int
+	logger                    zerolog.Logger
+	concurrency               int
+	singleTableConcurrency    sync.Map
+	singleTableMaxConcurrency int
 }
 
 type syncClient struct {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -72,12 +72,6 @@ func WithSingleTableMaxConcurrency(concurrency int64) Option {
 	}
 }
 
-func WithGlobalRateLimiting() Option {
-	return func(s *Scheduler) {
-		s.globalRateLimiting = true
-	}
-}
-
 type SyncOption func(*syncClient)
 
 func WithSyncDeterministicCQID(deterministicCQID bool) SyncOption {
@@ -105,8 +99,6 @@ type Scheduler struct {
 	singleTableConcurrency sync.Map
 	// The maximum number of go routines that can be spawned for a single table+client pair.
 	singleTableMaxConcurrency int64
-	// A boolean that indicates whether or not to use the global rate limiter. By default rate limiting is assumed to be table+client specific.
-	globalRateLimiting bool
 }
 
 type syncClient struct {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -66,9 +66,9 @@ func WithStrategy(strategy Strategy) Option {
 	}
 }
 
-func WithSingleTableMaxConcurrency(concurrency int64) Option {
+func WithSingleNestedTableMaxConcurrency(concurrency int64) Option {
 	return func(s *Scheduler) {
-		s.singleTableMaxConcurrency = concurrency
+		s.singleNestedTableMaxConcurrency = concurrency
 	}
 }
 
@@ -97,8 +97,8 @@ type Scheduler struct {
 	concurrency int
 	// This Map holds all of the concurrency semaphores for each table+client pair.
 	singleTableConcurrency sync.Map
-	// The maximum number of go routines that can be spawned for a single table+client pair.
-	singleTableMaxConcurrency int64
+	// The maximum number of go routines that can be spawned for a single table+client pair
+	singleNestedTableMaxConcurrency int64
 }
 
 type syncClient struct {
@@ -133,8 +133,8 @@ func NewScheduler(opts ...Option) *Scheduler {
 	s.resourceSem = semaphore.NewWeighted(int64(resourceConcurrency))
 
 	// To preserve backwards compatibility, if singleTableMaxConcurrency is not set, set it to the max concurrency
-	if s.singleTableMaxConcurrency == 0 {
-		s.singleTableMaxConcurrency = int64(tableConcurrency)
+	if s.singleNestedTableMaxConcurrency == 0 {
+		s.singleNestedTableMaxConcurrency = int64(tableConcurrency)
 	}
 	return &s
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -69,7 +69,7 @@ func WithStrategy(strategy Strategy) Option {
 
 func WithSingleTableMaxConcurrency(concurrency int) Option {
 	return func(s *Scheduler) {
-		s.singleTableMaxConcurrency = concurrency
+		s.singleTableMaxConcurrency = int64(concurrency)
 	}
 }
 
@@ -97,7 +97,7 @@ type Scheduler struct {
 	logger                    zerolog.Logger
 	concurrency               int
 	singleTableConcurrency    sync.Map
-	singleTableMaxConcurrency int
+	singleTableMaxConcurrency int64
 }
 
 type syncClient struct {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -30,7 +30,7 @@ const (
 	minTableConcurrency              = 1
 	minResourceConcurrency           = 100
 	otelName                         = "schedule"
-	defaultSingleTableMaxConcurrency = 10
+	defaultSingleTableMaxConcurrency = 50
 )
 
 var ErrNoTables = errors.New("no tables specified for syncing, review `tables` and `skip_tables` in your config and specify at least one table to sync")

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	DefaultConcurrency     = 50000
-	DefaultMaxDepth        = 4
-	minTableConcurrency    = 1
-	minResourceConcurrency = 100
-	otelName               = "schedule"
+	DefaultConcurrency               = 50000
+	DefaultMaxDepth                  = 4
+	minTableConcurrency              = 1
+	minResourceConcurrency           = 100
+	otelName                         = "schedule"
+	defaultSingleTableMaxConcurrency = 10
 )
 
 var ErrNoTables = errors.New("no tables specified for syncing, review `tables` and `skip_tables` in your config and specify at least one table to sync")
@@ -111,9 +112,10 @@ type syncClient struct {
 
 func NewScheduler(opts ...Option) *Scheduler {
 	s := Scheduler{
-		caser:       caser.New(),
-		concurrency: DefaultConcurrency,
-		maxDepth:    DefaultMaxDepth,
+		caser:                     caser.New(),
+		concurrency:               DefaultConcurrency,
+		maxDepth:                  DefaultMaxDepth,
+		singleTableMaxConcurrency: defaultSingleTableMaxConcurrency,
 	}
 	for _, opt := range opts {
 		opt(&s)

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -196,7 +196,7 @@ func (s *syncClient) resolveResourcesDfs(ctx context.Context, table *schema.Tabl
 			relation := relation
 			tableConcurrencyKey := table.Name + "-" + client.ID()
 			// Acquire the semaphore for the table
-			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(tableConcurrencyKey, semaphore.NewWeighted(s.scheduler.singleTableMaxConcurrency))
+			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(tableConcurrencyKey, semaphore.NewWeighted(s.scheduler.singleNestedTableMaxConcurrency))
 			tableSem := tableSemVal.(*semaphore.Weighted)
 			if err := tableSem.Acquire(ctx, 1); err != nil {
 				// This means context was cancelled

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/semaphore"
 )
 
 func (s *syncClient) syncDfs(ctx context.Context, resolvedResources chan<- *schema.Resource) {
@@ -198,10 +199,19 @@ func (s *syncClient) resolveResourcesDfs(ctx context.Context, table *schema.Tabl
 				wg.Wait()
 				return
 			}
+			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(table.Name+"-"+client.ID(), semaphore.NewWeighted(int64(s.scheduler.singleTableMaxConcurrency)))
+			tableSem := tableSemVal.(*semaphore.Weighted)
+			if err := tableSem.Acquire(ctx, 1); err != nil {
+				// This means context was cancelled
+				s.scheduler.tableSems[depth].Release(1)
+				wg.Wait()
+				return
+			}
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				defer s.scheduler.tableSems[depth].Release(1)
+				defer tableSem.Release(1)
 				s.resolveTableDfs(ctx, relation, client, resource, resolvedResources, depth+1)
 			}()
 		}

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -199,7 +199,7 @@ func (s *syncClient) resolveResourcesDfs(ctx context.Context, table *schema.Tabl
 				wg.Wait()
 				return
 			}
-			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(table.Name+"-"+client.ID(), semaphore.NewWeighted(int64(s.scheduler.singleTableMaxConcurrency)))
+			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(table.Name+"-"+client.ID(), semaphore.NewWeighted(s.scheduler.singleTableMaxConcurrency))
 			tableSem := tableSemVal.(*semaphore.Weighted)
 			if err := tableSem.Acquire(ctx, 1); err != nil {
 				// This means context was cancelled

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -194,11 +194,7 @@ func (s *syncClient) resolveResourcesDfs(ctx context.Context, table *schema.Tabl
 		resolvedResources <- resource
 		for _, relation := range resource.Table.Relations {
 			relation := relation
-			// Depending on the source, rate limiting might be done on the table basis (GCP) or client + table (AWS)
 			tableConcurrencyKey := table.Name + "-" + client.ID()
-			if s.scheduler.globalRateLimiting {
-				tableConcurrencyKey = table.Name
-			}
 			// Acquire the semaphore for the table
 			tableSemVal, _ := s.scheduler.singleTableConcurrency.LoadOrStore(tableConcurrencyKey, semaphore.NewWeighted(s.scheduler.singleTableMaxConcurrency))
 			tableSem := tableSemVal.(*semaphore.Weighted)


### PR DESCRIPTION
#### Summary

This pr introduces a rate semaphore that limits the number of simultaneous go routines that can be resolving the same table + client to just 10. Prior to this a single table could be using all of the available concurrency to resolve a single table. This alleviates the problem where nested tables get throttled because the load is not spread across all client/table pairs but is concentrated on a single client and table.

I will update this PR with a benchmark case once #1410 gets merged
