### PR TITLE
fix: Use Atomic Pointer for updating duration metric

### DIFF
--- a/scheduler/metrics.go
+++ b/scheduler/metrics.go
@@ -20,16 +20,10 @@ type TableClientMetrics struct {
 }
 
 func durationPointerEqual(a, b *time.Duration) bool {
-	if a == nil && b != nil {
-		return false
+	if a == nil {
+		return b == nil
 	}
-	if a != nil && b == nil {
-		return false
-	}
-	if a == nil && b == nil {
-		return true
-	}
-	return *a == *b
+	return b != nil && *a == *b
 }
 
 func (s *TableClientMetrics) Equal(other *TableClientMetrics) bool {

--- a/scheduler/metrics.go
+++ b/scheduler/metrics.go
@@ -16,7 +16,7 @@ type TableClientMetrics struct {
 	Resources uint64
 	Errors    uint64
 	Panics    uint64
-	Duration  time.Duration
+	Duration  atomic.Pointer[time.Duration]
 }
 
 func (s *TableClientMetrics) Equal(other *TableClientMetrics) bool {

--- a/scheduler/metrics.go
+++ b/scheduler/metrics.go
@@ -19,8 +19,21 @@ type TableClientMetrics struct {
 	Duration  atomic.Pointer[time.Duration]
 }
 
+func durationPointerEqual(a, b *time.Duration) bool {
+	if a == nil && b != nil {
+		return false
+	}
+	if a != nil && b == nil {
+		return false
+	}
+	if a == nil && b == nil {
+		return true
+	}
+	return *a == *b
+}
+
 func (s *TableClientMetrics) Equal(other *TableClientMetrics) bool {
-	return s.Resources == other.Resources && s.Errors == other.Errors && s.Panics == other.Panics && s.Duration == other.Duration
+	return s.Resources == other.Resources && s.Errors == other.Errors && s.Panics == other.Panics && durationPointerEqual(s.Duration.Load(), other.Duration.Load())
 }
 
 // Equal compares to stats. Mostly useful in testing

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -230,7 +230,12 @@ func (s *syncClient) logTablesMetrics(tables schema.Tables, client Client) {
 	clientName := client.ID()
 	for _, table := range tables {
 		metrics := s.metrics.TableClient[table.Name][clientName]
-		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", metrics.Resources).Dur("duration_ms", *metrics.Duration.Load()).Uint64("errors", metrics.Errors).Msg("table sync finished")
+		duration := metrics.Duration.Load()
+		if duration == nil {
+			// This can happen for a relation when there are no resources to resolve from the parent
+			duration = new(time.Duration)
+		}
+		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", metrics.Resources).Dur("duration_ms", *duration).Uint64("errors", metrics.Errors).Msg("table sync finished")
 		s.logTablesMetrics(table.Relations, client)
 	}
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -230,7 +230,7 @@ func (s *syncClient) logTablesMetrics(tables schema.Tables, client Client) {
 	clientName := client.ID()
 	for _, table := range tables {
 		metrics := s.metrics.TableClient[table.Name][clientName]
-		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", metrics.Resources).Dur("duration_ms", metrics.Duration).Uint64("errors", metrics.Errors).Msg("table sync finished")
+		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", metrics.Resources).Dur("duration_ms", *metrics.Duration.Load()).Uint64("errors", metrics.Errors).Msg("table sync finished")
 		s.logTablesMetrics(table.Relations, client)
 	}
 }

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -105,7 +105,7 @@ func (s *syncClient) resolveTableDfs(ctx context.Context, table *schema.Table, c
 	duration := time.Since(startTime)
 	tableMetrics.Duration.Store(&duration)
 	if parent == nil { // Log only for root tables and relations only after resolving is done, otherwise we spam per object instead of per table.
-		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", *tableMetrics.Duration.Load()).Msg("table sync finished")
+		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", duration).Msg("table sync finished")
 		s.logTablesMetrics(table.Relations, client)
 	}
 }

--- a/scheduler/scheduler_dfs.go
+++ b/scheduler/scheduler_dfs.go
@@ -102,9 +102,10 @@ func (s *syncClient) resolveTableDfs(ctx context.Context, table *schema.Table, c
 	}
 
 	// we don't need any waitgroups here because we are waiting for the channel to close
-	tableMetrics.Duration = time.Since(startTime)
+	duration := time.Since(startTime)
+	tableMetrics.Duration.Store(&duration)
 	if parent == nil { // Log only for root tables and relations only after resolving is done, otherwise we spam per object instead of per table.
-		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", tableMetrics.Duration).Msg("table sync finished")
+		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", *tableMetrics.Duration.Load()).Msg("table sync finished")
 		s.logTablesMetrics(table.Relations, client)
 	}
 }


### PR DESCRIPTION
#### Summary

Follow up to https://github.com/cloudquery/plugin-sdk/pull/1757, as it seems we're accessing table metrics in other Go routines (e.g. `resolveResource`)

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
