### PR TITLE
feat: Add remoteoauth helpers (`TokenAuthTransport` and `TokenAuthEditor`)

### DIFF
--- a/helpers/remoteoauth/tokenautheditor.go
+++ b/helpers/remoteoauth/tokenautheditor.go
@@ -1,0 +1,26 @@
+package remoteoauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// TokenAuthEditor returns a custom RequestEditorFn to inject the OAuth2 token
+func TokenAuthEditor(tokenSource oauth2.TokenSource) func(context.Context, *http.Request) error {
+	return func(_ context.Context, req *http.Request) error {
+		token, err := tokenSource.Token()
+		if err != nil {
+			return fmt.Errorf("remoteoauth: failed to get token: %w", err)
+		}
+		if token == nil {
+			return errNilToken
+		}
+
+		// Inject the token as the Authorization header
+		token.SetAuthHeader(req)
+		return nil
+	}
+}

--- a/helpers/remoteoauth/tokenauthtransport.go
+++ b/helpers/remoteoauth/tokenauthtransport.go
@@ -1,0 +1,56 @@
+package remoteoauth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// TokenAuthTransport is a custom http.RoundTripper to inject the OAuth2 token
+type TokenAuthTransport struct {
+	TokenSource oauth2.TokenSource // required
+
+	BaseTransport http.RoundTripper
+	Rewriter      RewriterFunc
+}
+
+var errNilToken = errors.New("remoteoauth: nil token")
+
+// RewriterFunc is a function that can be used to rewrite the request before it is sent
+type RewriterFunc func(*http.Request, oauth2.Token)
+
+// RoundTrip executes a single HTTP transaction and injects the token into the request header
+func (t *TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqCopy := req.Clone(req.Context())
+
+	token, err := t.TokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("remoteoauth: failed to get token: %w", err)
+	}
+	if token == nil {
+		return nil, errNilToken
+	}
+
+	if t.Rewriter != nil {
+		t.Rewriter(reqCopy, *token)
+	} else {
+		// Inject the token as the Authorization header
+		token.SetAuthHeader(reqCopy)
+	}
+
+	transport := t.BaseTransport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	return transport.RoundTrip(reqCopy)
+}
+
+// NewAuthTransport creates a new TokenAuthTransport with the provided TokenSource
+func NewAuthTransport(ts oauth2.TokenSource) http.RoundTripper {
+	return &TokenAuthTransport{
+		TokenSource: ts,
+	}
+}


### PR DESCRIPTION
These helpers can be used to inject dynamic tokens into requests.

`TokenAuthTransport` is a `http.RoundTripper`, with optional custom rewriting capability
`TokenAuthEditor(oauth2.TokenSource)` returns a `func(context.Context, *http.Request) error` to be used as a `RequestEditorFn` in openapi clients.