### PR TITLE
feat: Enhance test suite

### DIFF
--- a/plugin/testing_write_delete.go
+++ b/plugin/testing_write_delete.go
@@ -91,7 +91,7 @@ func (s *WriterTestSuite) testDeleteStaleAll(ctx context.Context, t *testing.T) 
 	table.Columns[table.Columns.Index("id")].PrimaryKey = true
 	r.NoErrorf(s.plugin.writeOne(ctx, &message.WriteMigrateTable{Table: table}), "failed to create table")
 
-	tg := schema.NewTestDataGenerator()
+	tg := schema.NewTestDataGenerator(0)
 	normalRecord := tg.Generate(table, schema.GenTestDataOptions{
 		MaxRows:       rowsPerRecord,
 		TimePrecision: s.genDatOptions.TimePrecision,

--- a/plugin/testing_write_insert.go
+++ b/plugin/testing_write_insert.go
@@ -89,7 +89,7 @@ func (s *WriterTestSuite) testInsertAll(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
-	tg := schema.NewTestDataGenerator()
+	tg := schema.NewTestDataGenerator(0)
 	normalRecord := tg.Generate(table, schema.GenTestDataOptions{
 		MaxRows:       rowsPerRecord,
 		TimePrecision: s.genDatOptions.TimePrecision,

--- a/plugin/testing_write_migrate.go
+++ b/plugin/testing_write_migrate.go
@@ -124,7 +124,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.AddColumn {
 			t.Skip("skipping test: add_column")
 		}
-		tableName := "add_column" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_add_column" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -151,7 +151,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.AddColumnNotNull {
 			t.Skip("skipping test: add_column_not_null")
 		}
-		tableName := "add_column_not_null" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_add_column_not_null" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -178,7 +178,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.RemoveColumn {
 			t.Skip("skipping test: remove_column")
 		}
-		tableName := "remove_column" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_remove_column" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -202,7 +202,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.RemoveColumnNotNull {
 			t.Skip("skipping test: remove_column_not_null")
 		}
-		tableName := "remove_column_not_null" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_remove_column_not_null" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -227,7 +227,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.ChangeColumn {
 			t.Skip("skipping test: change_column")
 		}
-		tableName := "change_column" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_change_column" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -252,7 +252,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.MovePKToCQOnly {
 			t.Skip("skipping test: move_to_cq_id_only")
 		}
-		tableName := "move_to_cq_id_only" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_move_to_cq_id_only" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -278,7 +278,7 @@ func (s *WriterTestSuite) testMigrate(
 		if !forceMigrate && !s.tests.SafeMigrations.MovePKToCQOnly {
 			t.Skip("skipping test: move_to_cq_id_only_adding_pk")
 		}
-		tableName := "move_to_cq_id_only_adding_pkc" + suffix + "_" + tableUUIDSuffix()
+		tableName := "cq_move_to_cq_id_only_adding_pkc" + suffix + "_" + tableUUIDSuffix()
 		source := &schema.Table{
 			Name: tableName,
 			Columns: schema.ColumnList{
@@ -305,7 +305,7 @@ func (s *WriterTestSuite) testMigrate(
 		if forceMigrate {
 			t.Skip("double migration test has sense only for safe migrations")
 		}
-		tableName := "double_migration_" + tableUUIDSuffix()
+		tableName := "cq_double_migration_" + tableUUIDSuffix()
 		table := schema.TestTable(tableName, s.genDatOptions)
 		// s.migrate will perform create->write->migrate->write
 		require.NoError(t, s.migrate(ctx, table, table, true, false))

--- a/plugin/testing_write_upsert.go
+++ b/plugin/testing_write_upsert.go
@@ -78,7 +78,7 @@ func (s *WriterTestSuite) testUpsertAll(ctx context.Context) error {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
 
-	tg := schema.NewTestDataGenerator()
+	tg := schema.NewTestDataGenerator(0)
 	normalRecord := tg.Generate(table, schema.GenTestDataOptions{
 		MaxRows:       rowsPerRecord,
 		TimePrecision: s.genDatOptions.TimePrecision,

--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -204,11 +204,10 @@ type TestDataGenerator struct {
 	colToRnd map[string]*rand.Rand
 }
 
-func NewTestDataGenerator() *TestDataGenerator {
-	const seed = 0 // we can add an argument for this in the future, if necessary
+func NewTestDataGenerator(randomSeed uint64) *TestDataGenerator {
 	return &TestDataGenerator{
-		counter:  0,
-		seed:     seed,
+		counter:  int(randomSeed),
+		seed:     randomSeed,
 		colToRnd: map[string]*rand.Rand{},
 	}
 }


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Enhance the destination test suite
- Run a double migration when syncing a safe migration. This will catch any issues or incomplete migrations that occurred
- Add more tests cases for the automigration to `_cq_id` 

In order to enable this functionality the `TestDataGenerator` needed to be enhanced to enable setting of the `seed` and `counter` so that records would not collide when tests use multiple passes