### PR TITLE
fix: Fix panic when converting schema changes to string

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -231,7 +231,7 @@ func (t TableColumnChange) String() string {
 	case TableColumnChangeTypeRemoveUniqueConstraint:
 		return fmt.Sprintf("column: %s, previous: %s", t.ColumnName, t.Previous)
 	case TableColumnChangeTypeMoveToCQOnly:
-		return fmt.Sprintf("multi-column: %s, type: %s, previous: %s", t.ColumnName, t.Type, t.Previous)
+		return fmt.Sprintf("multi-column: %s, type: %s", t.ColumnName, t.Type)
 	default:
 		return fmt.Sprintf("column: %s, type: %s, current: %s, previous: %s", t.ColumnName, t.Type, t.Current, t.Previous)
 	}


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->


`previous` is never set so shouldn't be stringified