### PR TITLE
fix: Verify `nil` value consistently

### DIFF
--- a/scalar/inet.go
+++ b/scalar/inet.go
@@ -92,17 +92,23 @@ func (s *Inet) Set(val any) error {
 		}
 		s.Value = ipnet
 	case *net.IPNet:
-		if err := s.Set(*value); err != nil {
-			return err
+		if value == nil {
+			s.Valid = false
+			return nil
 		}
+		return s.Set(*value)
 	case *net.IP:
-		if err := s.Set(*value); err != nil {
-			return err
+		if value == nil {
+			s.Valid = false
+			return nil
 		}
+		return s.Set(*value)
 	case *string:
-		if err := s.Set(*value); err != nil {
-			return err
+		if value == nil {
+			s.Valid = false
+			return nil
 		}
+		return s.Set(*value)
 	default:
 		if tv, ok := value.(encoding.TextMarshaler); ok {
 			text, err := tv.MarshalText()

--- a/scalar/inet_test.go
+++ b/scalar/inet_test.go
@@ -72,7 +72,7 @@ func TestInetSet(t *testing.T) {
 			return &b
 		}("127.0.0.1"), result: Inet{Value: mustParseInet(t, "127.0.0.1"), Valid: true}},
 		{source: &Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}, result: Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}},
-		{source: (*net.HardwareAddr)(nil), result: Inet{Value: nil, Valid: false}},
+		{source: (*net.IPNet)(nil), result: Inet{Value: nil, Valid: false}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/inet_test.go
+++ b/scalar/inet_test.go
@@ -72,6 +72,7 @@ func TestInetSet(t *testing.T) {
 			return &b
 		}("127.0.0.1"), result: Inet{Value: mustParseInet(t, "127.0.0.1"), Valid: true}},
 		{source: &Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}, result: Inet{Value: &net.IPNet{IP: net.ParseIP("::ffff:0.0.0.0"), Mask: net.CIDRMask(104, 128)}, Valid: true}},
+		{source: (*net.HardwareAddr)(nil), result: Inet{Value: nil, Valid: false}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scalar/interval.go
+++ b/scalar/interval.go
@@ -65,7 +65,8 @@ func (s *MonthInterval) Set(value any) error {
 		return nil
 	case *string:
 		if v == nil {
-			return s.Int.Set(nil)
+			s.Valid = false
+			return nil
 		}
 		return s.Set(*v)
 	case map[string]any:

--- a/scalar/mac.go
+++ b/scalar/mac.go
@@ -44,6 +44,7 @@ func (s *Mac) Get() any {
 
 func (s *Mac) Set(val any) error {
 	if val == nil {
+		s.Valid = false
 		return nil
 	}
 
@@ -68,11 +69,13 @@ func (s *Mac) Set(val any) error {
 		s.Value = addr
 	case *net.HardwareAddr:
 		if value == nil {
+			s.Valid = false
 			return nil
 		}
 		return s.Set(*value)
 	case *string:
 		if value == nil {
+			s.Valid = false
 			return nil
 		}
 		return s.Set(*value)


### PR DESCRIPTION
Instead of https://github.com/cloudquery/plugin-sdk/pull/1476
Closes https://github.com/cloudquery/plugin-sdk/issues/1475
The `typed nil` also can be observed in https://github.com/cloudquery/cloudquery/pull/16221