### PR TITLE
chore: Use string instead of array to set `ignored_types`

### DIFF
--- a/.github/workflows/add_tags.yml
+++ b/.github/workflows/add_tags.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: bcoe/conventional-release-labels@v1
         with:
           type_labels: '{ "feat": "feat", "fix": "fix", "chore": "chore", "refactor": "refactor", "test": "test", "breaking": "breaking" }'
-          ignored_types: []
+          ignored_types: '[]'


### PR DESCRIPTION
#### Summary

Follow up to https://github.com/cloudquery/plugin-sdk/pull/2276.

This input needs to be a string not an array

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
