### PR TITLE
feat: Add queue based scheduler

### DIFF
--- a/scheduler/metrics/metrics.go
+++ b/scheduler/metrics/metrics.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/v4/schema"
-	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -269,18 +268,4 @@ func (m *TableClientMetrics) OtelEndTime(ctx context.Context, end time.Time) {
 		m.otelMeters.endTime.Add(ctx, val, metric.WithAttributes(m.otelMeters.attributes...))
 	}
 	m.otelMeters.previousEndTime = val
-}
-
-func LogTablesMetrics(logger zerolog.Logger, m *Metrics, tables schema.Tables, client schema.ClientMeta) {
-	clientName := client.ID()
-	for _, table := range tables {
-		tableMetrics := m.TableClient[table.Name][clientName]
-		duration := tableMetrics.Duration.Load()
-		if duration == nil {
-			// This can happen for a relation when there are no resources to resolve from the parent
-			duration = new(time.Duration)
-		}
-		logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", tableMetrics.Resources).Dur("duration_ms", *duration).Uint64("errors", tableMetrics.Errors).Msg("table sync finished")
-		LogTablesMetrics(logger, m, table.Relations, client)
-	}
 }

--- a/scheduler/metrics/metrics_test.go
+++ b/scheduler/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package metrics
 
 import "testing"
 

--- a/scheduler/queue/dispatcher.go
+++ b/scheduler/queue/dispatcher.go
@@ -1,0 +1,305 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cloudquery/plugin-sdk/v4/caser"
+	"github.com/cloudquery/plugin-sdk/v4/helpers"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/metrics"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/resolvers"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const DefaultWorkerCount = 1000
+
+func (w *worker) resolveTable(ctx context.Context, table *schema.Table, client schema.ClientMeta, parent *schema.Resource) {
+	clientName := client.ID()
+	ctx, span := otel.Tracer(metrics.OtelName).Start(ctx,
+		"sync.table."+table.Name,
+		trace.WithAttributes(
+			attribute.Key("sync.client.id").String(clientName),
+			attribute.Key("sync.invocation.id").String(w.invocationID),
+		),
+	)
+	defer span.End()
+	logger := w.logger.With().Str("table", table.Name).Str("client", clientName).Logger()
+	startTime := time.Now()
+	if parent == nil { // Log only for root tables, otherwise we spam too much.
+		logger.Info().Msg("top level table resolver started")
+	}
+	tableMetrics := w.metrics.TableClient[table.Name][clientName]
+	tableMetrics.OtelStartTime(ctx, startTime)
+
+	res := make(chan any)
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				stack := fmt.Sprintf("%s\n%s", err, string(debug.Stack()))
+				logger.Error().Interface("error", err).Str("stack", stack).Msg("table resolver finished with panic")
+				tableMetrics.OtelPanicsAdd(ctx, 1)
+				atomic.AddUint64(&tableMetrics.Panics, 1)
+			}
+			close(res)
+		}()
+		if err := table.Resolver(ctx, client, parent, res); err != nil {
+			logger.Error().Err(err).Msg("table resolver finished with error")
+			tableMetrics.OtelErrorsAdd(ctx, 1)
+			atomic.AddUint64(&tableMetrics.Errors, 1)
+			return
+		}
+	}()
+
+	for r := range res {
+		w.resolveResource(ctx, table, client, parent, r)
+	}
+
+	endTime := time.Now()
+	duration := endTime.Sub(startTime)
+	tableMetrics.Duration.Store(&duration)
+	tableMetrics.OtelEndTime(ctx, endTime)
+	if parent == nil {
+		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", duration).Msg("table sync finished")
+		metrics.LogTablesMetrics(w.logger, w.metrics, table.Relations, client)
+	}
+}
+
+func (w *worker) resolveResource(ctx context.Context, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, resources any) {
+	resourcesSlice := helpers.InterfaceSlice(resources)
+	if len(resourcesSlice) == 0 {
+		return
+	}
+
+	resourcesChan := make(chan *schema.Resource, len(resourcesSlice))
+	go func() {
+		defer close(resourcesChan)
+		var wg sync.WaitGroup
+		for i := range resourcesSlice {
+			i := i
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resolvedResource := resolvers.ResolveSingleResource(ctx, w.logger, w.metrics, table, client, parent, resourcesSlice[i], w.caser)
+				if resolvedResource == nil {
+					return
+				}
+
+				if err := resolvedResource.CalculateCQID(w.deterministicCQID); err != nil {
+					tableMetrics := w.metrics.TableClient[table.Name][client.ID()]
+					w.logger.Error().Err(err).Str("table", table.Name).Str("client", client.ID()).Msg("resource resolver finished with primary key calculation error")
+					atomic.AddUint64(&tableMetrics.Errors, 1)
+					return
+				}
+				if err := resolvedResource.Validate(); err != nil {
+					tableMetrics := w.metrics.TableClient[table.Name][client.ID()]
+					w.logger.Error().Err(err).Str("table", table.Name).Str("client", client.ID()).Msg("resource resolver finished with validation error")
+					atomic.AddUint64(&tableMetrics.Errors, 1)
+					return
+				}
+				select {
+				case resourcesChan <- resolvedResource:
+				case <-ctx.Done():
+				}
+			}()
+		}
+		wg.Wait()
+	}()
+
+	for resource := range resourcesChan {
+		resource := resource
+		w.resolvedResources <- resource
+		for _, r := range resource.Table.Relations {
+			relation := r
+			newJob := &TableClientPair{
+				Table:  relation,
+				Client: client,
+				Parent: resource,
+			}
+			w.newJobs <- newJob
+		}
+	}
+}
+
+type worker struct {
+	jobs              <-chan *TableClientPair
+	newJobs           chan<- *TableClientPair
+	resolvedResources chan<- *schema.Resource
+
+	logger            zerolog.Logger
+	caser             *caser.Caser
+	invocationID      string
+	deterministicCQID bool
+	metrics           *metrics.Metrics
+	onResolveStart    func()
+	onResolveDone     func()
+}
+
+func newWorker(
+	jobs <-chan *TableClientPair,
+	newJobs chan<- *TableClientPair,
+	resolvedResources chan<- *schema.Resource,
+
+	logger zerolog.Logger,
+	c *caser.Caser,
+	invocationID string,
+	deterministicCQID bool,
+	m *metrics.Metrics,
+	onResolveStart func(),
+	onResolveDone func(),
+) *worker {
+	return &worker{
+		jobs:              jobs,
+		newJobs:           newJobs,
+		resolvedResources: resolvedResources,
+		logger:            logger,
+		caser:             c,
+		deterministicCQID: deterministicCQID,
+		invocationID:      invocationID,
+		metrics:           m,
+		onResolveStart:    onResolveStart,
+		onResolveDone:     onResolveDone,
+	}
+}
+
+func (w *worker) work(ctx context.Context) {
+	for j := range w.jobs {
+		w.onResolveStart()
+		client := j.Client
+		table := j.Table
+		parent := j.Parent
+
+		w.resolveTable(ctx, table, client, parent)
+		w.onResolveDone()
+	}
+}
+
+type Dispatcher struct {
+	workerCount       int
+	logger            zerolog.Logger
+	caser             *caser.Caser
+	deterministicCQID bool
+	metrics           *metrics.Metrics
+	invocationID      string
+}
+
+type Option func(*Dispatcher)
+
+func WithWorkerCount(workerCount int) Option {
+	return func(d *Dispatcher) {
+		d.workerCount = workerCount
+	}
+}
+
+func WithCaser(c *caser.Caser) Option {
+	return func(d *Dispatcher) {
+		d.caser = c
+	}
+}
+
+func WithDeterministicCQID(deterministicCQID bool) Option {
+	return func(d *Dispatcher) {
+		d.deterministicCQID = deterministicCQID
+	}
+}
+
+func WithInvocationID(invocationID string) Option {
+	return func(d *Dispatcher) {
+		d.invocationID = invocationID
+	}
+}
+
+func NewDispatcher(logger zerolog.Logger, m *metrics.Metrics, opts ...Option) *Dispatcher {
+	dispatcher := &Dispatcher{
+		logger:       logger,
+		metrics:      m,
+		workerCount:  DefaultWorkerCount,
+		caser:        caser.New(),
+		invocationID: uuid.New().String(),
+	}
+
+	for _, opt := range opts {
+		opt(dispatcher)
+	}
+
+	return dispatcher
+}
+
+func (d *Dispatcher) Dispatch(ctx context.Context, tableClients []TableClientPair, resolvedResources chan<- *schema.Resource) {
+	if len(tableClients) == 0 {
+		return
+	}
+	queue := NewConcurrentQueue(tableClients)
+
+	jobs := make(chan *TableClientPair)
+	newJobs := make(chan *TableClientPair)
+	activeWorkers := &atomic.Uint32{}
+	workStarted := &atomic.Bool{}
+
+	onResolveStart := func() {
+		workStarted.Store(true)
+		activeWorkers.Add(1)
+	}
+	onResolveDone := func() {
+		activeWorkers.Add(^uint32(0))
+	}
+
+	wg := sync.WaitGroup{}
+	for w := 0; w < d.workerCount; w++ {
+		worker := newWorker(
+			jobs,
+			newJobs,
+			resolvedResources,
+			d.logger,
+			d.caser,
+			d.invocationID,
+			d.deterministicCQID,
+			d.metrics,
+			onResolveStart,
+			onResolveDone,
+		)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker.work(ctx)
+		}()
+	}
+
+	go func() {
+		for {
+			if ctx.Err() != nil {
+				break
+			}
+			item := queue.Pop()
+			if item == nil {
+				if !workStarted.Load() || activeWorkers.Load() != 0 {
+					continue
+				}
+				break
+			}
+			jobs <- item
+		}
+		close(jobs)
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case result := <-newJobs:
+				queue.Push(*result)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/scheduler/queue/dispatcher.go
+++ b/scheduler/queue/dispatcher.go
@@ -69,7 +69,6 @@ func (w *worker) resolveTable(ctx context.Context, table *schema.Table, client s
 	tableMetrics.OtelEndTime(ctx, endTime)
 	if parent == nil {
 		logger.Info().Uint64("resources", tableMetrics.Resources).Uint64("errors", tableMetrics.Errors).Dur("duration_ms", duration).Msg("table sync finished")
-		metrics.LogTablesMetrics(w.logger, w.metrics, table.Relations, client)
 	}
 }
 
@@ -281,6 +280,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, tableClients []TableClientPai
 			item := queue.Pop()
 			if item == nil {
 				if !workStarted.Load() || activeWorkers.Load() != 0 {
+					time.Sleep(10 * time.Millisecond)
 					continue
 				}
 				break

--- a/scheduler/queue/dispatcher_test.go
+++ b/scheduler/queue/dispatcher_test.go
@@ -1,0 +1,91 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/metrics"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/cloudquery/plugin-sdk/v4/transformers"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	resourceCount = 10
+)
+
+type Data struct {
+	Name string `json:"name"`
+}
+
+func testResolver(_ context.Context, _ schema.ClientMeta, parent *schema.Resource, res chan<- any) error {
+	resources := make([]*Data, 0, resourceCount)
+	for i := 0; i < resourceCount; i++ {
+		if parent == nil {
+			resources = append(resources, &Data{Name: fmt.Sprintf("test-%d", i)})
+		} else {
+			item := parent.Item.(*Data)
+			resources = append(resources, &Data{Name: fmt.Sprintf("%s-test-%d", item.Name, i)})
+		}
+	}
+	res <- resources
+	return nil
+}
+
+func TestDispatcher(t *testing.T) {
+	nopLogger := zerolog.Nop()
+	m := &metrics.Metrics{TableClient: make(map[string]map[string]*metrics.TableClientMetrics)}
+	dispatcher := NewDispatcher(nopLogger, m, WithWorkerCount(1000))
+	tableClients := []TableClientPair{
+		{
+			Table: &schema.Table{
+				Name:      "table-1",
+				Resolver:  testResolver,
+				Transform: transformers.TransformWithStruct(&Data{}),
+				Relations: schema.Tables{
+					{
+						Name:      "table-1-relation-1",
+						Resolver:  testResolver,
+						Transform: transformers.TransformWithStruct(&Data{}),
+					},
+				},
+			},
+			Client: &testClient{id: "client-1"},
+		},
+		{
+			Table: &schema.Table{
+				Name:      "table-2",
+				Resolver:  testResolver,
+				Transform: transformers.TransformWithStruct(&Data{}),
+				Relations: schema.Tables{
+					{
+						Name:      "table-2-relation-1",
+						Resolver:  testResolver,
+						Transform: transformers.TransformWithStruct(&Data{}),
+					},
+				},
+			},
+			Client: &testClient{id: "client-1"},
+		},
+	}
+
+	for _, tc := range tableClients {
+		m.InitWithClients(tc.Table, []schema.ClientMeta{tc.Client})
+	}
+
+	resolvedResources := make(chan *schema.Resource)
+	go func() {
+		defer close(resolvedResources)
+		dispatcher.Dispatch(context.Background(), tableClients, resolvedResources)
+	}()
+
+	gotResources := make([]*schema.Resource, 0)
+	for r := range resolvedResources {
+		gotResources = append(gotResources, r)
+	}
+
+	// 2 top level tables, each with 10 resources, and each top level has a relation with 10 resources
+	require.Len(t, gotResources, 2*10+2*10*10)
+}

--- a/scheduler/queue/priorityqueue.go
+++ b/scheduler/queue/priorityqueue.go
@@ -75,7 +75,6 @@ func newQueue(tableClients []TableClientPair) *priorityQueue {
 }
 
 type ConcurrentQueue struct {
-	maxSize                   int
 	queue                     *priorityQueue
 	lock                      sync.Mutex
 	itemCountByTableAndClient map[string]int
@@ -88,7 +87,6 @@ func tableClientID(tableClient TableClientPair) string {
 func NewConcurrentQueue(tableClients []TableClientPair) *ConcurrentQueue {
 	cq := ConcurrentQueue{
 		queue:                     newQueue(tableClients),
-		maxSize:                   defaultMaxSize,
 		itemCountByTableAndClient: make(map[string]int),
 	}
 	for _, tc := range tableClients {

--- a/scheduler/queue/priorityqueue.go
+++ b/scheduler/queue/priorityqueue.go
@@ -1,0 +1,131 @@
+package queue
+
+import (
+	"container/heap"
+	"sync"
+
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+)
+
+const (
+	maxPriority    = 10
+	defaultMaxSize = 50000
+)
+
+type TableClientPair struct {
+	Table  *schema.Table
+	Client schema.ClientMeta
+	Parent *schema.Resource
+}
+
+type Item struct {
+	value    TableClientPair
+	priority int
+	index    int
+}
+
+type priorityQueue []*Item
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].priority > pq[j].priority
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *priorityQueue) Push(x any) {
+	n := len(*pq)
+	item := x.(*Item)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *priorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq *priorityQueue) Update(item *Item, value TableClientPair, priority int) {
+	item.value = value
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}
+
+func newQueue(tableClients []TableClientPair) *priorityQueue {
+	pq := make(priorityQueue, len(tableClients))
+	for i, tc := range tableClients {
+		pq[i] = &Item{
+			value:    tc,
+			priority: maxPriority,
+			index:    i,
+		}
+	}
+	heap.Init(&pq)
+	return &pq
+}
+
+type ConcurrentQueue struct {
+	maxSize                   int
+	queue                     *priorityQueue
+	lock                      sync.Mutex
+	itemCountByTableAndClient map[string]int
+}
+
+func tableClientID(tableClient TableClientPair) string {
+	return tableClient.Client.ID() + ":" + tableClient.Table.Name
+}
+
+func NewConcurrentQueue(tableClients []TableClientPair) *ConcurrentQueue {
+	cq := ConcurrentQueue{
+		queue:                     newQueue(tableClients),
+		maxSize:                   defaultMaxSize,
+		itemCountByTableAndClient: make(map[string]int),
+	}
+	for _, tc := range tableClients {
+		if _, ok := cq.itemCountByTableAndClient[tc.Client.ID()+":"+tc.Table.Name]; ok {
+			cq.itemCountByTableAndClient[tableClientID(tc)]++
+		} else {
+			cq.itemCountByTableAndClient[tableClientID(tc)] = 1
+		}
+	}
+	return &cq
+}
+
+func (cq *ConcurrentQueue) getPriority(tableClient TableClientPair) int {
+	priority := maxPriority - cq.itemCountByTableAndClient[tableClientID(tableClient)]
+	return priority
+}
+
+func (cq *ConcurrentQueue) Push(tableClient TableClientPair) {
+	cq.lock.Lock()
+	defer cq.lock.Unlock()
+	if _, ok := cq.itemCountByTableAndClient[tableClientID(tableClient)]; !ok {
+		cq.itemCountByTableAndClient[tableClientID(tableClient)] = 0
+	}
+	heap.Push(cq.queue, &Item{
+		value:    tableClient,
+		priority: cq.getPriority(tableClient),
+	})
+	cq.itemCountByTableAndClient[tableClientID(tableClient)]++
+}
+
+func (cq *ConcurrentQueue) Pop() *TableClientPair {
+	cq.lock.Lock()
+	defer cq.lock.Unlock()
+	if cq.queue.Len() == 0 {
+		return nil
+	}
+	tableClient := heap.Pop(cq.queue).(*Item).value
+	cq.itemCountByTableAndClient[tableClient.Client.ID()+":"+tableClient.Table.Name]--
+	return &tableClient
+}

--- a/scheduler/queue/priorityqueue_test.go
+++ b/scheduler/queue/priorityqueue_test.go
@@ -1,0 +1,93 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/stretchr/testify/require"
+)
+
+type testClient struct {
+	id string
+}
+
+func (tc *testClient) ID() string {
+	return tc.id
+}
+
+func TestNewConcurrentQueue(t *testing.T) {
+	tableClients := []TableClientPair{
+		{
+			Table:  &schema.Table{Name: "table-1"},
+			Client: &testClient{id: "client-1"},
+		},
+		{
+			Table:  &schema.Table{Name: "table-2"},
+			Client: &testClient{id: "client-2"},
+		},
+	}
+	queue := NewConcurrentQueue(tableClients)
+	require.Equal(t, len(tableClients), queue.queue.Len())
+}
+
+func TestConcurrentQueuePushPop(t *testing.T) {
+	tableClients := []TableClientPair{
+		{
+			Table:  &schema.Table{Name: "table-1"},
+			Client: &testClient{id: "client-1"},
+		},
+		{
+			Table:  &schema.Table{Name: "table-2"},
+			Client: &testClient{id: "client-2"},
+		},
+	}
+	queue := NewConcurrentQueue(tableClients)
+
+	// Simulate table 3 as a child of table 1
+	table3Count := 5
+	for i := 0; i < table3Count; i++ {
+		queue.Push(TableClientPair{
+			Table:  &schema.Table{Name: "table-3"},
+			Client: &testClient{id: "client-1"},
+		})
+	}
+
+	// Simulate table 4 as a child of table 2
+	table4Count := 10
+	for i := 0; i < table4Count; i++ {
+		queue.Push(TableClientPair{
+			Table:  &schema.Table{Name: "table-4"},
+			Client: &testClient{id: "client-2"},
+		})
+	}
+
+	gotClients := make([]TableClientPair, 0)
+	for {
+		if queue.queue.Len() == 0 {
+			break
+		}
+		gotClients = append(gotClients, *queue.Pop())
+	}
+	require.Equal(t, len(tableClients)+table3Count+table4Count, len(gotClients))
+
+	require.Equal(t, "table-1", gotClients[0].Table.Name)
+	require.Equal(t, "table-2", gotClients[1].Table.Name)
+
+	// Priority declines as there are more items in the queue
+	// We expect to get 5 of table-3 and table-4, then the rest of table-4
+	require.Equal(t, "table-4", gotClients[2].Table.Name)
+	require.Equal(t, "table-3", gotClients[3].Table.Name)
+	require.Equal(t, "table-3", gotClients[4].Table.Name)
+	require.Equal(t, "table-4", gotClients[5].Table.Name)
+	require.Equal(t, "table-3", gotClients[6].Table.Name)
+	require.Equal(t, "table-4", gotClients[7].Table.Name)
+	require.Equal(t, "table-4", gotClients[8].Table.Name)
+	require.Equal(t, "table-3", gotClients[9].Table.Name)
+	require.Equal(t, "table-4", gotClients[10].Table.Name)
+	require.Equal(t, "table-3", gotClients[11].Table.Name)
+	require.Equal(t, "table-4", gotClients[12].Table.Name)
+	require.Equal(t, "table-4", gotClients[13].Table.Name)
+	require.Equal(t, "table-4", gotClients[14].Table.Name)
+	require.Equal(t, "table-4", gotClients[15].Table.Name)
+	require.Equal(t, "table-4", gotClients[16].Table.Name)
+}

--- a/scheduler/resolvers/resolvers.go
+++ b/scheduler/resolvers/resolvers.go
@@ -1,0 +1,82 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync/atomic"
+	"time"
+
+	"github.com/cloudquery/plugin-sdk/v4/caser"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/metrics"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/rs/zerolog"
+	"github.com/thoas/go-funk"
+)
+
+func resolveColumn(ctx context.Context, logger zerolog.Logger, tableMetrics *metrics.TableClientMetrics, client schema.ClientMeta, resource *schema.Resource, column schema.Column, c *caser.Caser) {
+	columnStartTime := time.Now()
+	defer func() {
+		if err := recover(); err != nil {
+			stack := fmt.Sprintf("%s\n%s", err, string(debug.Stack()))
+			logger.Error().Str("column", column.Name).Interface("error", err).TimeDiff("duration", time.Now(), columnStartTime).Str("stack", stack).Msg("column resolver finished with panic")
+			atomic.AddUint64(&tableMetrics.Panics, 1)
+		}
+	}()
+
+	if column.Resolver != nil {
+		if err := column.Resolver(ctx, client, resource, column); err != nil {
+			logger.Error().Err(err).Msg("column resolver finished with error")
+			atomic.AddUint64(&tableMetrics.Errors, 1)
+		}
+	} else {
+		// base use case: try to get column with CamelCase name
+		v := funk.Get(resource.GetItem(), c.ToPascal(column.Name), funk.WithAllowZero())
+		if v != nil {
+			err := resource.Set(column.Name, v)
+			if err != nil {
+				logger.Error().Err(err).Msg("column resolver finished with error")
+				atomic.AddUint64(&tableMetrics.Errors, 1)
+			}
+		}
+	}
+}
+
+func ResolveSingleResource(ctx context.Context, logger zerolog.Logger, m *metrics.Metrics, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, item any, c *caser.Caser) *schema.Resource {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	resource := schema.NewResourceData(table, parent, item)
+	objectStartTime := time.Now()
+	clientID := client.ID()
+	tableMetrics := m.TableClient[table.Name][clientID]
+	tableLogger := logger.With().Str("table", table.Name).Str("client", clientID).Logger()
+	defer func() {
+		if err := recover(); err != nil {
+			stack := fmt.Sprintf("%s\n%s", err, string(debug.Stack()))
+			tableLogger.Error().Interface("error", err).TimeDiff("duration", time.Now(), objectStartTime).Str("stack", stack).Msg("resource resolver finished with panic")
+			atomic.AddUint64(&tableMetrics.Panics, 1)
+		}
+	}()
+	if table.PreResourceResolver != nil {
+		if err := table.PreResourceResolver(ctx, client, resource); err != nil {
+			tableLogger.Error().Err(err).Msg("pre resource resolver failed")
+			atomic.AddUint64(&tableMetrics.Errors, 1)
+			return nil
+		}
+	}
+
+	for _, column := range table.Columns {
+		resolveColumn(ctx, tableLogger, tableMetrics, client, resource, column, c)
+	}
+
+	if table.PostResourceResolver != nil {
+		if err := table.PostResourceResolver(ctx, client, resource); err != nil {
+			tableLogger.Error().Stack().Err(err).Msg("post resource resolver finished with error")
+			atomic.AddUint64(&tableMetrics.Errors, 1)
+		}
+	}
+
+	tableMetrics.OtelResourcesAdd(ctx, 1)
+	atomic.AddUint64(&tableMetrics.Resources, 1)
+	return resource
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cloudquery/plugin-sdk/v4/caser"
 	"github.com/cloudquery/plugin-sdk/v4/message"
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/metrics"
 	"github.com/cloudquery/plugin-sdk/v4/schema"
 	"github.com/rs/zerolog"
-	"github.com/thoas/go-funk"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -27,7 +25,6 @@ const (
 	DefaultMaxDepth                        = 4
 	minTableConcurrency                    = 1
 	minResourceConcurrency                 = 100
-	otelName                               = "io.cloudquery"
 )
 
 var ErrNoTables = errors.New("no tables specified for syncing, review `tables` and `skip_tables` in your config and specify at least one table to sync")
@@ -36,6 +33,7 @@ const (
 	StrategyDFS Strategy = iota
 	StrategyRoundRobin
 	StrategyShuffle
+	StrategyPriorityQueue
 )
 
 type Option func(*Scheduler)
@@ -125,7 +123,7 @@ type syncClient struct {
 	scheduler         *Scheduler
 	deterministicCQID bool
 	// status sync metrics
-	metrics      *Metrics
+	metrics      *metrics.Metrics
 	logger       zerolog.Logger
 	invocationID string
 }
@@ -178,7 +176,7 @@ func (s *Scheduler) SyncAll(ctx context.Context, client schema.ClientMeta, table
 }
 
 func (s *Scheduler) Sync(ctx context.Context, client schema.ClientMeta, tables schema.Tables, res chan<- message.SyncMessage, opts ...SyncOption) error {
-	ctx, span := otel.Tracer(otelName).Start(ctx,
+	ctx, span := otel.Tracer(metrics.OtelName).Start(ctx,
 		"sync",
 		trace.WithAttributes(attribute.Key("sync.invocation.id").String(s.invocationID)),
 	)
@@ -188,7 +186,7 @@ func (s *Scheduler) Sync(ctx context.Context, client schema.ClientMeta, tables s
 	}
 
 	syncClient := &syncClient{
-		metrics:      &Metrics{TableClient: make(map[string]map[string]*TableClientMetrics)},
+		metrics:      &metrics.Metrics{TableClient: make(map[string]map[string]*metrics.TableClientMetrics)},
 		tables:       tables,
 		client:       client,
 		scheduler:    s,
@@ -232,6 +230,8 @@ func (s *Scheduler) Sync(ctx context.Context, client schema.ClientMeta, tables s
 			syncClient.syncRoundRobin(ctx, resources)
 		case StrategyShuffle:
 			syncClient.syncShuffle(ctx, resources)
+		case StrategyPriorityQueue:
+			syncClient.syncPriorityQueue(ctx, resources)
 		default:
 			panic(fmt.Errorf("unknown scheduler %s", s.strategy.String()))
 		}
@@ -255,81 +255,14 @@ func (s *Scheduler) Sync(ctx context.Context, client schema.ClientMeta, tables s
 func (s *syncClient) logTablesMetrics(tables schema.Tables, client Client) {
 	clientName := client.ID()
 	for _, table := range tables {
-		metrics := s.metrics.TableClient[table.Name][clientName]
-		duration := metrics.Duration.Load()
+		m := s.metrics.TableClient[table.Name][clientName]
+		duration := m.Duration.Load()
 		if duration == nil {
 			// This can happen for a relation when there are no resources to resolve from the parent
 			duration = new(time.Duration)
 		}
-		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", metrics.Resources).Dur("duration_ms", *duration).Uint64("errors", metrics.Errors).Msg("table sync finished")
+		s.logger.Info().Str("table", table.Name).Str("client", clientName).Uint64("resources", m.Resources).Dur("duration_ms", *duration).Uint64("errors", m.Errors).Msg("table sync finished")
 		s.logTablesMetrics(table.Relations, client)
-	}
-}
-
-func (s *syncClient) resolveResource(ctx context.Context, table *schema.Table, client schema.ClientMeta, parent *schema.Resource, item any) *schema.Resource {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
-	resource := schema.NewResourceData(table, parent, item)
-	objectStartTime := time.Now()
-	clientID := client.ID()
-	tableMetrics := s.metrics.TableClient[table.Name][clientID]
-	logger := s.logger.With().Str("table", table.Name).Str("client", clientID).Logger()
-	defer func() {
-		if err := recover(); err != nil {
-			stack := fmt.Sprintf("%s\n%s", err, string(debug.Stack()))
-			logger.Error().Interface("error", err).TimeDiff("duration", time.Now(), objectStartTime).Str("stack", stack).Msg("resource resolver finished with panic")
-			atomic.AddUint64(&tableMetrics.Panics, 1)
-		}
-	}()
-	if table.PreResourceResolver != nil {
-		if err := table.PreResourceResolver(ctx, client, resource); err != nil {
-			logger.Error().Err(err).Msg("pre resource resolver failed")
-			atomic.AddUint64(&tableMetrics.Errors, 1)
-			return nil
-		}
-	}
-
-	for _, c := range table.Columns {
-		s.resolveColumn(ctx, logger, tableMetrics, client, resource, c)
-	}
-
-	if table.PostResourceResolver != nil {
-		if err := table.PostResourceResolver(ctx, client, resource); err != nil {
-			logger.Error().Stack().Err(err).Msg("post resource resolver finished with error")
-			atomic.AddUint64(&tableMetrics.Errors, 1)
-		}
-	}
-
-	tableMetrics.OtelResourcesAdd(ctx, 1)
-	atomic.AddUint64(&tableMetrics.Resources, 1)
-	return resource
-}
-
-func (s *syncClient) resolveColumn(ctx context.Context, logger zerolog.Logger, tableMetrics *TableClientMetrics, client schema.ClientMeta, resource *schema.Resource, c schema.Column) {
-	columnStartTime := time.Now()
-	defer func() {
-		if err := recover(); err != nil {
-			stack := fmt.Sprintf("%s\n%s", err, string(debug.Stack()))
-			logger.Error().Str("column", c.Name).Interface("error", err).TimeDiff("duration", time.Now(), columnStartTime).Str("stack", stack).Msg("column resolver finished with panic")
-			atomic.AddUint64(&tableMetrics.Panics, 1)
-		}
-	}()
-
-	if c.Resolver != nil {
-		if err := c.Resolver(ctx, client, resource, c); err != nil {
-			logger.Error().Err(err).Msg("column resolver finished with error")
-			atomic.AddUint64(&tableMetrics.Errors, 1)
-		}
-	} else {
-		// base use case: try to get column with CamelCase name
-		v := funk.Get(resource.GetItem(), s.scheduler.caser.ToPascal(c.Name), funk.WithAllowZero())
-		if v != nil {
-			err := resource.Set(c.Name, v)
-			if err != nil {
-				logger.Error().Err(err).Msg("column resolver finished with error")
-				atomic.AddUint64(&tableMetrics.Errors, 1)
-			}
-		}
 	}
 }
 

--- a/scheduler/scheduler_debug.go
+++ b/scheduler/scheduler_debug.go
@@ -50,7 +50,7 @@ func (s *syncClient) syncTest(ctx context.Context, syncMultiplier int, resolvedR
 		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initialize the metrics structure once in the main goroutine
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.
-		s.metrics.initWithClients(table, clients)
+		s.metrics.InitWithClients(table, clients)
 	}
 
 	// First interleave the tables like in round-robin

--- a/scheduler/scheduler_round_robin.go
+++ b/scheduler/scheduler_round_robin.go
@@ -33,7 +33,7 @@ func (s *syncClient) syncRoundRobin(ctx context.Context, resolvedResources chan<
 		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.
-		s.metrics.initWithClients(table, clients)
+		s.metrics.InitWithClients(table, clients)
 	}
 
 	tableClients := roundRobinInterleave(s.tables, preInitialisedClients)

--- a/scheduler/scheduler_shuffle.go
+++ b/scheduler/scheduler_shuffle.go
@@ -33,7 +33,7 @@ func (s *syncClient) syncShuffle(ctx context.Context, resolvedResources chan<- *
 		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.
-		s.metrics.initWithClients(table, clients)
+		s.metrics.InitWithClients(table, clients)
 	}
 
 	// First interleave the tables like in round-robin

--- a/scheduler/scheduler_worker.go
+++ b/scheduler/scheduler_worker.go
@@ -1,0 +1,47 @@
+package scheduler
+
+import (
+	"context"
+
+	"github.com/cloudquery/plugin-sdk/v4/scheduler/queue"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+)
+
+func (s *syncClient) syncPriorityQueue(ctx context.Context, resolvedResources chan<- *schema.Resource) {
+	// we have this because plugins can return sometimes clients in a random way which will cause
+	// differences between this run and the next one.
+	preInitialisedClients := make([][]schema.ClientMeta, len(s.tables))
+	tableNames := make([]string, len(s.tables))
+	for i, table := range s.tables {
+		tableNames[i] = table.Name
+		clients := []schema.ClientMeta{s.client}
+		if table.Multiplex != nil {
+			clients = table.Multiplex(s.client)
+		}
+		preInitialisedClients[i] = clients
+		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
+		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.
+		s.metrics.InitWithClients(table, clients)
+	}
+
+	tableClients := roundRobinInterleave(s.tables, preInitialisedClients)
+	seed := hashTableNames(tableNames)
+	shuffle(tableClients, seed)
+
+	dispatcher := queue.NewDispatcher(
+		s.logger,
+		s.metrics,
+		queue.WithWorkerCount(s.scheduler.concurrency),
+		queue.WithCaser(s.scheduler.caser),
+		queue.WithDeterministicCQID(s.deterministicCQID),
+		queue.WithInvocationID(s.invocationID),
+	)
+	queueClients := make([]queue.TableClientPair, 0, len(tableClients))
+	for _, tc := range tableClients {
+		queueClients = append(queueClients, queue.TableClientPair{
+			Table:  tc.table,
+			Client: tc.client,
+		})
+	}
+	dispatcher.Dispatch(ctx, queueClients, resolvedResources)
+}

--- a/scheduler/strategy.go
+++ b/scheduler/strategy.go
@@ -70,11 +70,12 @@ func (Strategy) JSONSchema() *jsonschema.Schema {
 	}
 }
 
-var AllStrategies = Strategies{StrategyDFS, StrategyRoundRobin, StrategyShuffle}
+var AllStrategies = Strategies{StrategyDFS, StrategyRoundRobin, StrategyShuffle, StrategyPriorityQueue}
 var AllStrategyNames = [...]string{
-	StrategyDFS:        "dfs",
-	StrategyRoundRobin: "round-robin",
-	StrategyShuffle:    "shuffle",
+	StrategyDFS:           "dfs",
+	StrategyRoundRobin:    "round-robin",
+	StrategyShuffle:       "shuffle",
+	StrategyPriorityQueue: "priority-queue",
 }
 
 func StrategyForName(s string) (Strategy, error) {


### PR DESCRIPTION
#### Summary

Mostly an experiment to deal with https://github.com/cloudquery/cloudquery-issues/issues/2227 as I couldn't think of a nice way to make `singleNestedTableMaxConcurrency` dynamic without making the code super complex.

This PR adds a scheduler that uses a worker pool pattern on top of a priority queue. This should ensure that as long as there's work to be done, all Go routines will be occupied. Also the `concurrency` setting is not only for the top level tables, as it's the number of workers so it's a fixed limit and simpler.
The more table client pairs in the queue the less priority they'll have, this should prevent a specific table from occupying all the workers.

Opening as draft since:
1. I'm still testing this to see the impact
2. There's still a lot of code duplication with current code and refactoring needed to avoid it


---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
