### PR TITLE
fix: Ensure module field exists in all log messages

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -210,7 +210,7 @@ func (p *Plugin) Targets() []BuildTarget {
 }
 
 func (p *Plugin) SetLogger(logger zerolog.Logger) {
-	p.logger = logger.With().Str("module", p.name+"-"+string(p.Kind())).Logger()
+	p.logger = logger
 }
 
 func (p *Plugin) Tables(ctx context.Context, options TableOptions) (schema.Tables, error) {

--- a/serve/plugin.go
+++ b/serve/plugin.go
@@ -134,6 +134,8 @@ func (s *PluginServe) newCmdPluginServe() *cobra.Command {
 				logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout}).Level(zerologLevel)
 			}
 
+			logger = logger.With().Str("module", s.plugin.Name()+"-"+string(s.plugin.Kind())).Logger()
+
 			shutdown, err := setupOtel(cmd.Context(), logger, s.plugin, otelEndpoint, otelEndpointInsecure)
 			if err != nil {
 				return fmt.Errorf("failed to setup OpenTelemetry: %w", err)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/cloudquery-issues/issues/2627

The wrong value in the `module` field is because of the bug fixed in https://github.com/cloudquery/plugin-pb-go/pull/421

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
