### PR TITLE
fix: Revert "fix: Allow marshaling plain string values into JSON scalars"

### DIFF
--- a/scalar/errors.go
+++ b/scalar/errors.go
@@ -24,7 +24,7 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("cannot set `%s` with value `%v`: %s (%s)", e.Type, e.Value, e.Msg, e.Err)
 }
 
-// MaskedError prints the error without the value
+// this prints the error without the value
 func (e *ValidationError) MaskedError() string {
 	if e.Err == nil {
 		return fmt.Sprintf("cannot set `%s`: %s", e.Type, e.Msg)

--- a/scalar/json.go
+++ b/scalar/json.go
@@ -74,29 +74,15 @@ func (s *JSON) Set(val any) error {
 		if value == "" {
 			return nil
 		}
-		if json.Valid([]byte(value)) {
-			s.Value = []byte(value)
-			break
+		if !json.Valid([]byte(value)) {
+			return &ValidationError{Type: types.ExtensionTypes.JSON, Msg: "invalid json string", Value: value}
 		}
-
-		// we have a string value only
-		data, err := json.Marshal(value)
-		if err != nil {
-			return &ValidationError{
-				Type:  types.ExtensionTypes.JSON,
-				Msg:   "invalid json string",
-				Value: value,
-				Err:   err,
-			}
-		}
-		s.Value = data
-
+		s.Value = []byte(value)
 	case *string:
 		if value == nil {
 			return nil
 		}
 		return s.Set(*value)
-
 	case []byte:
 		if value == nil {
 			return nil
@@ -106,7 +92,7 @@ func (s *JSON) Set(val any) error {
 		}
 
 		if !json.Valid(value) {
-			return &ValidationError{Type: types.ExtensionTypes.JSON, Msg: "invalid json byte array", Value: value}
+			return &ValidationError{Type: types.ExtensionTypes.UUID, Msg: "invalid json byte array", Value: value}
 		}
 		s.Value = value
 	// Encode* methods are defined on *JSON. If JSON is passed directly then the

--- a/scalar/json_test.go
+++ b/scalar/json_test.go
@@ -1,12 +1,6 @@
 package scalar
 
-import (
-	"fmt"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 type Foo struct {
 	Num int
@@ -21,7 +15,6 @@ func TestJSONSet(t *testing.T) {
 		{source: "{}", result: JSON{Value: []byte("{}"), Valid: true}},
 		{source: `"test"`, result: JSON{Value: []byte(`"test"`), Valid: true}},
 		{source: "1", result: JSON{Value: []byte("1"), Valid: true}},
-		{source: `json some data`, result: JSON{Value: []byte(`"json some data"`), Valid: true}},
 		{source: "[1, 2, 3]", result: JSON{Value: []byte("[1, 2, 3]"), Valid: true}},
 		{source: []byte("{}"), result: JSON{Value: []byte("{}"), Valid: true}},
 		{source: []byte(`"test"`), result: JSON{Value: []byte(`"test"`), Valid: true}},
@@ -54,13 +47,14 @@ func TestJSONSet(t *testing.T) {
 	}
 
 	for i, tt := range successfulTests {
-		t.Run(fmt.Sprint(tt.source), func(t *testing.T) {
-			var d JSON
-			require.NoError(t, d.Set(tt.source))
-			assert.Truef(t, d.Equal(&tt.result), "%q != %q", d.String(), tt.result.String())
-			if !d.Equal(&tt.result) {
-				t.Errorf("%d: %v != %v", i, d, tt.result)
-			}
-		})
+		var d JSON
+		err := d.Set(tt.source)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+		}
+
+		if !d.Equal(&tt.result) {
+			t.Errorf("%d: %v != %v", i, d, tt.result)
+		}
 	}
 }


### PR DESCRIPTION
Reverts cloudquery/plugin-sdk#1743