### PR TITLE
feat: Add function to create state client and gRPC backend connection

### DIFF
--- a/state/client.go
+++ b/state/client.go
@@ -14,15 +14,21 @@ type ConnectionOptions struct {
 	MaxMsgSizeInBytes int
 }
 
-// NewGrpcConnectedClient returns a state client and a gRPC connection to the state backend with a 100MiB max message size.
+type NopCloser interface {
+	Close() error
+}
+
+// NewGrpcConnectedClient returns a state client and initialises the gRPC connection to the state backend with a 100MiB max message size.
 // The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
-func NewGrpcConnectedClient(ctx context.Context, backendOpts *plugin.BackendOptions) (Client, *grpc.ClientConn, error) {
+// You must call Close() on the returned closer object.
+func NewGrpcConnectedClient(ctx context.Context, backendOpts *plugin.BackendOptions) (Client, NopCloser, error) {
 	return NewGrpcConnectedClientWithOptions(ctx, backendOpts, ConnectionOptions{MaxMsgSizeInBytes: defaultMaxMsgSizeInBytes})
 }
 
-// NewGrpcConnectedClientWithOptions returns a state client and a gRPC connection to the state backend.
+// NewGrpcConnectedClientWithOptions returns a state client and initialises the gRPC connection to the state backend.
 // The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
-func NewGrpcConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.BackendOptions, opts ConnectionOptions) (Client, *grpc.ClientConn, error) {
+// You must call Close() on the returned closer object.
+func NewGrpcConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.BackendOptions, opts ConnectionOptions) (Client, NopCloser, error) {
 	if backendOpts == nil {
 		return &NoOpClient{}, nil, nil
 	}

--- a/state/client.go
+++ b/state/client.go
@@ -1,0 +1,48 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudquery/plugin-sdk/v4/plugin"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const defaultMaxMsgSizeInBytes = 100 * 1024 * 1024 // 100 MiB
+
+type ConnectionOptions struct {
+	MaxMsgSizeInBytes int
+}
+
+// NewGrpcConnectedClient returns a state client and a gRPC connection to the state backend with a 100MiB max message size.
+// The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
+func NewGrpcConnectedClient(ctx context.Context, backendOpts *plugin.BackendOptions) (Client, *grpc.ClientConn, error) {
+	return NewGrpcConnectedClientWithOptions(ctx, backendOpts, ConnectionOptions{MaxMsgSizeInBytes: defaultMaxMsgSizeInBytes})
+}
+
+// NewGrpcConnectedClientWithOptions returns a state client and a gRPC connection to the state backend.
+// The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
+func NewGrpcConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.BackendOptions, opts ConnectionOptions) (Client, *grpc.ClientConn, error) {
+	if backendOpts == nil {
+		return &NoOpClient{}, nil, nil
+	}
+
+	backendConn, err := grpc.DialContext(ctx, backendOpts.Connection,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(opts.MaxMsgSizeInBytes),
+			grpc.MaxCallSendMsgSize(opts.MaxMsgSizeInBytes),
+		),
+	)
+
+	if err != nil {
+		return &NoOpClient{}, nil, fmt.Errorf("failed to dial grpc source plugin at %s: %w", backendOpts.Connection, err)
+	}
+
+	stateClient, err := NewClient(ctx, backendConn, backendOpts.TableName)
+	if err != nil {
+		return &NoOpClient{}, nil, fmt.Errorf("failed to create state client: %w", err)
+	}
+
+	return stateClient, backendConn, nil
+}


### PR DESCRIPTION
I'd like to propose adding a function to the `state` package to make it easier to initialise the client along with a gRPC connection.

Currently our plugins that support incremental syncing have this code in the `plugin/client.go` file:

```
var stateClient state.Client
if options.BackendOptions == nil {
	c.logger.Info().Msg("No backend options provided, using no state backend")
	stateClient = &state.NoOpClient{}
	c.backendConn = nil
} else {
	c.backendConn, err = grpc.DialContext(ctx, options.BackendOptions.Connection,
		grpc.WithTransportCredentials(insecure.NewCredentials()),
		grpc.WithDefaultCallOptions(
			grpc.MaxCallRecvMsgSize(maxMsgSize),
			grpc.MaxCallSendMsgSize(maxMsgSize),
		),
	)
	if err != nil {
		return fmt.Errorf("failed to dial grpc source plugin at %s: %w", options.BackendOptions.Connection, err)
	}
	stateClient, err = state.NewClient(ctx, c.backendConn, options.BackendOptions.TableName)
	if err != nil {
		return fmt.Errorf("failed to create state client: %w", err)
	}
	c.logger.Info().Str("table_name", options.BackendOptions.TableName).Msg("Connected to state backend")
}
```

My solution would replace it with:
```
stateClient, backendConn, err := state.NewGrpcConnectedClient(ctx, options.BackendOptions)
```
