### PR TITLE
feat: Skip table validation during init

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -80,6 +80,8 @@ type Plugin struct {
 	schemaValidator *jsonschema.Schema
 	// skips the usage client
 	skipUsageClient bool
+	// skips table validation
+	skipTableValidation bool
 }
 
 // NewPlugin returns a new CloudQuery Plugin with the given name, version and implementation.
@@ -142,6 +144,11 @@ func (p *Plugin) Meta() Meta {
 // SetSkipUsageClient sets whether the usage client should be skipped
 func (p *Plugin) SetSkipUsageClient(v bool) {
 	p.skipUsageClient = v
+}
+
+// SetSkipTableValidation sets whether table validation should be skipped
+func (p *Plugin) SetSkipTableValidation(v bool) {
+	p.skipTableValidation = v
 }
 
 type OnBeforeSender interface {

--- a/plugin/validate.go
+++ b/plugin/validate.go
@@ -23,6 +23,9 @@ func validateTables(tables schema.Tables) error {
 }
 
 func (p *Plugin) validate(ctx context.Context) error {
+	if p.skipTableValidation {
+		return nil
+	}
 	tables, err := p.client.Tables(ctx, TableOptions{Tables: []string{"*"}})
 	// ErrNotImplemented means it's a destination only plugin
 	if err != nil && !errors.Is(err, ErrNotImplemented) {


### PR DESCRIPTION
#### Summary

Not all source plugins are able to generate the list of tables at initialization time. For example S3 source needs to list and then download the object in order to generate the table. This can have a super high cost as a bucket can have near limitless amount of data