### PR TITLE
fix: Better build overrides

### DIFF
--- a/plugin/options.go
+++ b/plugin/options.go
@@ -29,12 +29,6 @@ func WithJSONSchema(schema string) Option {
 	}
 }
 
-func WithStaticLinking() Option {
-	return func(p *Plugin) {
-		p.staticLinking = true
-	}
-}
-
 func WithKind(kind string) Option {
 	k := Kind(kind)
 	err := k.Validate()

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -63,8 +63,6 @@ type Plugin struct {
 	targets []BuildTarget
 	// Called upon init call to validate and init configuration
 	newClient NewClientFunc
-	// staticLinking true if C libraries should be added to compiled executable
-	staticLinking bool
 	// Logger to call, this logger is passed to the serve.Serve Client, if not defined Serve will create one instead.
 	logger zerolog.Logger
 	// mu is a mutex that limits the number of concurrent init/syncs (can only be one at a time)
@@ -170,11 +168,6 @@ func (p *Plugin) OnSyncFinish(ctx context.Context) error {
 		return v.OnSyncFinish(ctx)
 	}
 	return nil
-}
-
-// IsStaticLinkingEnabled whether static linking is to be enabled
-func (p *Plugin) IsStaticLinkingEnabled() bool {
-	return p.staticLinking
 }
 
 func (p *Plugin) Targets() []BuildTarget {

--- a/plugin/plugin_package.go
+++ b/plugin/plugin_package.go
@@ -36,14 +36,21 @@ const (
 type BuildTarget struct {
 	OS   string   `json:"os"`
 	Arch string   `json:"arch"`
+	CGO  bool     `json:"cgo"`
 	Env  []string `json:"env"`
 }
 
 func (t BuildTarget) GetEnvVariables() []string {
+	cgo := "CGO_ENABLED="
+	if t.CGO {
+		cgo += "1"
+	} else {
+		cgo += "0"
+	}
 	return append([]string{
 		"GOOS=" + t.OS,
 		"GOARCH=" + t.Arch,
-		"CGO_ENABLED=0", // default is this, but adding `CGO_ENABLED=1` to BuildTarget.Env solves the issue
+		cgo, // default is to tool at the param. Can be overridden by adding `CGO_ENABLED=1` to BuildTarget.Env
 	}, t.Env...)
 }
 

--- a/plugin/plugin_package.go
+++ b/plugin/plugin_package.go
@@ -40,7 +40,7 @@ type BuildTarget struct {
 	Env  []string `json:"env"`
 }
 
-func (t BuildTarget) GetEnvVariables() []string {
+func (t BuildTarget) EnvVariables() []string {
 	cgo := "CGO_ENABLED="
 	if t.CGO {
 		cgo += "1"

--- a/plugin/plugin_package.go
+++ b/plugin/plugin_package.go
@@ -34,14 +34,23 @@ const (
 )
 
 type BuildTarget struct {
-	OS   string `json:"os"`
-	Arch string `json:"arch"`
+	OS   string   `json:"os"`
+	Arch string   `json:"arch"`
+	Env  []string `json:"env"`
+}
+
+func (t BuildTarget) GetEnvVariables() []string {
+	return append([]string{
+		"GOOS=" + t.OS,
+		"GOARCH=" + t.Arch,
+		"CGO_ENABLED=0", // default is this, but adding `CGO_ENABLED=1` to BuildTarget.Env solves the issue
+	}, t.Env...)
 }
 
 var DefaultBuildTargets = []BuildTarget{
-	{GoOSLinux, GoArchAmd64},
-	{GoOSLinux, GoArchArm64},
-	{GoOSWindows, GoArchAmd64},
-	{GoOSDarwin, GoArchAmd64},
-	{GoOSDarwin, GoArchArm64},
+	{OS: GoOSLinux, Arch: GoArchAmd64},
+	{OS: GoOSLinux, Arch: GoArchArm64},
+	{OS: GoOSWindows, Arch: GoArchAmd64},
+	{OS: GoOSDarwin, Arch: GoArchAmd64},
+	{OS: GoOSDarwin, Arch: GoArchArm64},
 }

--- a/serve/package.go
+++ b/serve/package.go
@@ -107,17 +107,14 @@ func (s *PluginServe) writeTablesJSON(ctx context.Context, dir string) error {
 	return os.WriteFile(outputPath, buffer.Bytes(), 0644)
 }
 
-func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersion string) (*TargetBuild, error) {
-	pluginFileName := fmt.Sprintf("plugin-%s-%s-%s-%s", s.plugin.Name(), pluginVersion, goos, goarch)
+func (s *PluginServe) build(pluginDirectory string, target plugin.BuildTarget, distPath, pluginVersion string) (*TargetBuild, error) {
+	pluginFileName := fmt.Sprintf("plugin-%s-%s-%s-%s", s.plugin.Name(), pluginVersion, target.OS, target.Arch)
 	pluginPath := path.Join(distPath, pluginFileName)
 	importPath, err := s.getModuleName(pluginDirectory)
 	if err != nil {
 		return nil, err
 	}
 	ldFlags := fmt.Sprintf("-s -w -X %[1]s/plugin.Version=%[2]s -X %[1]s/resources/plugin.Version=%[2]s", importPath, pluginVersion)
-	if s.plugin.IsStaticLinkingEnabled() && strings.EqualFold(goos, plugin.GoOSLinux) {
-		ldFlags += " -linkmode external -extldflags=-static"
-	}
 	args := []string{"build", "-o", pluginPath}
 	args = append(args, "-buildmode=exe")
 	args = append(args, "-ldflags", ldFlags)
@@ -125,10 +122,7 @@ func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersi
 	cmd.Dir = pluginDirectory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOOS=%s", goos))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOARCH=%s", goarch))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_ENABLED=%v", getEnvOrDefault("CGO_ENABLED", "0"))) // default to CGO_ENABLED=0
+	cmd.Env = append(os.Environ(), target.GetEnvVariables()...)
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("failed to build plugin with `go %v`: %w", args, err)
 	}
@@ -178,8 +172,8 @@ func (s *PluginServe) build(pluginDirectory, goos, goarch, distPath, pluginVersi
 	}
 
 	return &TargetBuild{
-		OS:       goos,
-		Arch:     goarch,
+		OS:       target.OS,
+		Arch:     target.Arch,
 		Path:     targetZip,
 		Checksum: "sha256:" + checksum,
 	}, nil
@@ -421,7 +415,7 @@ func (s *PluginServe) newCmdPluginPackage() *cobra.Command {
 			targets := []TargetBuild{}
 			for _, target := range s.plugin.Targets() {
 				fmt.Println("Building for OS: " + target.OS + ", ARCH: " + target.Arch)
-				targetBuild, err := s.build(pluginDirectory, target.OS, target.Arch, distPath, pluginVersion)
+				targetBuild, err := s.build(pluginDirectory, target, distPath, pluginVersion)
 				if err != nil {
 					return fmt.Errorf("failed to build plugin for %s/%s: %w", target.OS, target.Arch, err)
 				}

--- a/serve/package.go
+++ b/serve/package.go
@@ -122,7 +122,7 @@ func (s *PluginServe) build(pluginDirectory string, target plugin.BuildTarget, d
 	cmd.Dir = pluginDirectory
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), target.GetEnvVariables()...)
+	cmd.Env = append(os.Environ(), target.EnvVariables()...)
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("failed to build plugin with `go %v`: %w", args, err)
 	}


### PR DESCRIPTION
Instead of passing `static` option we should allow for env var values overrides in the package call.