### PR TITLE
fix: Ensure no table clients are ever dropped

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -316,7 +316,11 @@ func shardTableClients(tableClients []tableClient, shard *shard) []tableClient {
 		return nil
 	}
 	if len(chunks) > total && num == total {
-		return append(chunks[num-1], chunks[num]...)
+		chunkReturn := chunks[num-1]
+		for _, chunk := range chunks[total:] {
+			chunkReturn = append(chunkReturn, chunk...)
+		}
+		return chunkReturn
 	}
 	return chunks[num-1]
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -577,6 +577,51 @@ func Test_shardTableClients(t *testing.T) {
 				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_5"}},
 			},
 		},
+
+		{
+			name: "uneven split 1 of 3",
+			tableClients: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_1"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_2"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_3"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_4"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_5"}},
+			},
+			shard: &shard{num: 1, total: 3},
+			expected: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_1"}},
+			},
+		},
+		{
+			name: "uneven split 2 of 3",
+			tableClients: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_1"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_2"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_3"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_4"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_5"}},
+			},
+			shard: &shard{num: 2, total: 3},
+			expected: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_2"}},
+			},
+		},
+		{
+			name: "uneven split 3 of 3",
+			tableClients: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_1"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_2"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_3"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_4"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_5"}},
+			},
+			shard: &shard{num: 3, total: 3},
+			expected: []tableClient{
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_3"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_4"}},
+				{client: &testExecutionClient{}, table: &schema.Table{Name: "table_5"}},
+			},
+		},
 		{
 			name: "more shards than table clients",
 			tableClients: []tableClient{


### PR DESCRIPTION
#### Summary

Prior to this PR, under certain circumstances (5 clients and 3 shards) clients could be dropped because the logic was that chunks were defined as 5/3 = 1 and so each shard would have 1 client and the last client would have 2 clients. After this fix, the last shard would have 3 clients