### PR TITLE
fix: Preserve int64 precision when setting nested scalars from JSON

### DIFF
--- a/scalar/float.go
+++ b/scalar/float.go
@@ -1,6 +1,7 @@
 package scalar
 
 import (
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -119,6 +120,8 @@ func (s *Float) Set(val any) error {
 			return err
 		}
 		s.Value = value
+	case json.Number:
+		return s.Set(string(value))
 	case string:
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {

--- a/scalar/int.go
+++ b/scalar/int.go
@@ -1,6 +1,7 @@
 package scalar
 
 import (
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -124,6 +125,8 @@ func (s *Int) Set(val any) error {
 		return s.Set(int64(value))
 	case float64:
 		return s.Set(int64(value))
+	case json.Number:
+		return s.Set(string(value))
 	case string:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {

--- a/scalar/json_number.go
+++ b/scalar/json_number.go
@@ -1,0 +1,14 @@
+package scalar
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// unmarshalJSONWithNumbers decodes JSON with UseNumber so int64/uint64 values that
+// exceed float64 precision survive as json.Number instead of being rounded.
+func unmarshalJSONWithNumbers(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}

--- a/scalar/json_number_test.go
+++ b/scalar/json_number_test.go
@@ -1,0 +1,27 @@
+package scalar
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNestedIntPrecision(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dt   arrow.DataType
+		str  string
+	}{
+		{name: "struct_int64", dt: arrow.StructOf(arrow.Field{Name: "v", Type: arrow.PrimitiveTypes.Int64, Nullable: true}), str: `{"v":-8717895732742165505}`},
+		{name: "struct_uint64", dt: arrow.StructOf(arrow.Field{Name: "v", Type: arrow.PrimitiveTypes.Uint64, Nullable: true}), str: `{"v":18428615660272232523}`},
+		{name: "list_int64", dt: arrow.ListOf(arrow.PrimitiveTypes.Int64), str: `[-8717895732742165505]`},
+		{name: "list_uint64", dt: arrow.ListOf(arrow.PrimitiveTypes.Uint64), str: `[18428615660272232523]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewScalar(tc.dt)
+			require.NoError(t, s.Set(tc.str))
+			require.Equal(t, tc.str, s.String())
+		})
+	}
+}

--- a/scalar/list.go
+++ b/scalar/list.go
@@ -1,7 +1,6 @@
 package scalar
 
 import (
-	"encoding/json"
 	"reflect"
 	"strings"
 
@@ -93,7 +92,7 @@ func (s *List) Set(val any) error {
 	switch value := val.(type) {
 	case string:
 		var x []any
-		if err := json.Unmarshal([]byte(value), &x); err != nil {
+		if err := unmarshalJSONWithNumbers([]byte(value), &x); err != nil {
 			return err
 		}
 		length := len(x)
@@ -110,7 +109,7 @@ func (s *List) Set(val any) error {
 
 	case []byte:
 		var x []any
-		if err := json.Unmarshal(value, &x); err != nil {
+		if err := unmarshalJSONWithNumbers(value, &x); err != nil {
 			return err
 		}
 		length := len(x)

--- a/scalar/struct.go
+++ b/scalar/struct.go
@@ -59,7 +59,7 @@ func (s *Struct) Set(val any) error {
 	switch value := val.(type) {
 	case string:
 		var x map[string]any
-		if err := json.Unmarshal([]byte(value), &x); err != nil {
+		if err := unmarshalJSONWithNumbers([]byte(value), &x); err != nil {
 			return err
 		}
 		for name := range x {
@@ -88,7 +88,7 @@ func (s *Struct) Set(val any) error {
 
 	case []byte:
 		var x map[string]any
-		if err := json.Unmarshal(value, &x); err != nil {
+		if err := unmarshalJSONWithNumbers(value, &x); err != nil {
 			return err
 		}
 		s.Value = x

--- a/scalar/uint.go
+++ b/scalar/uint.go
@@ -1,6 +1,7 @@
 package scalar
 
 import (
+	"encoding/json"
 	"math"
 	"strconv"
 
@@ -128,6 +129,8 @@ func (s *Uint) Set(val any) error {
 			return &ValidationError{Type: s.DataType(), Msg: "float64 is greater than MaxUint64", Value: value}
 		}
 		return s.Set(uint64(value))
+	case json.Number:
+		return s.Set(string(value))
 	case string:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {


### PR DESCRIPTION
Follow-up to #2553, which fixed the write-test helpers. The `scalar` package has the same problem on the read side: `Struct.Set` and `List.Set` decode JSON into `map[string]any`/`[]any` with the default decoder, so int64/uint64 values beyond float64 precision are rounded before they ever reach a builder.

`{"v":-8717895732742165505}` came back as `{"v":-8717895732742166000}`, and `[-8717895732742165505]` as `[-8717895732742165504]`.

Decode with `UseNumber` and teach `Int`, `Uint` and `Float` to accept `json.Number` (delegating to the existing string parse — `json.Number` is a distinct named type, so the existing `case string` never matched it).

This is what still blocks the postgresql destination in cloudquery/cloudquery#23163, whose read path goes through `scalar.NewScalar`/`Set`.