### PR TITLE
chore: Remove `errcheck` deprecated configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters-settings:
   errcheck:
     check-blank: false
-    ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
   gocritic:
     disabled-checks:
       - commentFormatting

--- a/docs/markdown.go
+++ b/docs/markdown.go
@@ -39,7 +39,10 @@ func (g *Generator) renderTablesAsMarkdown(dir string) error {
 		return fmt.Errorf("failed to create file %v: %v", outputPath, err)
 	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(content)
+	if err != nil {
+		return fmt.Errorf("failed to write content to file %v: %v", outputPath, err)
+	}
 	return nil
 }
 
@@ -76,8 +79,11 @@ func (g *Generator) renderTable(dir string, table *schema.Table) error {
 		return fmt.Errorf("failed to create file %v: %v", outputPath, err)
 	}
 	defer f.Close()
-	f.WriteString(content)
-	return f.Close()
+	_, err = f.WriteString(content)
+	if err != nil {
+		return fmt.Errorf("failed to write content to file %v: %v", outputPath, err)
+	}
+	return nil
 }
 
 func formatMarkdown(s string) string {

--- a/helpers/remoteoauth/token_test.go
+++ b/helpers/remoteoauth/token_test.go
@@ -153,7 +153,7 @@ func setupMockTokenServer(t *testing.T, responses map[string]string) string {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(resp))
+		_, _ = w.Write([]byte(resp))
 	}))
 	t.Cleanup(func() {
 		ts.Close()

--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -385,7 +385,7 @@ func (tg TestDataGenerator) getExampleJSON(colName string, dataType arrow.DataTy
 	for _, binaryType := range binaryTypes {
 		if arrow.TypeEqual(dataType, binaryType) {
 			bytes := make([]byte, 4)
-			rnd.Read(bytes)
+			_, _ = rnd.Read(bytes)
 			return `"` + base64.StdEncoding.EncodeToString(bytes) + `"`
 		}
 	}


### PR DESCRIPTION
#### Summary

Fixes https://github.com/cloudquery/plugin-sdk/actions/runs/13367954470/job/37329892347?pr=2080

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
