### PR TITLE
fix: Remove JSON schema validation warnings

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -215,16 +214,6 @@ func (p *Plugin) Init(ctx context.Context, spec []byte, options NewClientOptions
 	}
 	defer p.mu.Unlock()
 	var err error
-
-	if !options.NoConnection && p.schemaValidator != nil {
-		var v any
-		if err := json.Unmarshal(spec, &v); err != nil {
-			return fmt.Errorf("failed to unmarshal plugin spec: %w", err)
-		}
-		if err := p.schemaValidator.Validate(v); err != nil {
-			p.logger.Err(err).Msg("failed JSON schema validation for spec")
-		}
-	}
 
 	options.PluginMeta = p.Meta()
 


### PR DESCRIPTION
#### Summary

Similar to https://github.com/cloudquery/cloudquery/pull/17994.
It keeps the code that checks that the schema itself is a valid to ensure plugins embed a valid one

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
