### PR TITLE
chore: Remove writer benchmarks from CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,5 @@ benchmark:
 
 benchmark-ci:
 	go install go.bobheadxi.dev/gobenchdata@v1.2.1
-	{ go test -bench . -benchmem ./... -run="^$$" | grep -v 'BenchmarkWriterMemory/' && \
-go test -bench=BenchmarkWriterMemory -benchmem  -test.benchtime 10000x ./writers/ -run="^$$"; } | gobenchdata --json bench.json
+	go test -bench . -benchmem ./... -run="^$$" | grep -v 'BenchmarkWriterMemory/' | gobenchdata --json bench.json
 	rm -rf .delta.* && go run scripts/benchmark-delta/main.go bench.json


### PR DESCRIPTION
Remove noisy BatchWriter benchmarks

Still keeps it in `make benchmark`