### PR TITLE
feat: Handle unknown token types when getting team name in usage client

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -405,14 +405,16 @@ func (u *BatchUpdater) getTeamNameByTokenType(tokenType auth.TokenType) (string,
 			return "", fmt.Errorf("expected to find exactly one team for API key, found %d", len(resp.JSON200.Items))
 		}
 		return resp.JSON200.Items[0].Name, nil
-	case auth.SyncRunAPIKey, auth.SyncTestConnectionAPIKey:
+	default:
 		team := os.Getenv("_CQ_TEAM_NAME")
 		if team == "" {
-			return "", fmt.Errorf("_CQ_TEAM_NAME environment variable not set")
+			switch tokenType {
+			case auth.SyncRunAPIKey, auth.SyncTestConnectionAPIKey:
+				return "", fmt.Errorf("_CQ_TEAM_NAME environment variable not set")
+			}
+			return "", fmt.Errorf("unsupported token type: %v", tokenType)
 		}
 		return team, nil
-	default:
-		return "", fmt.Errorf("unsupported token type: %v", tokenType)
 	}
 }
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Every time we add a new token type (e.g. test connection token type) the existing plugin versions that use the usage client can't use the new token type since the default on unknown token type is to fail when trying to get the team name.
This PR updates the code to fallback to `_CQ_TEAM_NAME` so even if a new token type is added we try to get the team name from `_CQ_TEAM_NAME`.
This will ensure that if we add a new token type, existing versions can still get the team name as long as `_CQ_TEAM_NAME` exists.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
