### PR TITLE
fix: Error if both PKs and PK components are set

### DIFF
--- a/transformers/tables.go
+++ b/transformers/tables.go
@@ -26,6 +26,9 @@ func TransformTables(tables schema.Tables) error {
 		if err := TransformTables(table.Relations); err != nil {
 			return err
 		}
+		if len(table.PrimaryKeys()) > 0 && len(table.PrimaryKeyComponents()) > 0 {
+			return fmt.Errorf("primary keys and primary key components cannot both be set for table %q", table.Name)
+		}
 	}
 	return nil
 }

--- a/transformers/tables_test.go
+++ b/transformers/tables_test.go
@@ -1,0 +1,27 @@
+package transformers
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/cloudquery/plugin-sdk/v4/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformTablesErrorOnPKFieldsAndPKComponentFields(t *testing.T) {
+	type testStructWithPKComponent struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	testTable := &schema.Table{
+		Name:      "test",
+		Transform: TransformWithStruct(testStructWithPKComponent{}, WithPrimaryKeys("id")),
+		Columns: []schema.Column{
+			{Name: "name", Type: arrow.BinaryTypes.String, PrimaryKeyComponent: true},
+		},
+	}
+
+	err := TransformTables([]*schema.Table{testTable})
+	require.Error(t, err, "primary keys and primary key components cannot both be set for table \"test\"")
+}


### PR DESCRIPTION
#### Summary

I spent too much time debugging a bug I had when I (meaning Cursor AI) auto complete `PrimaryKeyComponent: true` instead of `PrimaryKey: true` for me. Which means I had both PKs and PK components on the same table, causing `_cq_id` to only be calculated from the PK component, losing data when `pk_mode: cq-id-only` was enabled.

See https://github.com/cloudquery/cloudquery-private/pull/6902/commits/ef8762eb1f1a6624913e5ee9ff7a88e9e0944537

This PR adds a validation to ensure only either ones are defined, or not defined at all. This has to happen after the `TransformTables` call since columns can be configured manually as well

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
