### PR TITLE
fix: Handle integer overflow

### DIFF
--- a/configtype/time.go
+++ b/configtype/time.go
@@ -3,6 +3,7 @@ package configtype
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"time"
@@ -237,10 +238,19 @@ func (d *timeDuration) addUnit(unit string, number int64) error {
 	case "hour", "hours":
 		d.duration += time.Hour * time.Duration(number)
 	case "day", "days":
+		if number < math.MinInt || number > math.MaxInt {
+			return fmt.Errorf("invalid %s value: %d. Out of bounds", unit, number)
+		}
 		d.days += int(number)
 	case "month", "months":
+		if number < math.MinInt || number > math.MaxInt {
+			return fmt.Errorf("invalid %s value: %d. Out of bounds", unit, number)
+		}
 		d.months += int(number)
 	case "year", "years":
+		if number < math.MinInt || number > math.MaxInt {
+			return fmt.Errorf("invalid %s value: %d. Out of bounds", unit, number)
+		}
 		d.years += int(number)
 	default:
 		return fmt.Errorf("invalid unit: %q", unit)


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

Fixes https://github.com/cloudquery/plugin-sdk/security/code-scanning/3
Fixes https://github.com/cloudquery/plugin-sdk/security/code-scanning/2
Fixes https://github.com/cloudquery/plugin-sdk/security/code-scanning/1

Technically a false positive since on 64 machines (we only compile to 64 bit) `int` and `int64` (`number` is `int64`) usually have the same size so no overflow

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
