### PR TITLE
feat: Add State Client support to append only destinations

### DIFF
--- a/internal/clients/state/v3/latestbuffer.go
+++ b/internal/clients/state/v3/latestbuffer.go
@@ -1,0 +1,183 @@
+package state
+
+import (
+	"strconv"
+	"time"
+)
+
+type LatestBuffer struct {
+	data map[string][]formatMap
+}
+
+type format int
+
+const (
+	fOriginal format = iota
+	fInt
+	fFloat
+	fTime
+)
+
+type formatMap map[format]any
+
+func NewLatestBuffer() *LatestBuffer {
+	return &LatestBuffer{
+		data: make(map[string][]formatMap),
+	}
+}
+
+func (l *LatestBuffer) Add(key, value string) {
+	l.data[key] = append(l.data[key], possibleFormats(value))
+}
+
+func (l *LatestBuffer) All() map[string]string {
+	ret := make(map[string]string, len(l.data))
+	for key := range l.data {
+		ret[key] = l.Get(key)
+	}
+	return ret
+}
+
+func (l *LatestBuffer) Get(key string) string {
+	vals := l.data[key]
+	switch len(vals) {
+	case 0: // unknown key
+		return ""
+	case 1: // single value
+		return vals[0][fOriginal].(string)
+	}
+
+	var common *format
+	for _, fmts := range vals {
+		f := fmts.Type()
+		if f == nil {
+			break
+		}
+		if common == nil {
+			common = f
+			continue
+		}
+		if (*f == fInt && *common == fFloat) || (*f == fFloat && *common == fInt) {
+			*common = fFloat
+			continue
+		}
+		if *common != *f {
+			common = nil
+			break
+		}
+	}
+	if common == nil || *common == fOriginal {
+		return vals[0][fOriginal].(string) // no known common format, return first value
+	}
+
+	valIndex := -1
+
+	// Depending on our common format, find the largest value
+	switch *common {
+	case fInt:
+		var maxVal int64
+		for i, fVal := range vals {
+			v, ok := fVal.Get(fInt)
+			if !ok {
+				panic("wanted to get fInt but not found")
+			}
+			vt := v.(int64)
+			if valIndex == -1 || vt > maxVal {
+				maxVal = vt
+				valIndex = i
+			}
+		}
+	case fFloat:
+		var maxVal float64
+		for i, fVal := range vals {
+			v, ok := fVal.Get(fFloat)
+			if !ok {
+				v, ok = fVal.Get(fInt)
+				if ok {
+					v = float64(v.(int64)) // cast int to float as other values are floats
+				}
+			}
+			if !ok {
+				panic("wanted to get fFloat but not found")
+			}
+			vt := v.(float64)
+			if valIndex == -1 || vt > maxVal {
+				maxVal = vt
+				valIndex = i
+			}
+		}
+	case fTime:
+		var maxVal time.Time
+		for i, fVal := range vals {
+			v, ok := fVal.Get(fTime)
+			if !ok {
+				panic("wanted to get fTime but not found")
+			}
+			vt := v.(time.Time)
+			if valIndex == -1 || vt.After(maxVal) {
+				maxVal = vt
+				valIndex = i
+			}
+		}
+	}
+
+	if valIndex == -1 {
+		// should not happen
+		panic("valIndex is -1, common is " + strconv.FormatInt(int64(*common), 10))
+		//return vals[0][fOriginal].(string) // return first value
+	}
+
+	return vals[valIndex][fOriginal].(string) // Return original value (of the largest value)
+}
+
+func possibleFormats(s string) formatMap {
+	fmts := map[format]any{
+		fOriginal: s,
+	}
+
+	// ints also parse as floats, so check int and if it passes ignore float
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		fmts[fInt] = v
+	} else if v, err := strconv.ParseFloat(s, 64); err == nil {
+		fmts[fFloat] = v
+	}
+	if v, err := time.Parse(time.RFC3339, s); err == nil {
+		fmts[fTime] = v
+	}
+	if v, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		fmts[fTime] = v
+	}
+
+	return fmts
+}
+
+func (m formatMap) String() string {
+	return m[fOriginal].(string)
+}
+
+func (m formatMap) Get(f format) (any, bool) {
+	if v, ok := m[f]; ok {
+		return v, true
+	}
+	return nil, false
+}
+
+func (m formatMap) Type() *format {
+	formats := make([]format, 0, len(m))
+	for f := range m {
+		formats = append(formats, f)
+	}
+	switch len(formats) {
+	case 0: // empty
+		return nil
+	case 1: // this would be fOriginal
+		return &formats[0]
+	case 2: // fOriginal and one other
+		if formats[0] == fOriginal {
+			return &formats[1]
+		}
+		return &formats[0]
+	}
+
+	return nil // no common format
+}

--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -3,8 +3,8 @@ package state
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/apache/arrow/go/v15/arrow"
@@ -114,8 +114,11 @@ func NewClientWithTable(ctx context.Context, pbClient pb.PluginClient, table *sc
 			keys := record.Columns()[0].(*array.String)
 			values := record.Columns()[1].(*array.String)
 			for i := 0; i < keys.Len(); i++ {
-				fmt.Println(keys.Value(i), values.Value(i))
-				c.mem[keys.Value(i)] = values.Value(i)
+				k, v := keys.Value(i), values.Value(i)
+				curVal, ok := c.mem[k]
+				if !ok || strings.Compare(curVal, v) == -1 { // set only if not exists or greater lexicographically
+					c.mem[k] = v
+				}
 			}
 		}
 	}

--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -22,8 +22,6 @@ type Client struct {
 	mem     *LatestBuffer
 	changes map[string]struct{}
 	mutex   *sync.RWMutex
-	keys    []string
-	values  []string
 	schema  *arrow.Schema
 }
 
@@ -54,8 +52,6 @@ func NewClientWithTable(ctx context.Context, pbClient pb.PluginClient, table *sc
 		mem:     NewLatestBuffer(),
 		changes: make(map[string]struct{}),
 		mutex:   &sync.RWMutex{},
-		keys:    make([]string, 0),
-		values:  make([]string, 0),
 	}
 	sc := table.ToArrowSchema()
 	c.schema = sc

--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/apache/arrow/go/v15/arrow"
@@ -118,7 +117,7 @@ func NewClientWithTable(ctx context.Context, pbClient pb.PluginClient, table *sc
 			for i := 0; i < keys.Len(); i++ {
 				k, v := keys.Value(i), values.Value(i)
 				curVal, ok := c.mem[k]
-				if !ok || len(curVal) != len(v) || strings.Compare(curVal, v) == -1 { // set only if not exists, of different length, or greater lexicographically
+				if !ok || len(curVal) != len(v) || v > curVal { // set only if not exists, of different length, or greater lexicographically
 					c.mem[k] = v
 				}
 			}

--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -136,7 +136,10 @@ func (c *Client) Flush(ctx context.Context) error {
 	defer c.mutex.Unlock()
 	bldr := array.NewRecordBuilder(memory.DefaultAllocator, c.schema)
 	for k := range c.changes {
-		v := c.mem.Get(k)
+		v, err := c.mem.Get(k)
+		if err != nil {
+			return err
+		}
 		bldr.Field(0).(*array.StringBuilder).Append(k)
 		bldr.Field(1).(*array.StringBuilder).Append(v)
 	}
@@ -169,5 +172,5 @@ func (c *Client) Flush(ctx context.Context) error {
 func (c *Client) GetKey(_ context.Context, key string) (string, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	return c.mem.Get(key), nil
+	return c.mem.Get(key)
 }

--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -118,7 +118,7 @@ func NewClientWithTable(ctx context.Context, pbClient pb.PluginClient, table *sc
 			for i := 0; i < keys.Len(); i++ {
 				k, v := keys.Value(i), values.Value(i)
 				curVal, ok := c.mem[k]
-				if !ok || strings.Compare(curVal, v) == -1 { // set only if not exists or greater lexicographically
+				if !ok || len(curVal) != len(v) || strings.Compare(curVal, v) == -1 { // set only if not exists, of different length, or greater lexicographically
 					c.mem[k] = v
 				}
 			}

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -169,16 +169,11 @@ func TestStateOverwrite(t *testing.T) {
 				}
 			}
 
-			val, err := stateClient.GetKey(ctx, "key")
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			stateClient, err = state.NewClientWithTable(ctx, c, table)
 			if err != nil {
 				t.Fatal(err)
 			}
-			val, err = stateClient.GetKey(ctx, "key")
+			val, err := stateClient.GetKey(ctx, "key")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -90,13 +90,13 @@ func TestStateOverwrite(t *testing.T) {
 	}{
 		{
 			"Overwrite",
-			[]string{"valua1", "value1", "value3", "value2"}, // All same length, expect largest value
-			"value3", // Largest value lexicographically
+			[]string{"valua", "value1", "value3", "value2"}, // All strings, expect first value
+			"valua",
 		},
 		{
 			"Overwrite with integers",
 			[]string{"1", "32", "4"},
-			"1", // First value written, last value read from memdb?
+			"32",
 		},
 		{
 			"Overwrite with timestamps",
@@ -110,7 +110,7 @@ func TestStateOverwrite(t *testing.T) {
 		},
 		{
 			"Overwrite with float unix timestamps with int in between",
-			[]string{"1712226133.860000", "1712226134", "1712226133.859000"},
+			[]string{"123", "1712226133.860000", "1712226134", "1712226133.859000"},
 			"1712226134",
 		},
 	}
@@ -172,9 +172,6 @@ func TestStateOverwrite(t *testing.T) {
 			val, err := stateClient.GetKey(ctx, "key")
 			if err != nil {
 				t.Fatal(err)
-			}
-			if finalValueWritten := tc.values[len(tc.values)-1]; val != finalValueWritten {
-				t.Fatalf("expected value to be %q but got %q", finalValueWritten, val)
 			}
 
 			stateClient, err = state.NewClientWithTable(ctx, c, table)

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -128,7 +128,92 @@ func TestStateOverwrite(t *testing.T) {
 		finalValueToWrite = "value2"
 		finalValueToRead  = "value3"
 	)
-	setValues := []string{"valua", "value", finalValueToRead, finalValueToWrite}
+	setValues := []string{"valua1", "value1", finalValueToRead, finalValueToWrite}
+
+	for _, v := range setValues {
+		if err := stateClient.SetKey(ctx, "key", v); err != nil {
+			t.Fatal(err)
+		}
+		// Without Flush(), value will only be updated in memory, and we won't get duplicate entries in memdb
+		if err := stateClient.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	val, err := stateClient.GetKey(ctx, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != finalValueToWrite {
+		t.Fatalf("expected value to be %q but got %q", finalValueToWrite, val)
+	}
+
+	stateClient, err = state.NewClientWithTable(ctx, c, table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, err = stateClient.GetKey(ctx, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != finalValueToRead {
+		t.Fatalf("expected value to be %q but got %q", finalValueToRead, val)
+	}
+
+	cancel()
+	wg.Wait()
+	if serverErr != nil {
+		t.Fatal(serverErr)
+	}
+}
+
+func TestStateOverwriteIntegers(t *testing.T) {
+	p := plugin.NewPlugin(
+		"testPluginV3",
+		"v1.0.0",
+		memdb.NewMemDBClient)
+	srv := Plugin(p, WithArgs("serve"), WithTestListener())
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var serverErr error
+	go func() {
+		defer wg.Done()
+		serverErr = srv.Serve(ctx)
+	}()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	// https://stackoverflow.com/questions/42102496/testing-a-grpc-service
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(srv.bufPluginDialer), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	c := pb.NewPluginClient(conn)
+	if _, err := c.Init(ctx, &pb.Init_Request{}); err != nil {
+		t.Fatal(err)
+	}
+
+	table := state.Table("test_no_pk")
+	// Remove PKs
+	for i := range table.Columns {
+		table.Columns[i].PrimaryKey = false
+	}
+
+	stateClient, err := state.NewClientWithTable(ctx, c, table)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		finalValueToRead  = "1" // First value written, last value read from memdb?
+		finalValueToWrite = "4"
+	)
+	setValues := []string{finalValueToRead, "32", finalValueToWrite}
 
 	for _, v := range setValues {
 		if err := stateClient.SetKey(ctx, "key", v); err != nil {

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -81,3 +81,85 @@ func TestState(t *testing.T) {
 		t.Fatal(serverErr)
 	}
 }
+
+func TestStateOverwrite(t *testing.T) {
+	p := plugin.NewPlugin(
+		"testPluginV3",
+		"v1.0.0",
+		memdb.NewMemDBClient)
+	srv := Plugin(p, WithArgs("serve"), WithTestListener())
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var serverErr error
+	go func() {
+		defer wg.Done()
+		serverErr = srv.Serve(ctx)
+	}()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	// https://stackoverflow.com/questions/42102496/testing-a-grpc-service
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(srv.bufPluginDialer), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+
+	c := pb.NewPluginClient(conn)
+	if _, err := c.Init(ctx, &pb.Init_Request{}); err != nil {
+		t.Fatal(err)
+	}
+
+	table := state.Table("test_no_pk")
+	// Remove PKs
+	for i := range table.Columns {
+		table.Columns[i].PrimaryKey = false
+	}
+
+	stateClient, err := state.NewClientWithTable(ctx, c, table)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const finalValue = "value2"
+	setValues := []string{"valua", "value", finalValue}
+
+	for _, v := range setValues {
+		if err := stateClient.SetKey(ctx, "key", v); err != nil {
+			t.Fatal(err)
+		}
+		// Without Flush(), value will only be updated in memory, and we won't get duplicate entries in memdb
+		if err := stateClient.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	val, err := stateClient.GetKey(ctx, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != finalValue {
+		t.Fatalf("expected value to be %q but got %q", finalValue, val)
+	}
+
+	stateClient, err = state.NewClientWithTable(ctx, c, table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, err = stateClient.GetKey(ctx, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != finalValue {
+		t.Fatalf("expected value to be %q but got %q", finalValue, val)
+	}
+
+	cancel()
+	wg.Wait()
+	if serverErr != nil {
+		t.Fatal(serverErr)
+	}
+}

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -98,6 +98,21 @@ func TestStateOverwrite(t *testing.T) {
 			[]string{"1", "32", "4"},
 			"1", // First value written, last value read from memdb?
 		},
+		{
+			"Overwrite with timestamps",
+			[]string{"2024-04-03T16:02:55.20412Z", "2024-04-03T16:03:37.06Z", "2024-04-03T16:03:22.440487Z", "2024-04-03T16:03:37.058413Z"},
+			"2024-04-03T16:03:37.06Z", // Latest timestamp despite rounding zeroes
+		},
+		{
+			"Overwrite with float unix timestamps",
+			[]string{"1712226133.860000", "1712226134.759", "1712226133.859000"},
+			"1712226134.759",
+		},
+		{
+			"Overwrite with float unix timestamps with int in between",
+			[]string{"1712226133.860000", "1712226134", "1712226133.859000"},
+			"1712226134",
+		},
 	}
 
 	for _, tc := range cases {

--- a/serve/state_test.go
+++ b/serve/state_test.go
@@ -124,8 +124,11 @@ func TestStateOverwrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const finalValue = "value2"
-	setValues := []string{"valua", "value", finalValue}
+	const (
+		finalValueToWrite = "value2"
+		finalValueToRead  = "value3"
+	)
+	setValues := []string{"valua", "value", finalValueToRead, finalValueToWrite}
 
 	for _, v := range setValues {
 		if err := stateClient.SetKey(ctx, "key", v); err != nil {
@@ -141,8 +144,8 @@ func TestStateOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if val != finalValue {
-		t.Fatalf("expected value to be %q but got %q", finalValue, val)
+	if val != finalValueToWrite {
+		t.Fatalf("expected value to be %q but got %q", finalValueToWrite, val)
 	}
 
 	stateClient, err = state.NewClientWithTable(ctx, c, table)
@@ -153,8 +156,8 @@ func TestStateOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if val != finalValue {
-		t.Fatalf("expected value to be %q but got %q", finalValue, val)
+	if val != finalValueToRead {
+		t.Fatalf("expected value to be %q but got %q", finalValueToRead, val)
 	}
 
 	cancel()


### PR DESCRIPTION
Enables the state client to load the ~~lexicographically~~ -latest value from the table. ~~Which works for most things (date strings) but not for unpadded integers (fixed in [`be1227d` (#1599)](https://github.com/cloudquery/plugin-sdk/pull/1599/commits/be1227d535c96dd45812172aa3f8efc1c90c227c) where we don't attempt any sorting if value lengths differ).~~ This way append-only destinations can also be used for state (with a bit of duplication) reliably.

Currently state client reads the whole table on init to memory, and writes everything back on Flush. Also a change list is added to avoid unnecessary writing.

It correctly handles zero-trimmed floats and timestamps.