### PR TITLE
feat: Transform `time.Duration` into `arrow.Duration`

### DIFF
--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -332,9 +332,9 @@ func DefaultTypeTransformer(v reflect.StructField) (arrow.DataType, error) {
 func defaultGoTypeToSchemaType(v reflect.Type) (arrow.DataType, error) {
 	// Non-primitive types
 	switch v {
-	case reflect.TypeFor[net.IP]():
+	case reflect.TypeOf(net.IP{}):
 		return types.ExtensionTypes.Inet, nil
-	case reflect.TypeFor[time.Duration]():
+	case reflect.TypeOf(time.Nanosecond):
 		return arrow.FixedWidthTypes.Duration_us, nil
 	}
 

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -330,9 +330,12 @@ func DefaultTypeTransformer(v reflect.StructField) (arrow.DataType, error) {
 }
 
 func defaultGoTypeToSchemaType(v reflect.Type) (arrow.DataType, error) {
-	// Non primitive types
-	if v == reflect.TypeOf(net.IP{}) {
+	// Non-primitive types
+	switch v {
+	case reflect.TypeFor[net.IP]():
 		return types.ExtensionTypes.Inet, nil
+	case reflect.TypeFor[time.Duration]():
+		return arrow.FixedWidthTypes.Duration_us, nil
 	}
 
 	k := v.Kind()

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -43,11 +43,13 @@ type (
 
 		AnyArrayCol []any `json:"any_array_col,omitempty"`
 
-		TimeCol        time.Time  `json:"time_col,omitempty"`
-		TimePointerCol *time.Time `json:"time_pointer_col,omitempty"`
-		JSONTag        *string    `json:"json_tag"`
-		SkipJSONTag    *string    `json:"-"`
-		NoJSONTag      *string
+		TimeCol            time.Time      `json:"time_col,omitempty"`
+		TimePointerCol     *time.Time     `json:"time_pointer_col,omitempty"`
+		DurationCol        time.Duration  `json:"duration_col,omitempty"`
+		DurationPointerCol *time.Duration `json:"duration_pointer_col,omitempty"`
+		JSONTag            *string        `json:"json_tag"`
+		SkipJSONTag        *string        `json:"-"`
+		NoJSONTag          *string
 		*embeddedStruct
 	}
 	testStructWithEmbeddedStruct struct {
@@ -147,6 +149,14 @@ var (
 		{
 			Name: "time_pointer_col",
 			Type: arrow.FixedWidthTypes.Timestamp_us,
+		},
+		{
+			Name: "duration_col",
+			Type: arrow.FixedWidthTypes.Duration_us,
+		},
+		{
+			Name: "duration_pointer_col",
+			Type: arrow.FixedWidthTypes.Duration_us,
 		},
 		{
 			Name: "json_tag",


### PR DESCRIPTION
Inspired by seeing this bug/feature?
https://github.com/cloudquery/cloudquery-private/blob/746f6636b11b0d7a2fbdb0f6bd37cd06678f8670/plugins/source/gcp/client/transformers.go#L47-L49

I propose making the durations being actually mapped to durations, but im may be a breaking change.