### PR TITLE
fix: Update usage limit message

### DIFF
--- a/premium/monitor.go
+++ b/premium/monitor.go
@@ -12,7 +12,7 @@ type ErrNoQuota struct {
 }
 
 func (e ErrNoQuota) Error() string {
-	return fmt.Sprintf("you have reached this plugin's usage limit for the month, please visit https://cloudquery.io/teams/%s/billing to upgrade your plan or increase the limit", e.team)
+	return fmt.Sprintf("You have reached this plugin's usage limit for the month, please visit https://cloudquery.io/teams/%s/billing to upgrade your plan or increase the limit.", e.team)
 }
 
 const DefaultQuotaCheckInterval = 30 * time.Second

--- a/premium/monitor.go
+++ b/premium/monitor.go
@@ -3,10 +3,17 @@ package premium
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
-var ErrNoQuota = errors.New("no remaining quota for the month, please increase your usage limit if you want to continue syncing this plugin")
+type ErrNoQuota struct {
+	team string
+}
+
+func (e ErrNoQuota) Error() string {
+	return fmt.Sprintf("you have reached this plugin's usage limit for the month, please visit https://cloudquery.io/teams/%s/billing to upgrade your plan or increase the limit", e.team)
+}
 
 const DefaultQuotaCheckInterval = 30 * time.Second
 const DefaultMaxQuotaFailures = 10 // 5 minutes
@@ -60,7 +67,7 @@ func (qc quotaChecker) checkInitialQuota(ctx context.Context) error {
 	}
 
 	if !hasQuota {
-		return ErrNoQuota
+		return ErrNoQuota{team: qc.qm.TeamName()}
 	}
 
 	return nil
@@ -90,7 +97,7 @@ func (qc quotaChecker) startQuotaMonitor(ctx context.Context) context.Context {
 				consecutiveFailures = 0
 				hasQuotaErrors = nil
 				if !hasQuota {
-					cancelWithCause(ErrNoQuota)
+					cancelWithCause(ErrNoQuota{team: qc.qm.TeamName()})
 					return
 				}
 			}

--- a/premium/monitor_test.go
+++ b/premium/monitor_test.go
@@ -31,7 +31,7 @@ func (f *fakeQuotaMonitor) HasQuota(_ context.Context) (bool, error) {
 	return resp.hasQuota, resp.err
 }
 
-func (f *fakeQuotaMonitor) TeamName() string {
+func (*fakeQuotaMonitor) TeamName() string {
 	return "test"
 }
 

--- a/premium/monitor_test.go
+++ b/premium/monitor_test.go
@@ -31,6 +31,10 @@ func (f *fakeQuotaMonitor) HasQuota(_ context.Context) (bool, error) {
 	return resp.hasQuota, resp.err
 }
 
+func (f *fakeQuotaMonitor) TeamName() string {
+	return "test"
+}
+
 func TestWithCancelOnQuotaExceeded_NoInitialQuota(t *testing.T) {
 	ctx := context.Background()
 
@@ -54,7 +58,7 @@ func TestWithCancelOnQuotaExceeded_NoQuota(t *testing.T) {
 
 	<-ctx.Done()
 	cause := context.Cause(ctx)
-	require.Equal(t, ErrNoQuota, cause)
+	require.ErrorIs(t, ErrNoQuota{team: "test"}, cause)
 }
 
 func TestWithCancelOnQuotaCheckConsecutiveFailures(t *testing.T) {

--- a/premium/tables.go
+++ b/premium/tables.go
@@ -4,8 +4,11 @@ import "github.com/cloudquery/plugin-sdk/v4/schema"
 
 // ContainsPaidTables returns true if any of the tables are paid
 func ContainsPaidTables(tables schema.Tables) bool {
+	if tables == nil {
+		return false
+	}
 	for _, t := range tables {
-		if t.IsPaid {
+		if t.IsPaid || ContainsPaidTables(t.Relations) {
 			return true
 		}
 	}

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -33,6 +33,8 @@ type TokenClient interface {
 }
 
 type QuotaMonitor interface {
+	// TeamName returns the team name
+	TeamName() string
 	// HasQuota returns true if the quota has not been exceeded
 	HasQuota(context.Context) (bool, error)
 }
@@ -241,6 +243,10 @@ func (u *BatchUpdater) Increase(rows uint32) error {
 	return nil
 }
 
+func (u *BatchUpdater) TeamName() string {
+	return u.teamName
+}
+
 func (u *BatchUpdater) HasQuota(ctx context.Context) (bool, error) {
 	u.logger.Debug().Str("url", u.url).Str("team", u.teamName).Str("pluginTeam", u.pluginTeam).Str("pluginKind", string(u.pluginKind)).Str("pluginName", u.pluginName).Msg("checking quota")
 	usage, err := u.apiClient.GetTeamPluginUsageWithResponse(ctx, u.teamName, u.pluginTeam, u.pluginKind, u.pluginName)
@@ -250,6 +256,7 @@ func (u *BatchUpdater) HasQuota(ctx context.Context) (bool, error) {
 	if usage.StatusCode() != http.StatusOK {
 		return false, fmt.Errorf("failed to get usage: %s", usage.Status())
 	}
+
 	hasQuota := usage.JSON200.RemainingRows == nil || *usage.JSON200.RemainingRows > 0
 	return hasQuota, nil
 }


### PR DESCRIPTION
Updates the usage limit message to also account for the case where the free quota limit is reached, and give users a clear action to perform.