### PR TITLE
fix: Remove access to parent tests in test suite

### DIFF
--- a/plugin/testing_write.go
+++ b/plugin/testing_write.go
@@ -143,10 +143,10 @@ func TestWriterSuiteRunner(t *testing.T, p *Plugin, tests WriterTestSuiteTests, 
 			t.Skip("skipping " + t.Name())
 		}
 		t.Run("Basic", func(t *testing.T) {
-			suite.testDeleteStaleBasic(t, ctx)
+			suite.testDeleteStaleBasic(ctx, t)
 		})
 		t.Run("All", func(t *testing.T) {
-			suite.testDeleteStaleAll(t, ctx)
+			suite.testDeleteStaleAll(ctx, t)
 		})
 	})
 
@@ -155,10 +155,10 @@ func TestWriterSuiteRunner(t *testing.T, p *Plugin, tests WriterTestSuiteTests, 
 			t.Skip("skipping " + t.Name())
 		}
 		t.Run("Basic", func(t *testing.T) {
-			suite.testDeleteRecordBasic(t, ctx)
+			suite.testDeleteRecordBasic(ctx, t)
 		})
 		t.Run("DeleteAll", func(t *testing.T) {
-			suite.testDeleteAllRecords(t, ctx)
+			suite.testDeleteAllRecords(ctx, t)
 		})
 	})
 

--- a/plugin/testing_write.go
+++ b/plugin/testing_write.go
@@ -10,7 +10,6 @@ import (
 )
 
 type WriterTestSuite struct {
-	t     *testing.T
 	tests WriterTestSuiteTests
 
 	plugin *Plugin
@@ -95,7 +94,6 @@ func WithRandomSeed(seed int64) func(o *WriterTestSuite) {
 
 func TestWriterSuiteRunner(t *testing.T, p *Plugin, tests WriterTestSuiteTests, opts ...func(o *WriterTestSuite)) {
 	suite := &WriterTestSuite{
-		t:      t,
 		tests:  tests,
 		plugin: p,
 	}
@@ -145,10 +143,10 @@ func TestWriterSuiteRunner(t *testing.T, p *Plugin, tests WriterTestSuiteTests, 
 			t.Skip("skipping " + t.Name())
 		}
 		t.Run("Basic", func(t *testing.T) {
-			suite.testDeleteStaleBasic(ctx)
+			suite.testDeleteStaleBasic(t, ctx)
 		})
 		t.Run("All", func(t *testing.T) {
-			suite.testDeleteStaleAll(ctx)
+			suite.testDeleteStaleAll(t, ctx)
 		})
 	})
 
@@ -157,10 +155,10 @@ func TestWriterSuiteRunner(t *testing.T, p *Plugin, tests WriterTestSuiteTests, 
 			t.Skip("skipping " + t.Name())
 		}
 		t.Run("Basic", func(t *testing.T) {
-			suite.testDeleteRecordBasic(ctx)
+			suite.testDeleteRecordBasic(t, ctx)
 		})
 		t.Run("DeleteAll", func(t *testing.T) {
-			suite.testDeleteAllRecords(ctx)
+			suite.testDeleteAllRecords(t, ctx)
 		})
 	})
 

--- a/plugin/testing_write_delete.go
+++ b/plugin/testing_write_delete.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (s *WriterTestSuite) testDeleteStaleBasic(t *testing.T, ctx context.Context) {
+func (s *WriterTestSuite) testDeleteStaleBasic(ctx context.Context, t *testing.T) {
 	r := require.New(t)
 	tableName := s.tableNameForTest("delete_basic")
 	syncTime := time.Now().UTC().Truncate(s.genDatOptions.TimePrecision).
@@ -79,7 +79,7 @@ func (s *WriterTestSuite) testDeleteStaleBasic(t *testing.T, ctx context.Context
 	r.Emptyf(RecordsDiff(table.ToArrowSchema(), records, []arrow.Record{record2}), "record differs after second delete stale")
 }
 
-func (s *WriterTestSuite) testDeleteStaleAll(t *testing.T, ctx context.Context) {
+func (s *WriterTestSuite) testDeleteStaleAll(ctx context.Context, t *testing.T) {
 	const rowsPerRecord = 10
 
 	r := require.New(t)
@@ -146,7 +146,7 @@ func (s *WriterTestSuite) testDeleteStaleAll(t *testing.T, ctx context.Context) 
 	r.Emptyf(RecordsDiff(table.ToArrowSchema(), readRecords, []arrow.Record{nullRecord}), "record differs")
 }
 
-func (s *WriterTestSuite) testDeleteRecordBasic(t *testing.T, ctx context.Context) {
+func (s *WriterTestSuite) testDeleteRecordBasic(ctx context.Context, t *testing.T) {
 	r := require.New(t)
 	tableName := s.tableNameForTest("delete_all_rows")
 	syncTime := time.Now().UTC().Truncate(s.genDatOptions.TimePrecision).
@@ -241,7 +241,7 @@ func (s *WriterTestSuite) testDeleteRecordBasic(t *testing.T, ctx context.Contex
 	r.EqualValuesf(0, TotalRows(records), "unexpected amount of items after delete with match")
 }
 
-func (s *WriterTestSuite) testDeleteAllRecords(t *testing.T, ctx context.Context) {
+func (s *WriterTestSuite) testDeleteAllRecords(ctx context.Context, t *testing.T) {
 	r := require.New(t)
 	tableName := s.tableNameForTest("delete_all_records")
 	syncTime := time.Now().UTC().Truncate(s.genDatOptions.TimePrecision).


### PR DESCRIPTION
Saving `*testing.T` inside the `Suite` to use it later in sub-tests results in this error if we have a failed test:

> testing.go:1490: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test

We shouldn't get this error.

Other parts of the test suite return `error` (signature is `func (s *WriterTestSuite) testName(context.Context) error`) and we do a simple `t.Fatal` in the main test body, but for DeleteStale tests we use `testify/require` inside the test so we need to access `*testing.T`.