### PR TITLE
fix: Revert faker pointer change

### DIFF
--- a/faker/faker.go
+++ b/faker/faker.go
@@ -18,11 +18,12 @@ type faker struct {
 
 var errEFaceNotAllowed = errors.New("any not allowed")
 
-func (f *faker) getFakedValue(a any) (reflect.Value, error) {
+func (f faker) getFakedValue(a any) (reflect.Value, error) {
 	t := reflect.TypeOf(a)
 	if t == nil {
 		return reflect.Value{}, errEFaceNotAllowed
 	}
+	//nolint:revive
 	f.maxDepth--
 	if f.maxDepth < 0 {
 		return reflect.Value{}, errors.New("max_depth reached")


### PR DESCRIPTION
#### Summary

Reverts https://github.com/cloudquery/plugin-sdk/pull/2087/files#diff-d23bd4e64abe4e710bc1f39711bda2ddc0d4a9a5c1ee80e7551787a0f81e2d5aL20 as it broke some plugins tests.

Underlying issue is that we call `getFakedValue` on the array of fields in https://github.com/cloudquery/plugin-sdk/blob/1298b36185f8d19e0a0c65f6f3958106565271c9/faker/faker.go#L65 so when operating on the pointer we share the max depth with the fields.

Reverting for now so it doesn't block the SDK update

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
