### PR TITLE
chore: Remove Codecov Action

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -44,9 +44,3 @@ jobs:
           path: |
             .delta.*
             pr_number
-      - name: Generate coverage report
-        if: always() && matrix.os == 'large-ubuntu-plugin-sdk'
-        run: go test -race -coverprofile=coverage.out -covermode=atomic  ./...
-      - name: Upload coverage to Codecov
-        if: always() && matrix.os == 'large-ubuntu-plugin-sdk'
-        uses: codecov/codecov-action@bbeaa140357942e4e8d8e15f1cd2f4e612f64c59


### PR DESCRIPTION
#### Summary

We do not use Codecov anymore, so no reason to run the action every commit