### PR TITLE
fix: Use `clear` for mixed batch writer

### DIFF
--- a/writers/mixedbatchwriter/mixedbatchwriter.go
+++ b/writers/mixedbatchwriter/mixedbatchwriter.go
@@ -192,7 +192,6 @@ func (m *batchManager[A, T]) flush(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	m.batch = nil
 	clear(m.batch) // GC can work
 	m.batch = m.batch[:0]
 	return nil


### PR DESCRIPTION
Fixes the issue with `cap` used on `nil` slice introduced in https://github.com/cloudquery/plugin-sdk/pull/1553