### PR TITLE
fix: Pass installation ID from env for usage report

### DIFF
--- a/premium/usage.go
+++ b/premium/usage.go
@@ -285,7 +285,7 @@ func NewUsageClient(meta plugin.Meta, ops ...UsageClientOptions) (UsageClient, e
 		}
 		u.teamName = teamName
 	}
-	u.installationID = determineInstallationID(u.tokenClient.GetTokenType())
+	u.installationID = determineInstallationID()
 
 	u.backgroundUpdater()
 
@@ -728,13 +728,8 @@ func (u *BatchUpdater) getTeamNameByTokenType(tokenType auth.TokenType) (string,
 	}
 }
 
-func determineInstallationID(tokenType auth.TokenType) string {
-	switch tokenType {
-	case auth.APIKey:
-		return os.Getenv("_CQ_INSTALLATION_ID")
-	default:
-		return ""
-	}
+func determineInstallationID() string {
+	return os.Getenv("_CQ_INSTALLATION_ID")
 }
 
 type NoOpUsageClient struct {

--- a/premium/usage.go
+++ b/premium/usage.go
@@ -730,7 +730,7 @@ func (u *BatchUpdater) getTeamNameByTokenType(tokenType auth.TokenType) (string,
 
 func determineInstallationID(tokenType auth.TokenType) string {
 	switch tokenType {
-	case auth.SyncRunAPIKey, auth.SyncTestConnectionAPIKey:
+	case auth.APIKey:
 		return os.Getenv("_CQ_INSTALLATION_ID")
 	default:
 		return ""


### PR DESCRIPTION
Follow-up to https://github.com/cloudquery/plugin-sdk/pull/2106

Plugins use regular team API keys for usage reports, not platform-specific local API keys.
