### PR TITLE
feat: Make getColumnChangeSummary public for use in plugins

### DIFF
--- a/schema/table.go
+++ b/schema/table.go
@@ -260,7 +260,7 @@ func (t TableColumnChange) String() string {
 	}
 }
 
-func getColumnChangeSummary(change TableColumnChange) string {
+func GetColumnChangeSummary(change TableColumnChange) string {
 	switch change.Type {
 	case TableColumnChangeTypeAdd:
 		if change.Current.PrimaryKey {
@@ -342,7 +342,7 @@ func GetChangesSummary(tablesChanges map[string][]TableColumnChange) string {
 		summary.WriteString(fmt.Sprintf("%s:\n", table))
 		changes := tablesChanges[table]
 		changesString := lo.Map(changes, func(change TableColumnChange, _ int) string {
-			return fmt.Sprintf("  - %s", getColumnChangeSummary(change))
+			return fmt.Sprintf("  - %s", GetColumnChangeSummary(change))
 		})
 		slices.Sort(changesString)
 		summary.WriteString(strings.Join(changesString, "\n"))


### PR DESCRIPTION
In the ClickHouse destination, we want to add some additional information about table-level changes (sort keys, partition keys) to that provided by `GetChangesSummary`. However right now, that would mean duplicating quite a lot of code, so I would like to suggest that we instead make `GetColumnChangeSummary` public for use in this case and others like it.