### PR TITLE
feat: Add `zerolog.Logger` to `retryablehttp.LeveledLogger` adapter struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/invopop/jsonschema v0.12.0
 	github.com/rs/zerolog v1.33.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
@@ -50,7 +51,6 @@ require (
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect

--- a/helpers/retryablehttp/logger.go
+++ b/helpers/retryablehttp/logger.go
@@ -9,19 +9,19 @@ type leveledLogger struct {
 	zerolog.Logger
 }
 
-func (l *leveledLogger) Debug(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogger) Debug(msg string, keysAndValues ...any) {
 	l.Logger.Debug().Fields(keysAndValues).Msg(msg)
 }
 
-func (l *leveledLogger) Error(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogger) Error(msg string, keysAndValues ...any) {
 	l.Logger.Error().Fields(keysAndValues).Msg(msg)
 }
 
-func (l *leveledLogger) Info(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogger) Info(msg string, keysAndValues ...any) {
 	l.Logger.Info().Fields(keysAndValues).Msg(msg)
 }
 
-func (l *leveledLogger) Warn(msg string, keysAndValues ...interface{}) {
+func (l *leveledLogger) Warn(msg string, keysAndValues ...any) {
 	l.Logger.Warn().Fields(keysAndValues).Msg(msg)
 }
 

--- a/helpers/retryablehttp/logger.go
+++ b/helpers/retryablehttp/logger.go
@@ -1,0 +1,30 @@
+package retryablehttp
+
+import (
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/rs/zerolog"
+)
+
+type leveledLogger struct {
+	zerolog.Logger
+}
+
+func (l *leveledLogger) Debug(msg string, keysAndValues ...interface{}) {
+	l.Logger.Debug().Fields(keysAndValues).Msg(msg)
+}
+
+func (l *leveledLogger) Error(msg string, keysAndValues ...interface{}) {
+	l.Logger.Error().Fields(keysAndValues).Msg(msg)
+}
+
+func (l *leveledLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.Logger.Info().Fields(keysAndValues).Msg(msg)
+}
+
+func (l *leveledLogger) Warn(msg string, keysAndValues ...interface{}) {
+	l.Logger.Warn().Fields(keysAndValues).Msg(msg)
+}
+
+func NewLeveledLogger(logger zerolog.Logger) retryablehttp.LeveledLogger {
+	return &leveledLogger{logger}
+}


### PR DESCRIPTION
#### Summary

This allows plugins that use https://github.com/hashicorp/go-retryablehttp to easily log retries as plugins use `github.com/rs/zerolog`

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
