### PR TITLE
fix(tests): Find empty columns for JSON types

### DIFF
--- a/schema/validators.go
+++ b/schema/validators.go
@@ -18,7 +18,7 @@ func FindEmptyColumns(table *Table, records []arrow.Record) []string {
 					if arrow.TypeEqual(arr.DataType(), types.ExtensionTypes.JSON) {
 						// JSON column shouldn't be empty
 						val := arr.GetOneForMarshal(i).(json.RawMessage)
-						if len(val) == 0 || string(val) == "null" || string(val) == "{}" || string(val) == "[]" {
+						if isEmptyJSON(val) {
 							continue
 						}
 					}
@@ -38,4 +38,16 @@ func FindEmptyColumns(table *Table, records []arrow.Record) []string {
 		}
 	}
 	return emptyColumns
+}
+
+func isEmptyJSON(msg json.RawMessage) bool {
+	if len(msg) == 0 {
+		return true
+	}
+	switch string(msg) {
+	case "null", "{}", "[]":
+		return true
+	default:
+		return false
+	}
 }

--- a/schema/validators_test.go
+++ b/schema/validators_test.go
@@ -1,0 +1,56 @@
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v14/arrow"
+	"github.com/apache/arrow/go/v14/arrow/array"
+	"github.com/apache/arrow/go/v14/arrow/memory"
+	"github.com/cloudquery/plugin-sdk/v4/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindEmptyColumns(t *testing.T) {
+	table := TestTable("test", TestSourceOptions{})
+	tg := NewTestDataGenerator()
+	record := tg.Generate(table, GenTestDataOptions{
+		MaxRows:  1,
+		NullRows: true,
+	})
+	v := FindEmptyColumns(table, []arrow.Record{record})
+	require.NotEmpty(t, v)
+	require.Len(t, v, len(table.Columns)-1) // exclude "id"
+}
+
+func TestFindEmptyColumnsNotEmpty(t *testing.T) {
+	table := TestTable("test", TestSourceOptions{})
+	tg := NewTestDataGenerator()
+	record := tg.Generate(table, GenTestDataOptions{
+		MaxRows:  1,
+		NullRows: false,
+	})
+	v := FindEmptyColumns(table, []arrow.Record{record})
+	require.Empty(t, v)
+}
+
+func TestFindEmptyColumnsJSON(t *testing.T) {
+	table := &Table{
+		Name: "test",
+		Columns: ColumnList{
+			{Name: "json", Type: types.ExtensionTypes.JSON},
+		},
+	}
+	sc := table.ToArrowSchema()
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, sc)
+	err := bldr.Field(0).UnmarshalJSON([]byte(`[{}]`))
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshal json for column: %v", err))
+	}
+	records := []arrow.Record{bldr.NewRecord()}
+	bldr.Release()
+
+	v := FindEmptyColumns(table, records)
+	require.NotEmpty(t, v)
+	require.Len(t, v, 1)
+}


### PR DESCRIPTION
I'm not sure if there's a better way, but this seems to work for me.

~Still testing cases.~

Fixes https://github.com/cloudquery/cloudquery/issues/15707