### PR TITLE
feat: Add WithNullableFieldTransformer to transformers.TransformWithStruct options

### DIFF
--- a/transformers/nullable_field.go
+++ b/transformers/nullable_field.go
@@ -1,0 +1,11 @@
+package transformers
+
+import "reflect"
+
+type NullableFieldTransformer func(field reflect.StructField) bool
+
+func DefaultNullableFieldTransformer(_ reflect.StructField) bool {
+	return true
+}
+
+var _ NullableFieldTransformer = DefaultNullableFieldTransformer

--- a/transformers/options.go
+++ b/transformers/options.go
@@ -63,6 +63,14 @@ func WithIgnoreInTestsTransformer(transformer IgnoreInTestsTransformer) StructTr
 	}
 }
 
+// WithNullableFieldTransformer overrides how column NotNull will be determined.
+// DefaultNullableFieldTransformer is used as the default.
+func WithNullableFieldTransformer(transformer NullableFieldTransformer) StructTransformerOption {
+	return func(t *structTransformer) {
+		t.nullableFieldTransformer = transformer
+	}
+}
+
 // WithPrimaryKeys allows to specify what struct fields should be used as primary keys
 func WithPrimaryKeys(fields ...string) StructTransformerOption {
 	return func(t *structTransformer) {

--- a/transformers/struct.go
+++ b/transformers/struct.go
@@ -23,6 +23,7 @@ type structTransformer struct {
 	typeTransformer               TypeTransformer
 	resolverTransformer           ResolverTransformer
 	ignoreInTestsTransformer      IgnoreInTestsTransformer
+	nullableFieldTransformer      NullableFieldTransformer
 	unwrapAllEmbeddedStructFields bool
 	structFieldsToUnwrap          []string
 	pkFields                      []string
@@ -161,6 +162,7 @@ func (t *structTransformer) addColumnFromField(field reflect.StructField, parent
 		Type:          columnType,
 		Resolver:      resolver,
 		IgnoreInTests: t.ignoreInTestsTransformer(field),
+		NotNull:       !t.nullableFieldTransformer(field),
 	}
 
 	// Enrich JSON column with detailed schema
@@ -199,6 +201,7 @@ func TransformWithStruct(st any, opts ...StructTransformerOption) schema.Transfo
 		typeTransformer:           DefaultTypeTransformer,
 		resolverTransformer:       DefaultResolverTransformer,
 		ignoreInTestsTransformer:  DefaultIgnoreInTestsTransformer,
+		nullableFieldTransformer:  DefaultNullableFieldTransformer,
 		jsonSchemaNameTransformer: DefaultJSONColumnSchemaNameTransformer,
 		maxJSONTypeSchemaDepth:    DefaultMaxJSONTypeSchemaDepth,
 	}

--- a/transformers/struct_test.go
+++ b/transformers/struct_test.go
@@ -82,6 +82,11 @@ type (
 		IntCol     int `json:"int_col"`
 		Properties any
 	}
+
+	testNullableField struct {
+		RegularString  string  `json:"regular_string"`
+		NullableString *string `json:"nullable_string"`
+	}
 )
 
 var (
@@ -301,6 +306,22 @@ var (
 			},
 		},
 	}
+
+	expectedTestTableStructNonNullableFields = schema.Table{
+		Name: "test_struct_with_non_nullable_fields",
+		Columns: schema.ColumnList{
+			{
+				Name:    "regular_string",
+				Type:    arrow.BinaryTypes.String,
+				NotNull: true,
+			},
+			{
+				Name:    "nullable_string",
+				Type:    arrow.BinaryTypes.String,
+				NotNull: false,
+			},
+		},
+	}
 )
 
 func TestTableFromGoStruct(t *testing.T) {
@@ -442,6 +463,18 @@ func TestTableFromGoStruct(t *testing.T) {
 				},
 			},
 			want: expectedTestTableStructWithCustomAny,
+		},
+		{
+			name: "Should be able to override any nullability for a field",
+			args: args{
+				testStruct: testNullableField{},
+				options: []StructTransformerOption{
+					WithNullableFieldTransformer(func(f reflect.StructField) bool {
+						return f.Type.Kind() == reflect.Pointer
+					}),
+				},
+			},
+			want: expectedTestTableStructNonNullableFields,
 		},
 	}
 


### PR DESCRIPTION
#### Summary

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

<!--
Explain what problem this PR addresses
-->

Fixes https://github.com/cloudquery/cloudquery/issues/20286

Add `transformers.WithNullableFieldTransformer(func ...)` to allow the SDK user to have custom rules to decide for a field nullability.
This is especially useful when the user defines its struct with some pointers and some regular value types: we can have the that set `nil` for pointers, non `nil` for non-pointers.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
