### PR TITLE
feat: Allow passing unknown flags to plugins

### DIFF
--- a/serve/docs.go
+++ b/serve/docs.go
@@ -49,6 +49,9 @@ func (s *PluginServe) newCmdPluginDoc() *cobra.Command {
 			}
 			return g.Generate(args[0], f)
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 	cmd.Flags().Var(format, "format", fmt.Sprintf("output format. one of: %s", strings.Join(format.Allowed, ",")))
 	return cmd

--- a/serve/package.go
+++ b/serve/package.go
@@ -447,6 +447,9 @@ func (s *PluginServe) newCmdPluginPackage() *cobra.Command {
 			}
 			return nil
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 	cmd.Flags().StringP("dist-dir", "D", "", "dist directory to output the built plugin. (default: <plugin_directory>/dist)")
 	cmd.Flags().StringP("docs-dir", "", "", "docs directory containing markdown files to copy to the dist directory. (default: <plugin_directory>/docs)")

--- a/serve/plugin.go
+++ b/serve/plugin.go
@@ -226,6 +226,9 @@ func (s *PluginServe) newCmdPluginServe() *cobra.Command {
 			}
 			return nil
 		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 	}
 	cmd.Flags().StringVar(&address, "address", "localhost:7777", "address to serve on. can be tcp: `localhost:7777` or unix socket: `/tmp/plugin.rpc.sock`")
 	cmd.Flags().StringVar(&network, "network", "tcp", `the network must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket"`)


### PR DESCRIPTION
#### Summary

Should help with https://github.com/cloudquery/cloudquery-issues/issues/2455#issuecomment-2363343665 (internal issue).

At the moment, each time we add a new flag to a plugin and pass it from the CLI it will break all existing plugins since they fail to parse known flags.

This should allow the CLI send new flags to new plugins without breaking existing ones

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
