### PR TITLE
fix: Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.8
+          version: v2.2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,91 +1,103 @@
+version: "2"
 run:
   tests: true
-  timeout: 10m
-
-linters-settings:
-  errcheck:
-    check-blank: false
-  gocritic:
-    disabled-checks:
-      - commentFormatting
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 500
-  decorder:
-    dec-order:
-      - type
-      - const
-      - var
-      - func
-    disable-dec-order-check: false
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-
-  revive:
-    enable-all-rules: true
-    rules:
-      - name: cyclomatic
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: line-length-limit
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: cognitive-complexity
-        disabled: true
-      - name: banned-characters
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: add-constant
-        disabled: true
-      - name: unhandled-error
-        disabled: true
-      - name: deep-exit
-        disabled: true
-      - name: nested-structs
-        disabled: true
-      - name: import-alias-naming
-        disabled: true
-      - name: unchecked-type-assertion
-        disabled: true
-
-  gofmt:
-    rewrite-rules:
-    - pattern:     'interface{}'
-      replacement: 'any'
-    - pattern:     'a[b:len(a)]'
-      replacement: 'a[b:]'
-
-
 linters:
   enable:
     - asciicheck
     - bodyclose
     - dupl
-    - errcheck
     - gocritic
-    - gofmt
-    - gosimple
-    - govet
-    - ineffassign
     - importas
     - misspell
     - nakedret
     - prealloc
     - revive
-    - staticcheck
     - unconvert
     - unparam
-    - unused
+  settings:
+    decorder:
+      dec-order:
+        - type
+        - const
+        - var
+        - func
+      disable-dec-order-check: false
+    dupl:
+      threshold: 500
+    errcheck:
+      check-blank: false
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    revive:
+      enable-all-rules: true
+      rules:
+        - name: cyclomatic
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: line-length-limit
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: banned-characters
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: add-constant
+          disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: deep-exit
+          disabled: true
+        - name: nested-structs
+          disabled: true
+        - name: import-alias-naming
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+        - name: unnecessary-format
+          disabled: true
+        - name: var-naming
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/scalar/duration.go
+++ b/scalar/duration.go
@@ -17,7 +17,7 @@ func (s *Duration) DataType() arrow.DataType {
 }
 
 func (s *Duration) String() string {
-	if !s.Int.IsValid() {
+	if !s.IsValid() {
 		return nullValueStr
 	}
 

--- a/schema/testdata.go
+++ b/schema/testdata.go
@@ -294,7 +294,7 @@ func (tg TestDataGenerator) getExampleJSON(colName string, dataType arrow.DataTy
 	if arrow.TypeEqual(dataType, types.ExtensionTypes.UUID) {
 		// This will make UUIDs deterministic like all other types
 		hash := sha256.New()
-		hash.Write([]byte(fmt.Sprintf(`"AString%d"`, rnd.Intn(100000))))
+		fmt.Fprintf(hash, `"AString%d"`, rnd.Intn(100000))
 		u := newUUID(uuid.UUID{}, hash.Sum(nil))
 		return `"` + u.String() + `"`
 	}

--- a/serve/package.go
+++ b/serve/package.go
@@ -84,7 +84,7 @@ func (s *PluginServe) writeTablesJSON(ctx context.Context, dir string) error {
 				// PrimaryKey Will be set to true Under the following conditions:
 				// 1. If the column is a `PrimaryKeyComponent`
 				// 2. If the column is a `PrimaryKey` and both of the following are true column name is NOT `_cq_id`  and there are other columns that are a PrimaryKeyComponent
-				PrimaryKey: (column.PrimaryKey && !(column.Name == schema.CqIDColumn.Name && len(table.PrimaryKeyComponents()) > 0)) || column.PrimaryKeyComponent,
+				PrimaryKey: (column.PrimaryKey && !(column.Name == schema.CqIDColumn.Name && len(table.PrimaryKeyComponents()) > 0)) || column.PrimaryKeyComponent, //nolint:staticcheck
 				Unique:     column.Unique,
 			}
 			if column.TypeSchema != "" {


### PR DESCRIPTION
This PR upgrades golangci-lint and it's corresponding configuration file to v2 format since development environment versions have already received the updates.