### PR TITLE
fix: Default Plugin logger assumes plugin is a `source`

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -179,7 +179,7 @@ func (p *Plugin) Targets() []BuildTarget {
 }
 
 func (p *Plugin) SetLogger(logger zerolog.Logger) {
-	p.logger = logger.With().Str("module", p.name+"-src").Logger()
+	p.logger = logger.With().Str("module", p.name+"-"+string(p.Kind())).Logger()
 }
 
 func (p *Plugin) Tables(ctx context.Context, options TableOptions) (schema.Tables, error) {


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


Rather than using `-src` for all plugins this PR uses the `plugin.Kind()` to set `-source` or `-destination`