### PR TITLE
chore: Switch test workflows to ubicloud runners

### DIFF
--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   golangci:
     name: Lint with GolangCI
-    runs-on: large-ubuntu-plugin-sdk
+    runs-on: ubicloud-standard-8
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
   unitests:
     strategy:
       matrix:
-        os: [large-ubuntu-plugin-sdk, large-windows-plugin-sdk, macos-latest]
+        os: [ubicloud-standard-8, large-windows-plugin-sdk, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
#### Summary

Uses ubicloud runners which are 10x cheaper for testing workflows.
Publishing related workflows will still use GitHub runners for security reasons

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
