### PR TITLE
fix: Ignore context cancelled errors.

### DIFF
--- a/internal/servers/plugin/v3/plugin.go
+++ b/internal/servers/plugin/v3/plugin.go
@@ -456,6 +456,10 @@ func (s *Server) Transform(stream pb.Plugin_TransformServer) error {
 			}
 			if err != nil {
 				close(recvRecords)
+				if errors.Is(err, context.Canceled) {
+					// Ignore context cancellation errors
+					return nil
+				}
 				return status.Errorf(codes.Internal, "Error receiving request: %v", err)
 			}
 			record, err := pb.NewRecordFromBytes(req.Record)

--- a/internal/servers/plugin/v3/plugin.go
+++ b/internal/servers/plugin/v3/plugin.go
@@ -456,7 +456,7 @@ func (s *Server) Transform(stream pb.Plugin_TransformServer) error {
 			}
 			if err != nil {
 				close(recvRecords)
-				if errors.Is(err, context.Canceled) {
+				if status.Code(err) == codes.Canceled {
 					// Ignore context cancellation errors
 					return nil
 				}


### PR DESCRIPTION
fixes https://github.com/cloudquery/cloudquery-issues/issues/3451

The CLI closes the context that the Transformer plugin uses upon completion of the sync. This is not an error, so the SDK should not raise it in the `Transform` function.

This error is benign in that the sync still works as expected, but it looks bad in the logs, which end up showing up in `cloudquery.log`, and it bubbles up to other products like Asset Inventory which happens to show errors in bright red colours.

Here's a typical current run

<img width="877" alt="Screenshot 2025-03-07 at 10 57 36" src="https://github.com/user-attachments/assets/5ce61a18-b7a1-4f47-89ca-c3a8e620487d" />

Here's a fixed run

<img width="949" alt="Screenshot 2025-03-07 at 10 54 49" src="https://github.com/user-attachments/assets/239f7665-48b1-49c5-a0bc-84db8a89efee" />
