### PR TITLE
feat(remoteoauth): Add `WithToken` option

### DIFF
--- a/helpers/remoteoauth/token_test.go
+++ b/helpers/remoteoauth/token_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 const testAPIKey = "test-key"
@@ -18,6 +19,18 @@ func TestLocalTokenAccess(t *testing.T) {
 	_, cloud := os.LookupEnv("CQ_CLOUD")
 	r.False(cloud, "CQ_CLOUD should not be set")
 	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
+	r.NoError(err)
+	tk, err := tok.Token()
+	r.NoError(err)
+	r.True(tk.Valid())
+	r.Equal("token", tk.AccessToken)
+}
+
+func TestLocalTokenAccessWithTokenOpt(t *testing.T) {
+	r := require.New(t)
+	_, cloud := os.LookupEnv("CQ_CLOUD")
+	r.False(cloud, "CQ_CLOUD should not be set")
+	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token", TokenType: "bearer"}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.NoError(err)

--- a/helpers/remoteoauth/token_test.go
+++ b/helpers/remoteoauth/token_test.go
@@ -18,7 +18,7 @@ func TestLocalTokenAccess(t *testing.T) {
 	r := require.New(t)
 	_, cloud := os.LookupEnv("CQ_CLOUD")
 	r.False(cloud, "CQ_CLOUD should not be set")
-	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
+	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token", TokenType: "bearer"}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.NoError(err)
@@ -26,11 +26,11 @@ func TestLocalTokenAccess(t *testing.T) {
 	r.Equal("token", tk.AccessToken)
 }
 
-func TestLocalTokenAccessWithTokenOpt(t *testing.T) {
+func TestLocalTokenAccessWithDeprecatedTokenOpt(t *testing.T) {
 	r := require.New(t)
 	_, cloud := os.LookupEnv("CQ_CLOUD")
 	r.False(cloud, "CQ_CLOUD should not be set")
-	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token", TokenType: "bearer"}))
+	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.NoError(err)
@@ -54,7 +54,7 @@ func TestFirstLocalTokenAccess(t *testing.T) {
 		"_CQ_CONNECTOR_ID":   connID,
 	})
 	r := require.New(t)
-	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
+	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token"}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.NoError(err)
@@ -76,7 +76,7 @@ func TestInvalidAPIKeyTokenAccess(t *testing.T) {
 		"_CQ_CONNECTOR_ID":   connID,
 	})
 	r := require.New(t)
-	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
+	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token"}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.Nil(tk)
@@ -123,7 +123,7 @@ func TestTestConnectionTokenAccess(t *testing.T) {
 		"_CQ_CONNECTOR_ID":            connID,
 	})
 	r := require.New(t)
-	tok, err := NewTokenSource(WithAccessToken("token", "bearer", time.Time{}))
+	tok, err := NewTokenSource(WithToken(oauth2.Token{AccessToken: "token"}))
 	r.NoError(err)
 	tk, err := tok.Token()
 	r.NoError(err)

--- a/helpers/remoteoauth/tokenoptions.go
+++ b/helpers/remoteoauth/tokenoptions.go
@@ -19,6 +19,12 @@ func WithAccessToken(token, tokenType string, expiry time.Time) TokenSourceOptio
 	}
 }
 
+func WithToken(token oauth2.Token) TokenSourceOption {
+	return func(t *tokenSource) {
+		t.currentToken = token
+	}
+}
+
 func WithDefaultContext(ctx context.Context) TokenSourceOption {
 	return func(t *tokenSource) {
 		t.defaultContext = ctx

--- a/helpers/remoteoauth/tokenoptions.go
+++ b/helpers/remoteoauth/tokenoptions.go
@@ -9,6 +9,8 @@ import (
 
 type TokenSourceOption func(source *tokenSource)
 
+// WithAccessToken sets the access token, token type and expiry time for the token source.
+// Deprecated: Use WithToken instead.
 func WithAccessToken(token, tokenType string, expiry time.Time) TokenSourceOption {
 	return func(t *tokenSource) {
 		t.currentToken = oauth2.Token{
@@ -19,12 +21,14 @@ func WithAccessToken(token, tokenType string, expiry time.Time) TokenSourceOptio
 	}
 }
 
+// WithToken sets the default token for the token source.
 func WithToken(token oauth2.Token) TokenSourceOption {
 	return func(t *tokenSource) {
 		t.currentToken = token
 	}
 }
 
+// WithDefaultContext sets the default context for the token source, used when creating a new token request.
 func WithDefaultContext(ctx context.Context) TokenSourceOption {
 	return func(t *tokenSource) {
 		t.defaultContext = ctx


### PR DESCRIPTION
instead of `WithAccessToken`, which needed explicit default values and didn't support refresh tokens in non-cloud mode.