### PR TITLE
feat: Allow reporting usage as breakdown by table

### DIFF
--- a/examples/simple_plugin/go.mod
+++ b/examples/simple_plugin/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect
-	github.com/cloudquery/cloudquery-api-go v1.9.2 // indirect
+	github.com/cloudquery/cloudquery-api-go v1.11.0 // indirect
 	github.com/cloudquery/plugin-pb-go v1.19.12 // indirect
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/simple_plugin/go.sum
+++ b/examples/simple_plugin/go.sum
@@ -45,8 +45,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpV
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
 github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
-github.com/cloudquery/cloudquery-api-go v1.9.2 h1:h3aBGNVdvUYhyB5n/hAY43QoN+LCGMwK4DD/El6aIZE=
-github.com/cloudquery/cloudquery-api-go v1.9.2/go.mod h1:F4kuaNBAVqsS9ZRHuX+tV2m6+Khoa2Rb9lROGhinGPk=
+github.com/cloudquery/cloudquery-api-go v1.11.0 h1:o28LS1E8W0AgnCajSe1gTaLvMB6n2OY5a6QwDxGx0xk=
+github.com/cloudquery/cloudquery-api-go v1.11.0/go.mod h1:F4kuaNBAVqsS9ZRHuX+tV2m6+Khoa2Rb9lROGhinGPk=
 github.com/cloudquery/plugin-pb-go v1.19.12 h1:2lDCGdSf1MtIdrNmO7+QEVTlGhqWydpK8G6eiSbcyYk=
 github.com/cloudquery/plugin-pb-go v1.19.12/go.mod h1:gCQQ29Sd7Ym/tECgFezAf25Sjrsd8NPiDDCWmDMTYIo=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.5
 require (
 	github.com/apache/arrow/go/v16 v16.0.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.8.0
-	github.com/cloudquery/cloudquery-api-go v1.9.2
+	github.com/cloudquery/cloudquery-api-go v1.11.0
 	github.com/cloudquery/plugin-pb-go v1.19.12
 	github.com/cloudquery/plugin-sdk/v2 v2.7.0
 	github.com/getsentry/sentry-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d/go.mod h1:8EPpV
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/chenzhuoyu/iasm v0.9.1 h1:tUHQJXo3NhBqw6s33wkGn9SP3bvrWLdlVIJ3hQBL7P0=
 github.com/chenzhuoyu/iasm v0.9.1/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
-github.com/cloudquery/cloudquery-api-go v1.9.2 h1:h3aBGNVdvUYhyB5n/hAY43QoN+LCGMwK4DD/El6aIZE=
-github.com/cloudquery/cloudquery-api-go v1.9.2/go.mod h1:F4kuaNBAVqsS9ZRHuX+tV2m6+Khoa2Rb9lROGhinGPk=
+github.com/cloudquery/cloudquery-api-go v1.11.0 h1:o28LS1E8W0AgnCajSe1gTaLvMB6n2OY5a6QwDxGx0xk=
+github.com/cloudquery/cloudquery-api-go v1.11.0/go.mod h1:F4kuaNBAVqsS9ZRHuX+tV2m6+Khoa2Rb9lROGhinGPk=
 github.com/cloudquery/plugin-pb-go v1.19.12 h1:2lDCGdSf1MtIdrNmO7+QEVTlGhqWydpK8G6eiSbcyYk=
 github.com/cloudquery/plugin-pb-go v1.19.12/go.mod h1:gCQQ29Sd7Ym/tECgFezAf25Sjrsd8NPiDDCWmDMTYIo=
 github.com/cloudquery/plugin-sdk/v2 v2.7.0 h1:hRXsdEiaOxJtsn/wZMFQC9/jPfU1MeMK3KF+gPGqm7U=

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -554,18 +554,19 @@ func createTestServerWithRemainingRows(t *testing.T, remainingRows int) *testSta
 
 			if req.Tables != nil {
 				for _, table := range *req.Tables {
-					if tbl, ok := stage.tables[table.Name]; !ok {
+					tbl, ok := stage.tables[table.Name]
+
+					if !ok {
 						stage.tables[table.Name] = struct {
 							Name string
 							Rows int
 						}{Name: table.Name, Rows: table.Rows}
 						continue
-					} else {
-						tbl.Rows += table.Rows
-						stage.tables[table.Name] = tbl
 					}
-				}
 
+					tbl.Rows += table.Rows
+					stage.tables[table.Name] = tbl
+				}
 			}
 
 			w.WriteHeader(http.StatusOK)

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -163,7 +163,7 @@ func TestUsageService_IncreaseWithTableBreakdown_ZeroBatchSize(t *testing.T) {
 	rows := 9999
 	for i := 0; i < rows; i++ {
 		table := "table:" + strconv.Itoa(i%tables)
-		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		err = usageClient.IncreaseForTable(table, 1)
 		require.NoError(t, err)
 	}
 
@@ -211,7 +211,7 @@ func TestUsageService_IncreaseWithTableBreakdown_WithBatchSize(t *testing.T) {
 	rows := 9999
 	for i := 0; i < rows; i++ {
 		table := "table:" + strconv.Itoa(i%tables)
-		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		err = usageClient.IncreaseForTable(table, 1)
 		require.NoError(t, err)
 	}
 	err = usageClient.Close()
@@ -260,7 +260,7 @@ func TestUsageService_IncreaseWithTableBreakdown_WithFlushDuration(t *testing.T)
 	rows := 30
 	for i := 0; i < rows; i++ {
 		table := "table:" + strconv.Itoa(i%tables)
-		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		err = usageClient.IncreaseForTable(table, 1)
 		require.NoError(t, err)
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -305,7 +305,7 @@ func TestUsageService_IncreaseWithTableBreakdown_WithMinimumUpdateDuration(t *te
 	rows := 9999
 	for i := 0; i < rows; i++ {
 		table := "table:" + strconv.Itoa(i%tables)
-		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		err = usageClient.IncreaseForTable(table, 1)
 		require.NoError(t, err)
 	}
 	err = usageClient.Close()
@@ -329,7 +329,7 @@ func TestUsageService_WithTableBreakdown_CorrectByTable(t *testing.T) {
 	rows := 9999
 	for i := 0; i < rows; i++ {
 		table := "table:" + strconv.Itoa(i%tables)
-		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		err = usageClient.IncreaseForTable(table, 1)
 		require.NoError(t, err)
 	}
 

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -47,7 +47,7 @@ func TestUsageService_NewUsageClient_Defaults(t *testing.T) {
 	uc, err := NewUsageClient(
 		plugin.Meta{
 			Team: "plugin-team",
-			Kind: cqapi.Source,
+			Kind: cqapi.PluginKindSource,
 			Name: "vault",
 		},
 		withTokenClient(newMockTokenClient(auth.BearerToken)),
@@ -73,7 +73,7 @@ func TestUsageService_NewUsageClient_Override(t *testing.T) {
 	uc, err := NewUsageClient(
 		plugin.Meta{
 			Team: "plugin-team",
-			Kind: cqapi.Source,
+			Kind: cqapi.PluginKindSource,
 			Name: "vault",
 		},
 		WithLogger(logger),
@@ -514,7 +514,7 @@ func newClient(t *testing.T, apiClient *cqapi.ClientWithResponses, ops ...UsageC
 	client, err := NewUsageClient(
 		plugin.Meta{
 			Team: "plugin-team",
-			Kind: cqapi.Source,
+			Kind: cqapi.PluginKindSource,
 			Name: "vault",
 		},
 		append(ops, withTeamName("team-name"), WithAPIClient(apiClient), withTokenClient(newMockTokenClient(auth.BearerToken)))...)
@@ -678,7 +678,7 @@ func Test_UsageClientInit_FromManagedSyncsAPIKeys(t *testing.T) {
 			_, err := NewUsageClient(
 				plugin.Meta{
 					Team: "plugin-team",
-					Kind: cqapi.Source,
+					Kind: cqapi.PluginKindSource,
 					Name: "test",
 				},
 			)
@@ -721,7 +721,7 @@ func Test_UsageClientInit_UnknownTokenType(t *testing.T) {
 			_, err := NewUsageClient(
 				plugin.Meta{
 					Team: "plugin-team",
-					Kind: cqapi.Source,
+					Kind: cqapi.PluginKindSource,
 					Name: "test",
 				},
 				withTokenClient(newMockTokenClient(math.MaxInt)),

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -129,7 +130,7 @@ func TestUsageService_HasQuota_WithRowsRemaining(t *testing.T) {
 	assert.True(t, hasQuota, "should have quota")
 }
 
-func TestUsageService_ZeroBatchSize(t *testing.T) {
+func TestUsageService_Increase_ZeroBatchSize(t *testing.T) {
 	s := createTestServer(t)
 	defer s.server.Close()
 
@@ -149,7 +150,31 @@ func TestUsageService_ZeroBatchSize(t *testing.T) {
 	assert.Equal(t, 10000, s.sumOfUpdates(), "total should equal number of updated rows")
 }
 
-func TestUsageService_WithBatchSize(t *testing.T) {
+func TestUsageService_IncreaseWithTableBreakdown_ZeroBatchSize(t *testing.T) {
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := newClient(t, apiClient, WithBatchLimit(0))
+
+	tables := 3
+	rows := 9999
+	for i := 0; i < rows; i++ {
+		table := "table:" + strconv.Itoa(i%tables)
+		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		require.NoError(t, err)
+	}
+
+	err = usageClient.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
+}
+
+func TestUsageService_Increase_WithBatchSize(t *testing.T) {
 	batchSize := 2000
 
 	s := createTestServer(t)
@@ -171,7 +196,33 @@ func TestUsageService_WithBatchSize(t *testing.T) {
 	assert.True(t, true, s.minExcludingClose() > batchSize, "minimum should be greater than batch size")
 }
 
-func TestUsageService_WithFlushDuration(t *testing.T) {
+func TestUsageService_IncreaseWithTableBreakdown_WithBatchSize(t *testing.T) {
+	batchSize := 2000
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := newClient(t, apiClient, WithBatchLimit(uint32(batchSize)))
+
+	tables := 3
+	rows := 9999
+	for i := 0; i < rows; i++ {
+		table := "table:" + strconv.Itoa(i%tables)
+		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		require.NoError(t, err)
+	}
+	err = usageClient.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
+	assert.True(t, true, s.minExcludingClose() > batchSize, "minimum should be greater than batch size")
+}
+
+func TestUsageService_Increase_WithFlushDuration(t *testing.T) {
 	batchSize := 2000
 
 	s := createTestServer(t)
@@ -194,7 +245,34 @@ func TestUsageService_WithFlushDuration(t *testing.T) {
 	assert.True(t, s.minExcludingClose() < batchSize, "we should see updates less than batchsize if ticker is firing")
 }
 
-func TestUsageService_WithMinimumUpdateDuration(t *testing.T) {
+func TestUsageService_IncreaseWithTableBreakdown_WithFlushDuration(t *testing.T) {
+	batchSize := 2000
+
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := newClient(t, apiClient, WithBatchLimit(uint32(batchSize)), WithMaxTimeBetweenFlushes(1*time.Millisecond), WithMinTimeBetweenFlushes(0*time.Millisecond))
+
+	tables := 3
+	rows := 30
+	for i := 0; i < rows; i++ {
+		table := "table:" + strconv.Itoa(i%tables)
+		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		require.NoError(t, err)
+		time.Sleep(5 * time.Millisecond)
+	}
+	err = usageClient.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
+	assert.True(t, s.minExcludingClose() < batchSize, "we should see updates less than batchsize if ticker is firing")
+}
+
+func TestUsageService_Increase_WithMinimumUpdateDuration(t *testing.T) {
 	s := createTestServer(t)
 	defer s.server.Close()
 
@@ -212,6 +290,58 @@ func TestUsageService_WithMinimumUpdateDuration(t *testing.T) {
 
 	assert.Equal(t, 10000, s.sumOfUpdates(), "total should equal number of updated rows")
 	assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+}
+
+func TestUsageService_IncreaseWithTableBreakdown_WithMinimumUpdateDuration(t *testing.T) {
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := newClient(t, apiClient, WithBatchLimit(0), WithMinTimeBetweenFlushes(30*time.Second))
+
+	tables := 3
+	rows := 9999
+	for i := 0; i < rows; i++ {
+		table := "table:" + strconv.Itoa(i%tables)
+		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		require.NoError(t, err)
+	}
+	err = usageClient.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
+	assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+}
+
+func TestUsageService_WithTableBreakdown_CorrectByTable(t *testing.T) {
+	s := createTestServer(t)
+	defer s.server.Close()
+
+	apiClient, err := cqapi.NewClientWithResponses(s.server.URL)
+	require.NoError(t, err)
+
+	usageClient := newClient(t, apiClient, WithBatchLimit(50))
+
+	tables := 9
+	rows := 9999
+	for i := 0; i < rows; i++ {
+		table := "table:" + strconv.Itoa(i%tables)
+		err = usageClient.IncreaseWithTableBreakdown(table, 1)
+		require.NoError(t, err)
+	}
+
+	err = usageClient.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
+
+	for i := 0; i < tables; i++ {
+		assert.Equal(t, 1111, s.tables["table:"+strconv.Itoa(i)].Rows, "table should have correct number of rows")
+	}
 }
 
 func TestUsageService_NoUpdates(t *testing.T) {
@@ -397,6 +527,10 @@ func createTestServerWithRemainingRows(t *testing.T, remainingRows int) *testSta
 	stage := testStage{
 		remainingRows: remainingRows,
 		update:        make([]int, 0),
+		tables: make(map[string]struct {
+			Name string
+			Rows int
+		}),
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -418,6 +552,22 @@ func createTestServerWithRemainingRows(t *testing.T, remainingRows int) *testSta
 			defer stage.mu.Unlock()
 			stage.update = append(stage.update, req.Rows)
 
+			if req.Tables != nil {
+				for _, table := range *req.Tables {
+					if tbl, ok := stage.tables[table.Name]; !ok {
+						stage.tables[table.Name] = struct {
+							Name string
+							Rows int
+						}{Name: table.Name, Rows: table.Rows}
+						continue
+					} else {
+						tbl.Rows += table.Rows
+						stage.tables[table.Name] = tbl
+					}
+				}
+
+			}
+
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -437,7 +587,11 @@ type testStage struct {
 
 	remainingRows int
 	update        []int
-	mu            sync.RWMutex
+	tables        map[string]struct {
+		Name string
+		Rows int
+	}
+	mu sync.RWMutex
 }
 
 func (s *testStage) numberOfUpdates() int {
@@ -452,6 +606,16 @@ func (s *testStage) sumOfUpdates() int {
 	sum := 0
 	for _, val := range s.update {
 		sum += val
+	}
+	return sum
+}
+
+func (s *testStage) sumOfTableUpdates() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sum := 0
+	for _, val := range s.tables {
+		sum += val.Rows
 	}
 	return sum
 }


### PR DESCRIPTION
Implements changes requested in [#1502](https://github.com/cloudquery/cloudquery-issues/issues/1502).

The solution consists of adding a new func `IncreaseWithTableBreakdown(table string, rows uint32)` to the existing client, which we can declaratively replace in required non-database plugins incrementally.