### PR TITLE
feat: Switch state grpc client to NewClient rather than DialContext

### DIFF
--- a/state/client.go
+++ b/state/client.go
@@ -59,9 +59,7 @@ func NewConnectedClientWithOptions(ctx context.Context, backendOpts *plugin.Back
 		return &NoOpClient{}, nil
 	}
 
-	// TODO: Remove once there's a documented migration path per https://github.com/grpc/grpc-go/issues/7244
-	// nolint:staticcheck
-	backendConn, err := grpc.DialContext(ctx, backendOpts.Connection,
+	backendConn, err := grpc.NewClient(backendOpts.Connection,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(connOpts.MaxMsgSizeInBytes),


### PR DESCRIPTION
We were able to validate grpc.NewClient works as expected after the upstream fix so there's nothing blocking us from upgrading it.