### PR TITLE
feat: Expose otel headers and url_path as flags

### DIFF
--- a/serve/plugin.go
+++ b/serve/plugin.go
@@ -169,7 +169,7 @@ func (s *PluginServe) newCmdPluginServe() *cobra.Command {
 				if otelEndpointURLPath != "" {
 					opts = append(opts, otlptracehttp.WithURLPath(otelEndpointURLPath))
 				}
-				
+
 				client := otlptracehttp.NewClient(opts...)
 				exp, err := otlptrace.New(cmd.Context(), client)
 				if err != nil {


### PR DESCRIPTION
This is a minor improvement to expose otel headers and url_path as flags. I tested it with OpenObserve - https://openobserve.ai/docs/ingestion/traces/go/#clone 

Example running a plugin with OpenObserve running locally

```
go run main.go serve --otel-endpoint localhost:5080 --otel-endpoint-headers "Authorization: Basic TOKEN" --otel-endpoint-insecure --otel-endpoint-urlpath "/api/default/v1/traces"
```

<img width="1452" alt="image" src="https://github.com/cloudquery/plugin-sdk/assets/16490766/966bee3c-ade7-42a4-ba7d-568fd912b81d">
