### PR TITLE
feat: Expose Migration test for new special case for moving to `_cq_id` as only primary key

### DIFF
--- a/plugin/testing_write.go
+++ b/plugin/testing_write.go
@@ -42,6 +42,7 @@ type SafeMigrations struct {
 	RemoveColumn        bool
 	RemoveColumnNotNull bool
 	ChangeColumn        bool
+	MovePKToCQOnly      bool
 }
 
 type WriterTestSuiteTests struct {

--- a/plugin/testing_write_migrate.go
+++ b/plugin/testing_write_migrate.go
@@ -230,6 +230,32 @@ func (s *WriterTestSuite) testMigrate(
 		}
 	})
 
+	t.Run("move_to_cq_id_only"+suffix, func(t *testing.T) {
+		if !forceMigrate && !s.tests.SafeMigrations.MovePKToCQOnly {
+			t.Skip("skipping test: move_to_cq_id_only")
+		}
+		tableName := "move_to_cq_id_only" + suffix + "_" + tableUUIDSuffix()
+		source := &schema.Table{
+			Name: tableName,
+			Columns: schema.ColumnList{
+				{Name: "_cq_id", Type: types.ExtensionTypes.UUID, NotNull: true, Unique: true},
+				{Name: "id", Type: arrow.PrimitiveTypes.Int64, PrimaryKey: true},
+				{Name: "uuid", Type: types.ExtensionTypes.UUID},
+				{Name: "bool", Type: arrow.FixedWidthTypes.Boolean, NotNull: true},
+			}}
+		target := &schema.Table{
+			Name: tableName,
+			Columns: schema.ColumnList{
+				{Name: "_cq_id", Type: types.ExtensionTypes.UUID, NotNull: true, Unique: true, PrimaryKey: true},
+				{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+				{Name: "uuid", Type: types.ExtensionTypes.UUID},
+				{Name: "bool", Type: arrow.FixedWidthTypes.Boolean, NotNull: true},
+			}}
+		if err := s.migrate(ctx, target, source, s.tests.SafeMigrations.MovePKToCQOnly, forceMigrate); err != nil {
+			t.Fatalf("failed to migrate move_to_cq_id_only: %v", err)
+		}
+	})
+
 	t.Run("double_migration", func(t *testing.T) {
 		if forceMigrate {
 			t.Skip("double migration test has sense only for safe migrations")

--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"encoding/base64"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -252,16 +251,7 @@ func (tg *TestDataGenerator) Generate(table *Table, opts GenTestDataOptions) arr
 		records = append(records, bldr.NewRecord())
 		bldr.Release()
 	}
-	if indices := sc.FieldIndices(CqIDColumn.Name); len(indices) > 0 {
-		cqIDIndex := indices[0]
-		sort.Slice(records, func(i, j int) bool {
-			firstUUID := records[i].Column(cqIDIndex).(*types.UUIDArray).Value(0).String()
-			secondUUID := records[j].Column(cqIDIndex).(*types.UUIDArray).Value(0).String()
-			return strings.Compare(firstUUID, secondUUID) < 0
-		})
-	}
 
-	// now we have sorted 1-row-records. Transform them into a single record with opts.MaxRows rows
 	arrowTable := array.NewTableFromRecords(sc, records)
 	columns := make([]arrow.Array, sc.NumFields())
 	for n := 0; n < sc.NumFields(); n++ {


### PR DESCRIPTION
#### Summary

Destinations can now verify the new `MoveToCQIDPrimaryKey` change type that was introduced in #1470 

Depends on #1479 


