### PR TITLE
feat: Add warning on duplicate clients for `round-robin` and `shuffle` schedulers

### DIFF
--- a/scheduler/scheduler_shuffle.go
+++ b/scheduler/scheduler_shuffle.go
@@ -21,6 +21,15 @@ func (s *syncClient) syncShuffle(ctx context.Context, resolvedResources chan<- *
 		if table.Multiplex != nil {
 			clients = table.Multiplex(s.client)
 		}
+		// Detect duplicate clients while multiplexing
+		seenClients := make(map[string]bool)
+		for _, c := range clients {
+			if _, ok := seenClients[c.ID()]; !ok {
+				seenClients[c.ID()] = true
+			} else {
+				s.logger.Warn().Str("client", c.ID()).Str("table", table.Name).Msg("multiplex returned duplicate client")
+			}
+		}
 		preInitialisedClients[i] = clients
 		// we do this here to avoid locks so we initial the metrics structure once in the main goroutines
 		// and then we can just read from it in the other goroutines concurrently given we are not writing to it.


### PR DESCRIPTION
#### Summary

`multiplex returned duplicate client` warning for incorrect multiplexers occurs only when `dfs` scheduler is used. This PR adds the same warning for `round-robin` and `shuffle` schedulers.

More context here: https://discord.com/channels/872925471417962546/1271466277189324831

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
