### PR TITLE
fix: Support list scalars from JSON

### DIFF
--- a/scalar/list.go
+++ b/scalar/list.go
@@ -106,7 +106,7 @@ func (s *List) Set(val any) error {
 
 	case []byte:
 		var x []any
-		if err := json.Unmarshal([]byte(value), &x); err != nil {
+		if err := json.Unmarshal(value, &x); err != nil {
 			return err
 		}
 		length := len(x)

--- a/scalar/list_test.go
+++ b/scalar/list_test.go
@@ -37,6 +37,15 @@ func TestListSet(t *testing.T) {
 			&Inet{Valid: false},
 			&Inet{Valid: false},
 		}, Valid: true, Type: arrow.ListOf(types.ExtensionTypes.Inet)}},
+		{source: `[1, 2]`, result: List{Value: []Scalar{
+			&Int{Value: 1, Valid: true},
+			&Int{Value: 2, Valid: true},
+		}, Valid: true, Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)}},
+		{source: `[1, null, 2]`, result: List{Value: []Scalar{
+			&Int{Value: 1, Valid: true},
+			&Int{Valid: false},
+			&Int{Value: 2, Valid: true},
+		}, Valid: true, Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)}},
 	}
 
 	for i, tt := range successfulTests {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -11,11 +11,8 @@ import (
 
 	"github.com/apache/arrow/go/v15/arrow"
 
-	"github.com/apache/arrow/go/v15/arrow/array"
-	"github.com/apache/arrow/go/v15/arrow/memory"
 	"github.com/cloudquery/plugin-sdk/v4/caser"
 	"github.com/cloudquery/plugin-sdk/v4/message"
-	"github.com/cloudquery/plugin-sdk/v4/scalar"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
@@ -225,10 +222,7 @@ func (s *Scheduler) Sync(ctx context.Context, client schema.ClientMeta, tables s
 
 func resourceToRecord(resource *schema.Resource) arrow.Record {
 	vector := resource.GetValues()
-	bldr := array.NewRecordBuilder(memory.DefaultAllocator, resource.Table.ToArrowSchema())
-	scalar.AppendToRecordBuilder(bldr, vector)
-	rec := bldr.NewRecord()
-	return rec
+	return vector.ToArrowRecord(resource.Table.ToArrowSchema())
 }
 
 func (s *syncClient) logTablesMetrics(tables schema.Tables, client Client) {


### PR DESCRIPTION
Without this, lists from the test source (at least, could be more plugins/cases) get persisted as `[]`

I'm still not 100% sure how the lists end up getting encoded to JSON, probably we use Arrow's `.ValueStr` and/or `.GetOneForMarshal` somewhere.

Called from table resolver - source plugins need this fix.