### PR TITLE
fix: Fix Transform hang in CLI sync

### DIFF
--- a/internal/servers/plugin/v3/plugin.go
+++ b/internal/servers/plugin/v3/plugin.go
@@ -480,16 +480,10 @@ func (s *Server) Transform(stream pb.Plugin_TransformServer) error {
 				return err
 			case <-gctx.Done():
 				close(recvRecords)
-				if err := eg.Wait(); err != nil {
-					return status.Errorf(codes.Canceled, "plugin returned error: %v", err)
-				}
-				return status.Errorf(codes.Internal, "transform failed for unknown reason")
+				return gctx.Err()
 			case <-ctx.Done():
 				close(recvRecords)
-				if err := eg.Wait(); err != nil {
-					return status.Errorf(codes.Internal, "context done: %v and failed to wait for plugin: %v", ctx.Err(), err)
-				}
-				return status.Errorf(codes.Canceled, "context done: %v", ctx.Err())
+				return ctx.Err()
 			}
 		}
 	})


### PR DESCRIPTION
When CLI runs sync_v3 and a transformer is in the spec, if the transformer errors at transform time, the CLI can hang forever.

This fix makes sure that the `.Transform()` function always returns after an error.

Tested 20 times:

```bash
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: EOF
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
Loading spec(s) from cmd/testdata/transformer-errors.yml
Starting sync for: test (cloudquery/test@v4.7.0) -> [test (cloudquery/test@v2.7.0)]
Error: failed to sync v3 source test: rpc error: code = Internal desc = failing at the transformer stage according to spec requirements
exit status 1
```