### PR TITLE
fix: Remove no sentry deprecation warning

### DIFF
--- a/serve/plugin.go
+++ b/serve/plugin.go
@@ -272,8 +272,6 @@ func (s *PluginServe) newCmdPluginServe() *cobra.Command {
 	cmd.Flags().BoolVar(&noSentry, "no-sentry", false, "disable sentry")
 	cmd.Flags().StringVar(&licenseFile, "license", "", "Path to offline license file or directory")
 
-	_ = cmd.Flags().MarkDeprecated("no-sentry", "no-sentry option is deprecated and unused")
-
 	return cmd
 }
 


### PR DESCRIPTION
#### Summary

If you try to disable telemetry with plugins using the latest SDK you get this warning:
```
Flag --no-sentry has been deprecated, no-sentry option is deprecated and unused
```

The reason is that the CLI still sends this flag (ends up here https://github.com/cloudquery/plugin-pb-go/blob/aeb0d17fd2577caacbfdadfecc89fa4a1357cca6/managedplugin/plugin.go#L448), so new plugins print a warning.

We can't remove the sending of the flag, since then older plugins will start sending sentry errors 🙃 

I suggest we remove the log warning for now, and give users a bit of time to upgrade plugins, then remove the flag altogether

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
