### PR TITLE
feat: Allow scanning structs into `scalar.Struct`

### DIFF
--- a/scalar/options.go
+++ b/scalar/options.go
@@ -1,0 +1,13 @@
+package scalar
+
+type Option func(Scalar)
+
+func WithNameTransformer(transformer NameTransformer) Option {
+	return func(s Scalar) {
+		st, ok := s.(*Struct)
+		if !ok {
+			return
+		}
+		st.nameTransformer = transformer
+	}
+}

--- a/scalar/scalar_test.go
+++ b/scalar/scalar_test.go
@@ -10,6 +10,15 @@ import (
 )
 
 func TestNewScalar(t *testing.T) {
+	type nested struct {
+		Level1 struct {
+			Level2 struct {
+				A int64
+			}
+			B int64
+		}
+		A int64
+	}
 	tl := []struct {
 		dt    arrow.DataType
 		input any
@@ -56,6 +65,23 @@ func TestNewScalar(t *testing.T) {
 		{dt: arrow.FixedWidthTypes.MonthInterval, input: map[string]any{"months": 1}},
 
 		{dt: arrow.StructOf(arrow.Field{Name: "i64", Type: arrow.PrimitiveTypes.Int64}, arrow.Field{Name: "s", Type: arrow.BinaryTypes.String}), input: `{"i64": 1, "s": "foo"}`},
+		{dt: arrow.StructOf(
+			arrow.Field{
+				Name: "Level1",
+				Type: arrow.StructOf(
+					arrow.Field{
+						Name: "Level2",
+						Type: arrow.StructOf(
+							arrow.Field{Name: "A", Type: arrow.PrimitiveTypes.Int64},
+						),
+					},
+					arrow.Field{Name: "B", Type: arrow.PrimitiveTypes.Int64},
+				),
+			},
+			arrow.Field{Name: "A", Type: arrow.PrimitiveTypes.Int64},
+		),
+			input: nested{}},
+
 		{dt: &arrow.Decimal128Type{Precision: 10, Scale: 5}},
 		{dt: &arrow.Decimal256Type{Precision: 10, Scale: 5}},
 	}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/1835
Extracted from https://github.com/cloudquery/plugin-sdk/pull/1728/files
Added tests & `scalar.NameTransformer`