### PR TITLE
feat: Sort state client cache keys before flush

### DIFF
--- a/internal/clients/state/v3/state.go
+++ b/internal/clients/state/v3/state.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"sort"
 	"sync"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -168,7 +169,14 @@ func (c *Client) Flush(ctx context.Context) error {
 	if c.versionedMode {
 		version = bldr.Field(2).(*array.Uint64Builder)
 	}
+
+	changes := make([]string, 0, len(c.changes))
 	for k := range c.changes {
+		changes = append(changes, k)
+	}
+	sort.Strings(changes)
+
+	for _, k := range changes {
 		val := c.mem[k]
 		keys.Append(k)
 		values.Append(val.value)


### PR DESCRIPTION
#### Summary

in some concurrent scenarios several cache keys can be updated by several routines, thus, in order to avoid the deadlocks (in postgresql for example) we should update keys in sorted order.
