### PR TITLE
fix: Eternal recursion in `scalar.MonthInterval`

### DIFF
--- a/scalar/interval.go
+++ b/scalar/interval.go
@@ -67,7 +67,7 @@ func (s *MonthInterval) Set(value any) error {
 		if v == nil {
 			return s.Int.Set(nil)
 		}
-		return s.Set(value)
+		return s.Set(*v)
 	case map[string]any:
 		b, _ := json.Marshal(v)
 		return s.Set(b)


### PR DESCRIPTION
Extracted from https://github.com/cloudquery/plugin-sdk/pull/1476