### PR TITLE
fix: Handle nil internal buffer

### DIFF
--- a/plugin/diff.go
+++ b/plugin/diff.go
@@ -20,12 +20,18 @@ func getUnifiedDiff(edits array.Edits, wantCol, haveCol arrow.Array) string {
 			wantDataType := wantCol.DataType()
 			wantData := make([]byte, wantCol.Len())
 			for _, buffer := range wantCol.Data().Buffers() {
-				wantData = append(wantData, buffer.Bytes()...)
+				buf := buffer.Buf()
+				if len(buf) > 0 {
+					wantData = append(wantData, buf...)
+				}
 			}
 			haveDataType := haveCol.DataType()
 			haveData := make([]byte, haveCol.Len())
 			for _, buffer := range haveCol.Data().Buffers() {
-				haveData = append(haveData, buffer.Bytes()...)
+				buf := buffer.Buf()
+				if len(buf) > 0 {
+					haveData = append(haveData, buf...)
+				}
 			}
 
 			wantBase64 := base64.StdEncoding.EncodeToString(wantData)


### PR DESCRIPTION
#### Summary

`Bytes()` can panic if the internal `buf` is `nil`. This uses `Buf()` instead, see arrow code in https://github.com/apache/arrow-go/blob/b196d3b316d09f63786f021d4f1baa1fdd7620d2/arrow/memory/buffer.go#L108

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
