### PR TITLE
feat: Enable `NewConnectedClientWithOptions` to set `ClientOptions`

### DIFF
--- a/state/client.go
+++ b/state/client.go
@@ -58,7 +58,7 @@ func NewConnectedClient(ctx context.Context, backendOpts *plugin.BackendOptions)
 // NewConnectedClientWithOptions returns a state client and initialises the gRPC connection to the state backend.
 // The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
 // You must call Close() on the returned Client object.
-func NewConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.BackendOptions, opts ConnectionOptions) (Client, error) {
+func NewConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.BackendOptions, connOpts ConnectionOptions, clOpts ClientOptions) (Client, error) {
 	if backendOpts == nil {
 		return &NoOpClient{}, nil
 	}
@@ -68,8 +68,8 @@ func NewConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.Back
 	backendConn, err := grpc.DialContext(ctx, backendOpts.Connection,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(opts.MaxMsgSizeInBytes),
-			grpc.MaxCallSendMsgSize(opts.MaxMsgSizeInBytes),
+			grpc.MaxCallRecvMsgSize(connOpts.MaxMsgSizeInBytes),
+			grpc.MaxCallSendMsgSize(connOpts.MaxMsgSizeInBytes),
 		),
 	)
 
@@ -77,7 +77,7 @@ func NewConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.Back
 		return &NoOpClient{}, fmt.Errorf("failed to dial grpc source plugin at %s: %w", backendOpts.Connection, err)
 	}
 
-	stateClient, err := NewClient(ctx, backendConn, backendOpts.TableName)
+	stateClient, err := NewClientWithOptions(ctx, backendConn, backendOpts.TableName, clOpts)
 	if err != nil {
 		return &NoOpClient{}, fmt.Errorf("failed to create state client: %w", err)
 	}

--- a/state/client.go
+++ b/state/client.go
@@ -52,7 +52,7 @@ func NewClientWithOptions(ctx context.Context, conn *grpc.ClientConn, tableName 
 // The state client is guaranteed to be non-nil (it defaults to the NoOpClient).
 // You must call Close() on the returned Client object.
 func NewConnectedClient(ctx context.Context, backendOpts *plugin.BackendOptions) (Client, error) {
-	return NewConnectedClientWithOptions(ctx, backendOpts, ConnectionOptions{MaxMsgSizeInBytes: defaultMaxMsgSizeInBytes})
+	return NewConnectedClientWithOptions(ctx, backendOpts, ConnectionOptions{MaxMsgSizeInBytes: defaultMaxMsgSizeInBytes}, ClientOptions{})
 }
 
 // NewConnectedClientWithOptions returns a state client and initialises the gRPC connection to the state backend.


### PR DESCRIPTION
#### Summary

Currently source plugins using the `ConnectedClient` cannot be used with `append` only destinations as the `ClientOption` cannot be set. This PR exposes that option. This won't have any impact on CQ plugins as none of our plugins use `NewConnectedClientWithOptions` 