### PR TITLE
chore: Go mod Tidy example on dep updates

### DIFF
--- a/.github/workflows/go_mod_tidy_examples.yml
+++ b/.github/workflows/go_mod_tidy_examples.yml
@@ -1,0 +1,28 @@
+name: Run go mod tidy on examples plugins
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - go.mod'
+jobs:
+  go-mod-tidy-example:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'cq-bot' && startsWith(github.event.pull_request.title, 'fix(deps)') && startsWith(github.head_ref, 'renovate/')
+    strategy:
+      matrix:
+        plugin: [simple_plugin]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Run go mod tidy
+        working-directory: examples/${{ matrix.plugin }}
+        run: go mod tidy
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+            commit_message: "chore: Tidy"


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Should automatically fix issues like https://github.com/cloudquery/plugin-sdk/actions/runs/8466877094/job/23196593316?pr=1578#step:6:111

where the test plugin needs a `go mod tidy` for tests to pass

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
