### PR TITLE
feat: Re-configure batch updater using response headers

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -458,7 +458,7 @@ func (u *BatchUpdater) updateUsageWithRetryAndBackoff(ctx context.Context, rows 
 func (u *BatchUpdater) updateConfigurationFromHeaders(header http.Header) {
 	if headerValue := header.Get(BatchLimitHeader); headerValue != "" {
 		if newBatchLimit, err := strconv.ParseUint(headerValue, 10, 32); err != nil {
-			u.logger.Warn().Err(err).Str("batch_limit", headerValue).Msg("failed to parse batch limit")
+			u.logger.Warn().Err(err).Str(BatchLimitHeader, headerValue).Msg("failed to parse batch limit")
 		} else {
 			u.batchLimit = uint32(newBatchLimit)
 		}
@@ -466,7 +466,7 @@ func (u *BatchUpdater) updateConfigurationFromHeaders(header http.Header) {
 
 	if headerValue := header.Get(MinimumUpdateIntervalHeader); headerValue != "" {
 		if newInterval, err := strconv.ParseInt(headerValue, 10, 32); err != nil {
-			u.logger.Warn().Err(err).Str("minimum_update_interval", headerValue).Msg("failed to parse minimum update interval")
+			u.logger.Warn().Err(err).Str(MinimumUpdateIntervalHeader, headerValue).Msg("failed to parse minimum update interval")
 		} else {
 			u.minTimeBetweenFlushes = time.Duration(newInterval) * time.Second
 		}
@@ -474,7 +474,7 @@ func (u *BatchUpdater) updateConfigurationFromHeaders(header http.Header) {
 
 	if headerValue := header.Get(MaximumUpdateIntervalHeader); headerValue != "" {
 		if newInterval, err := strconv.ParseInt(headerValue, 10, 32); err != nil {
-			u.logger.Warn().Err(err).Str("maximum_update_interval", headerValue).Msg("failed to parse maximum update interval")
+			u.logger.Warn().Err(err).Str(MaximumUpdateIntervalHeader, headerValue).Msg("failed to parse maximum update interval")
 		} else {
 			newMaxTimeBetweenFlushes := time.Duration(newInterval) * time.Second
 			if u.maxTimeBetweenFlushes != newMaxTimeBetweenFlushes {

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -439,7 +439,9 @@ func (u *BatchUpdater) updateUsageWithRetryAndBackoff(ctx context.Context, rows 
 		if resp.StatusCode() >= 200 && resp.StatusCode() < 300 {
 			u.logger.Debug().Str("url", u.url).Int("try", retry).Int("status_code", resp.StatusCode()).Uint32("rows", rows).Msg("usage updated")
 			u.lastUpdateTime = time.Now().UTC()
-			u.updateConfigurationFromHeaders(resp.HTTPResponse.Header)
+			if resp.HTTPResponse != nil {
+				u.updateConfigurationFromHeaders(resp.HTTPResponse.Header)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
The increase team usage endpoint now returns the desired batch limit and min/max update interval based on the team plan. The plugin sdk should now set the batch updater configuration to the values indicated by the API.

Refs: https://github.com/cloudquery/cloudquery-issues/issues/1551
