### PR TITLE
fix: Flaky usage tests

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -186,6 +186,7 @@ type BatchUpdater struct {
 	done                chan struct{}
 	closeError          chan error
 	isClosed            bool
+	dataOnClose         bool
 	usageIncreaseMethod int
 }
 
@@ -486,6 +487,7 @@ func (u *BatchUpdater) backgroundUpdater() {
 			case <-u.done:
 				tables, totals := u.getTableUsage()
 				if totals != 0 {
+					u.dataOnClose = true
 					// To allow us to round up the total in the last batch we need to save the original total
 					// to use in the last subtractTableUsage
 					originalTotals := totals

--- a/premium/usage_test.go
+++ b/premium/usage_test.go
@@ -287,15 +287,20 @@ func TestUsageService_Increase_WithMinimumUpdateDuration(t *testing.T) {
 
 	usageClient := newClient(t, apiClient, WithBatchLimit(0), WithMinTimeBetweenFlushes(30*time.Second))
 
-	for i := 0; i < 10000; i++ {
+	rows := 10000
+	for i := 0; i < rows; i++ {
 		err = usageClient.Increase(1)
 		require.NoError(t, err)
 	}
 	err = usageClient.Close()
 	require.NoError(t, err)
 
-	assert.Equal(t, 10000, s.sumOfUpdates(), "total should equal number of updated rows")
-	assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
+	if usageClient.dataOnClose {
+		assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+	} else {
+		assert.Equal(t, 1, s.numberOfUpdates(), "should only update first time if all data was processed before close")
+	}
 }
 
 func TestUsageService_IncreaseForTable_WithMinimumUpdateDuration(t *testing.T) {
@@ -319,7 +324,11 @@ func TestUsageService_IncreaseForTable_WithMinimumUpdateDuration(t *testing.T) {
 
 	assert.Equal(t, rows, s.sumOfUpdates(), "total should equal number of updated rows")
 	assert.Equal(t, rows, s.sumOfTableUpdates(), "breakdown over tables should equal number of updated rows")
-	assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+	if usageClient.dataOnClose {
+		assert.Equal(t, 2, s.numberOfUpdates(), "should only update first time and on close if minimum update duration is set")
+	} else {
+		assert.Equal(t, 1, s.numberOfUpdates(), "should only update first time if all data was processed before close")
+	}
 }
 
 func TestUsageService_IncreaseForTable_CorrectByTable(t *testing.T) {


### PR DESCRIPTION
The problem is that there is no way to know if all rows have already been processed by the time `*BatchUpdater.Close()` is called. If they have been, then `numberOfUpdates()` will return 1 less than expected, causing the flakiness.

There are two ways to fix this:
- Make sure enough time passes between calls to `Increase()` and `Close()`. A call to `runtime.Gosched()` in the test before calling close could also help, but there are no guarantees. Timing-based tests are also generally icky.
- Keep track of whether `Close()` actually resulted in any processed rows, and adjust the expected number of updates if so. This has to advantage of working 100% reliably, eliminating the flakiness, at the cost of introducing a field only used for tests.

This commit implements the second approach.

This fixes https://github.com/cloudquery/cloudquery-issues/issues/2367